### PR TITLE
Add non-LTS 18.x node version to workflow strategy

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [ 16.x, 14.x ]
+        node-version: [ 18.x, 16.x, 14.x ]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/server/docker/Dockerfile
+++ b/server/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.15-bullseye-slim
+FROM node:16.15.1-bullseye-slim
 WORKDIR /app
 
 RUN npm install -g pm2

--- a/server/docker/monolithic.Dockerfile
+++ b/server/docker/monolithic.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.15-bullseye-slim
+FROM node:16.15.1-bullseye-slim
 
 # Update Local Repository Index
 RUN apt-get update


### PR DESCRIPTION
# Description

Add Node 18.x to CI strategy to check for breaking changes