### PR TITLE
Apply RAL code scanning in client 0.3.17

### DIFF
--- a/client-npm/package.json
+++ b/client-npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fdm-monster/client",
   "author": "David Zwart",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "private": false,
   "license": "AGPL-3.0-or-later",
   "repository": {

--- a/client-vue/package.json
+++ b/client-vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fdm-monster/client",
   "author": "David Zwart",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "private": false,
   "license": "AGPL-3.0-or-later",
   "repository": {

--- a/client-vue/src/components/PrinterGrid/PrinterTile.vue
+++ b/client-vue/src/components/PrinterGrid/PrinterTile.vue
@@ -65,26 +65,24 @@ export default class PrinterGridTile extends Vue {
   }
 
   get printerFilamentColor() {
-    const color = this.convertColor(this.printer?.lastPrintedFile?.parsedColor?.toLowerCase());
-    if (!color) {
+    const ralCode = this.printer?.lastPrintedFile.parsedVisualizationRAL;
+    if (!ralCode) {
       return this.defaultBorder;
     }
 
-    const finds = Object.values(RAL_CODES).find(
-      (r) => r.names.nl.toLowerCase() === color.toLowerCase()
-    );
-    if (!finds) return this.defaultBorder;
-    return `8px solid ${finds.color.websafe}`;
+    const ralString = ralCode.toString();
+    const foundColor = Object.values(RAL_CODES).find((r) => r.code === ralString);
+    if (!foundColor) {
+      return this.defaultBorder;
+    }
+
+    return `8px solid ${foundColor.color.hex}`;
   }
 
   get printerStateColor() {
     if (!this.printer) return this.defaultColor;
 
     return this.printer?.printerState.colour.hex || this.defaultColor;
-  }
-
-  convertColor(colorName?: string) {
-    return colorName;
   }
 
   id() {

--- a/client-vue/src/models/printers/printer.model.ts
+++ b/client-vue/src/models/printers/printer.model.ts
@@ -19,6 +19,7 @@ export interface LastPrintedFile {
   fileName: string;
   editTimestamp: number;
   parsedColor: string;
+  parsedVisualizationRAL: number;
   parsedAmount: number;
   parsedMaterial: string;
   parsedOrderCode: string;

--- a/server/state/printer.state.js
+++ b/server/state/printer.state.js
@@ -186,7 +186,8 @@ class PrinterState {
       gcodeScripts: {},
       octoPrintVersion: this.getOctoPrintVersion(),
       lastPrintedFile: this.#entityData.lastPrintedFile || {
-        parsedColor: "any"
+        parsedColor: "any",
+        parsedVisualizationRAL: 0
       },
       selectedFilament: this.#entityData.selectedFilament,
       enabled: this.#entityData.enabled,


### PR DESCRIPTION
# Description

- Fixes the RAL processing applied to represent printer tile border color 
- Only process recognized RAL colors (backend)