### PR TITLE
Also adjust printer list with filter count

### DIFF
--- a/client-vue/src/views/Printers.vue
+++ b/client-vue/src/views/Printers.vue
@@ -39,7 +39,7 @@
       </template>
       <template v-slot:top>
         <v-toolbar flat>
-          <v-toolbar-title>Showing printers</v-toolbar-title>
+          <v-toolbar-title>Filtering {{ printers.length || 0 }} printers</v-toolbar-title>
           <v-spacer></v-spacer>
           <v-switch v-model="reorder" class="mt-5 mr-3" dark label="Sort mode" />
 


### PR DESCRIPTION
# Description

Small follow-up fix for printers search

![image](https://user-images.githubusercontent.com/6005355/176144887-c7b80085-1447-4bf7-bb34-321a764de32e.png)
This one does not adjust the count when filtering. Technically this is a bit more complex and luckily the paginator shows it at the bottom.