### PR TITLE
Bugfix renovate should ignore Node12 Dockerfile and Vue2 should only be minor updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,12 +2,37 @@
   "extends": [
     "config:base"
   ],
-  "assignees": ["davidzwa"],
-  "labels": ["renovate"],
+  "assignees": [
+    "davidzwa"
+  ],
+  "labels": [
+    "renovate"
+  ],
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
       "automerge": true
+    },
+    {
+      "paths": [
+        "client-vue/package.json"
+      ],
+      "enabled": true,
+      "automerge": true,
+      "updateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ]
     }
+  ],
+  "ignorePaths": [
+    "server/docker/test-node12.Dockerfile"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,15 @@
         "pin",
         "digest"
       ],
+      "enabled": true,
       "automerge": true
+    },
+    {
+      "updateTypes": [
+        "major"
+      ],
+      "enabled": true,
+      "automerge": false
     },
     {
       "paths": [


### PR DESCRIPTION
# Description

Fixes #343 