### PR TITLE
hotfix: delete files after upload

### DIFF
--- a/server/services/octoprint/octoprint-api.service.js
+++ b/server/services/octoprint/octoprint-api.service.js
@@ -211,7 +211,7 @@ class OctoPrintApiService extends OctoPrintRoutes {
 
       // Cleanup
       if (isPhysicalFile) {
-        // fs.unlinkSync(fileStreamOrBuffer.path);
+        fs.unlinkSync(fileStreamOrBuffer.path);
       }
 
       return await processGotResponse(response, responseOptions);


### PR DESCRIPTION
# Description

In production the uploaded files were not purged from file system after upload. This caused high volume size and docker VIRT memory problems.