### PR TITLE
Renovate ignore Docker major and specific Vue2 fixed majors

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,21 @@
   "labels": [
     "renovate"
   ],
+
   "packageRules": [
+    {
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "bump",
+        "digest",
+        "rollback"
+      ],
+      "enabled": true
+    },
     {
       "matchUpdateTypes": [
         "minor",

--- a/renovate.json
+++ b/renovate.json
@@ -34,24 +34,15 @@
       "automerge": true
     },
     {
-      "updateTypes": [
-        "major"
-      ],
-      "enabled": true,
-      "automerge": false
-    },
-    {
       "paths": [
         "client-vue/package.json"
       ],
-      "enabled": true,
-      "automerge": true,
-      "updateTypes": [
-        "minor",
-        "patch",
-        "pin",
-        "digest"
-      ]
+      "matchPackageNames": [
+        "vue",
+        "vuex",
+        "vue-router"
+      ],
+      "enabled": false,
     }
   ],
   "ignorePaths": [


### PR DESCRIPTION
# Description

Further followup fixes of specific issue
"Bugfix renovate should ignore Node12 Dockerfile and Vue2 should only be minor updates"
