### PR TITLE
fix: add last update time in printer state

### DIFF
--- a/server/services/octoprint/constants/octoprint-websocket.constants.js
+++ b/server/services/octoprint/constants/octoprint-websocket.constants.js
@@ -23,6 +23,7 @@ function getDefaultJobState() {
 
 function getDefaultPrinterState() {
   return {
+    updatedAt: null,
     state: PSTATE.Offline,
     flags: { operational: false },
     desc: "Printer needs WebSocket connection first",
@@ -32,6 +33,7 @@ function getDefaultPrinterState() {
 
 function getDefaultDisabledPrinterState() {
   return {
+    updatedAt: Date.now(),
     state: PSTATE.Disabled,
     flags: { operational: false },
     desc: "Printer is disabled",

--- a/server/services/octoprint/octoprint-rxjs-websocket.adapter.js
+++ b/server/services/octoprint/octoprint-rxjs-websocket.adapter.js
@@ -224,6 +224,7 @@ class OctoprintRxjsWebsocketAdapter extends GenericWebsocketAdapter {
       console.log(`changing OP printer state ${state}`);
     }
     this.#printerState = {
+      updatedAt: Date.now(),
       state,
       flags,
       colour: mapStateToColor(state),


### PR DESCRIPTION
# Description

The websocket state often becomes silent. This causes the server to not act and keep outdated state.
Need a silence tracker and reauth.