### PR TITLE
Vue2 - show selected printers count (printer grid)

### DIFF
--- a/client-vue/src/views/HomePrinterGrid.vue
+++ b/client-vue/src/views/HomePrinterGrid.vue
@@ -19,7 +19,13 @@
     <v-banner v-drop-upload="{ printers: selectedPrinters }">
       <v-row>
         <v-col>
-          <v-btn color="secondary" small @click="clearSelectedPrinters()">Clear selection</v-btn>
+          <v-btn
+            :color="hasPrintersSelected ? 'primary' : 'secondary'"
+            small
+            @click="clearSelectedPrinters()"
+          >
+            Clear selection ({{ selectedPrinters.length }} selected)
+          </v-btn>
           <v-chip-group>
             <v-chip v-if="selectedPrinters.length === 0">No printers selected</v-chip>
             <v-chip
@@ -94,6 +100,10 @@ export default class HomePage extends Vue {
     fileUpload: InstanceType<typeof HTMLInputElement>;
   };
   selectedFile?: File;
+
+  get hasPrintersSelected(): boolean {
+    return this.selectedPrinters?.length > 0;
+  }
 
   get selectedPrinters() {
     return printersState.selectedPrinters;


### PR DESCRIPTION
## Description

Adds the selection count for clearing the amount of selected printers more easily.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Vue visual inspection
- [ ] Node test
- [ ] NestJS test 

# Checklist:

- [x] I checked my changes
- [x] I have commented my code concisely
- [ ] I have covered my changes with tests