### PR TITLE
chore: remove SortIndex with migration

### DIFF
--- a/server/migrations/20230427202911-printer-remove-sortindex.js
+++ b/server/migrations/20230427202911-printer-remove-sortindex.js
@@ -1,0 +1,16 @@
+module.exports = {
+  async up(db, client) {
+    const session = client.startSession();
+    try {
+      await session.withTransaction(async () => {
+        await db.collection("printers").update({}, { $unset: { sortIndex: 1 } }, { multi: true });
+      });
+    } finally {
+      await session.endSession();
+    }
+  },
+
+  async down(db, client) {
+    await db.collection("printers").update({}, { $set: { sortIndex: 0 } }, { multi: true });
+  },
+};

--- a/server/models/Printer.js
+++ b/server/models/Printer.js
@@ -13,10 +13,6 @@ const PrinterSchema = new Schema({
     type: String,
     required: true, // !
   },
-  sortIndex: {
-    type: Number,
-    required: true,
-  },
   enabled: {
     type: Boolean,
     required: true,

--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,7 @@
     "pupdate": "pm2 update",
     "stop": "pm2 stop FDM",
     "stop:delete": "pm2 delete FDM",
-    "migration:create": "migrate-mongo create floor-remove-groupinfloor",
+    "migration:create": "migrate-mongo create printer-remove-sortindex",
     "migration:up": "migrate-mongo up",
     "migration:down": "migrate-mongo down",
     "migration:status": "migrate-mongo status",

--- a/server/services/printer.service.js
+++ b/server/services/printer.service.js
@@ -16,12 +16,8 @@ class PrinterService {
    */
   async list() {
     return Printer.find({}, null, {
-      sort: { sortIndex: 1 },
+      sort: { dateAdded: 1 },
     });
-  }
-
-  async #printerCount() {
-    return Printer.countDocuments();
   }
 
   async get(printerId) {
@@ -61,10 +57,7 @@ class PrinterService {
     if (!newPrinter) throw new Error("Missing printer");
 
     const mergedPrinter = await this.validateAndDefault(newPrinter);
-
     mergedPrinter.dateAdded = Date.now();
-    mergedPrinter.sortIndex = await this.#printerCount(); // 0-based index so no +1 needed
-
     return Printer.create(mergedPrinter);
   }
 
@@ -92,21 +85,6 @@ class PrinterService {
     await printer.save();
 
     return printer;
-  }
-
-  /**
-   *
-   * @param printerId
-   * @param sortIndex
-   * @returns {Promise<Query<Document<any, any> | null, Document<any, any>, {}>>}
-   */
-  async updateSortIndex(printerId, sortIndex) {
-    const update = { sortIndex };
-    await this.get(printerId);
-    return Printer.findByIdAndUpdate(printerId, update, {
-      new: true,
-      useFindAndModify: false,
-    });
   }
 
   async updateFlowRate(printerId, flowRate) {

--- a/server/state/printer.state.js
+++ b/server/state/printer.state.js
@@ -162,7 +162,6 @@ class PrinterState {
       },
       disabledReason: this.#entityData.disabledReason,
       enabled: this.#entityData.enabled,
-      sortIndex: this.#entityData.sortIndex,
       printerName: this.#entityData.settingsAppearance?.name,
       webSocketURL: this.#websocketAdapter?.webSocketURL || this.#entityData.webSocketURL,
       printerURL: this.#entityData.printerURL,
@@ -192,10 +191,6 @@ class PrinterState {
 
   updateStepSize(stepSize) {
     this.#stepSize = stepSize;
-  }
-
-  getSortIndex() {
-    return this.#entityData.sortIndex;
   }
 
   getWebSocketState() {

--- a/server/state/printer.state.js
+++ b/server/state/printer.state.js
@@ -162,6 +162,7 @@ class PrinterState {
       },
       disabledReason: this.#entityData.disabledReason,
       enabled: this.#entityData.enabled,
+      dateAdded: this.#entityData.dateAdded,
       printerName: this.#entityData.settingsAppearance?.name,
       webSocketURL: this.#websocketAdapter?.webSocketURL || this.#entityData.webSocketURL,
       printerURL: this.#entityData.printerURL,

--- a/server/test/api/printer-controller.test.js
+++ b/server/test/api/printer-controller.test.js
@@ -14,7 +14,6 @@ const DITokens = require("../../container.tokens");
 let Model = Printer;
 const defaultRoute = AppConstants.apiRoute + "/printer";
 const createRoute = defaultRoute;
-const updateSortIndexRoute = `${defaultRoute}/sort-index`;
 const testPrinterRoute = `${defaultRoute}/test-connection`;
 const pluginListRoute = `${defaultRoute}/plugin-list`;
 const getRoute = (id) => `${defaultRoute}/${id}`;
@@ -298,15 +297,5 @@ describe("PrinterController", () => {
     octoPrintApiService.storeResponse(response, 200);
     const res = await request.post(serialDisconnectCommandRoute(printer.id)).send();
     expectOkResponse(res);
-  });
-
-  it("should update sort indices", async () => {
-    const printer = await createTestPrinter(request);
-    const printer2 = await createTestPrinter(request, "Group0_1");
-
-    const res = await request.post(updateSortIndexRoute).send({
-      sortList: [printer.id, printer2.id],
-    });
-    expectOkResponse(res, {});
   });
 });

--- a/server/test/application/store/printer-store.test.js
+++ b/server/test/application/store/printer-store.test.js
@@ -172,11 +172,6 @@ describe("PrinterStore", () => {
     expect(printerState.getStateCategory()).toEqual(CATEGORY.Offline);
   });
 
-  it("should get printerState sortIndex", async () => {
-    let printerState = await printerStore.addPrinter(validNewPrinterState);
-    printerState.getSortIndex();
-  });
-
   it("should update printerState systemInfo", async () => {
     let printerState = await printerStore.addPrinter(validNewPrinterState);
     expect(printerState.updateSystemInfo({})).toBeUndefined();

--- a/server/test/domain/printer-schema.test.js
+++ b/server/test/domain/printer-schema.test.js
@@ -2,28 +2,12 @@ const { Printer } = require("../../models/Printer");
 const { expectValidationError } = require("../extensions");
 
 describe("printer-schema", function () {
-  it("should be invalid if sortIndex is not numeric", function (done) {
-    const m = new Printer({
-      apiKey: "asd",
-      printerURL: "myawesomeprinter/",
-      webSocketURL: "myawesomeprinter/",
-      sortIndex: "a",
-      settingsAppearance: {}
-    });
-
-    m.validate(function (err) {
-      expectValidationError(err, ["sortIndex"], true);
-      done();
-    });
-  });
-
   it("should be valid for required properties", function (done) {
     const m = new Printer({
       apiKey: "asd",
       printerURL: "myawesomeprinter/",
       webSocketURL: "myawesomeprinter/",
       settingsAppearance: {},
-      sortIndex: "1"
     });
 
     m.validate(function (err) {
@@ -32,20 +16,20 @@ describe("printer-schema", function () {
     });
   });
 
-  it("should be invalid if URLs, sortIndex, and apiKey properties are empty", function (done) {
+  it("should be invalid if URLs, and apiKey properties are empty", function (done) {
     const m = new Printer({});
 
     m.validate(function (err) {
       expectValidationError(
         err,
-        ["settingsAppearance", "sortIndex", "webSocketURL", "printerURL", "apiKey"],
+        ["settingsAppearance", "webSocketURL", "printerURL", "apiKey"],
         true
       );
       done();
     });
   });
 
-  it("should be invalid if printer misses sortIndex and webSocketURL", function (done) {
+  it("should be invalid if printer misses webSocketURL", function (done) {
     const m = new Printer({
       printerURL: "myawesomeprinter/",
       apiKey: "asd",
@@ -53,7 +37,7 @@ describe("printer-schema", function () {
     });
 
     m.validate(function (err) {
-      expectValidationError(err, ["sortIndex", "webSocketURL"], true);
+      expectValidationError(err, ["webSocketURL"], true);
       done();
     });
   });


### PR DESCRIPTION
# Description

Remove the SortIndex property from printers as it's not a suitable fit for how printers are sorted in @fdm-monster/client