### PR TITLE
Fix/1778 docker tag push event is not firing causing docker releases not to occur

### DIFF
--- a/.github/workflows/docker_quick_build.yml
+++ b/.github/workflows/docker_quick_build.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Docker build"
     steps:
+      - uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx

--- a/.github/workflows/docker_quick_build.yml
+++ b/.github/workflows/docker_quick_build.yml
@@ -33,6 +33,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # https://stackoverflow.com/questions/57968497/how-do-i-set-an-env-var-with-a-bash-expression-in-github-actions
+      - name: get-server-version
+        working-directory: server
+        # https://gist.github.com/DarrenN/8c6a5b969481725a4413?permalink_comment_id=3863317#gistcomment-3863317
+        run: |
+          echo "SERVER_VERSION=$(npm pkg get version | sed 's/"//g')" >> $GITHUB_ENV
+
       # New intended logic
       # if branch is develop => push to dockerhub with tag 'develop'
       # if branch is main => push to dockerhub with tag 'main'
@@ -42,9 +49,9 @@ jobs:
         uses: HackerHappyHour/tagging-strategy@v3
         with:
           image_name: davidzwa/fdm-monster
-          tag_name: ${{ github.ref }}
+          tag_name: ${{ env.SERVER_VERSION + '-' + github.run_number }}
           tags: |
-            %X%
+            %X.Y.Z%
           extra_tags: |
             main::${{ github.ref == 'refs/heads/main' || github.event.pull_request.base.ref == 'main' }}
             develop::${{ github.ref == 'refs/heads/develop' || github.event.pull_request.base.ref == 'develop' }}

--- a/.github/workflows/docker_quick_build.yml
+++ b/.github/workflows/docker_quick_build.yml
@@ -49,7 +49,7 @@ jobs:
         uses: HackerHappyHour/tagging-strategy@v3
         with:
           image_name: davidzwa/fdm-monster
-          tag_name: ${{ env.SERVER_VERSION + '-' + github.run_number }}
+          tag_name: ${{ env.SERVER_VERSION }}-${{ github.run_number }}
           tags: |
             %X.Y.Z%
           extra_tags: |

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -54,6 +54,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # https://stackoverflow.com/questions/57968497/how-do-i-set-an-env-var-with-a-bash-expression-in-github-actions
+      - name: get-server-version
+        working-directory: server
+        # https://gist.github.com/DarrenN/8c6a5b969481725a4413?permalink_comment_id=3863317#gistcomment-3863317
+        run: |
+          echo "SERVER_VERSION=$(npm pkg get version | sed 's/"//g')" >> $GITHUB_ENV
+
       # New intended logic
       # if tag is a release tag, then build and push to dockerhub with that tag
       # if tag then XYZ, if the tag does not contain rc or unstable then X and XY tags
@@ -64,13 +71,13 @@ jobs:
         uses: HackerHappyHour/tagging-strategy@v3
         with:
           image_name: davidzwa/fdm-monster
-          tag_name: ${{ github.ref }}
+          tag_name: ${{ env.SERVER_VERSION }}
           tags: |
-            %X%::${{ github.ref_type == 'tag' && !contains(github.ref_slug, 'rc') && !contains(github.ref_slug, 'unstable') }}
-            %X.Y%::${{ github.ref_type == 'tag' && !contains(github.ref_slug, 'rc') && !contains(github.ref_slug, 'unstable') }}
-            %X.Y.Z%::${{ github.ref_type == 'tag' }}
+            %X%::${{ !contains(env.SERVER_VERSION, 'rc') && !contains(env.SERVER_VERSION, 'unstable') }}
+            %X.Y%::${{ !contains(env.SERVER_VERSION, 'rc') && !contains(env.SERVER_VERSION, 'unstable') }}
+            %X.Y.Z%
           extra_tags: |
-            latest::${{ github.ref_type == 'tag' && !contains(github.ref_slug, 'rc') && !contains(github.ref_slug, 'unstable') }}
+            latest::${{ !contains(env.SERVER_VERSION, 'rc') && !contains(env.SERVER_VERSION, 'unstable') }}
 
       # Show docker tags to be (conditionally) pushed
       - name: "Show docker tags"

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -1,10 +1,32 @@
 name: Docker release
 on:
   push:
-    tags:
-      - '*'
+    branches:
+      - 'main'
+      - 'develop'
 jobs:
+  checkversion:
+    runs-on: ubuntu-latest
+    outputs:
+      foundServerVersion: ${{ steps.init.outputs.foundServerVersion }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: get-client-version
+        working-directory: server
+        # https://gist.github.com/DarrenN/8c6a5b969481725a4413?permalink_comment_id=3863317#gistcomment-3863317
+        run: |
+          echo "SERVER_VERSION=$(npm pkg get version | sed 's/"//g')" >> $GITHUB_ENV
+      - uses: mukunku/tag-exists-action@v1.2.0
+        id: checkTag
+        with:
+          tag: ${{ env.SERVER_VERSION }}
+      - run: echo ${{ steps.checkTag.outputs.exists }}
+      - name: Environment variables to output
+        id: init
+        run: |
+          echo "foundServerVersion=${{ steps.checkTag.outputs.exists }}" >> $GITHUB_OUTPUT
   meta:
+    needs: [ checkversion ]
     runs-on: ubuntu-latest
     outputs:
       labels: ${{ steps.metadata.outputs.labels }}
@@ -15,7 +37,8 @@ jobs:
           images: davidzwa/fdm-monster
 
   docker:
-    needs: [ meta ]
+    needs: [ meta, checkversion ]
+    if: needs.checkversion.outputs.foundServerVersion == 'false'
     runs-on: ubuntu-latest
     name: "Docker build"
     steps:

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -41,6 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Docker build"
     steps:
+      - uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'develop'
 jobs:
   checkversion:
     runs-on: ubuntu-latest

--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,7 @@
   "name": "fdm-monster",
   "author": "David Zwart",
   "license": "AGPL-3.0-or-later",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "FDM Monster is a bulk OctoPrint manager to set up, configure and monitor 3D printers. Our aim is to provide extremely optimized websocket performance and reliability.",
   "main": "index.mjs",
   "scripts": {


### PR DESCRIPTION
# Description

- Should not tag docker with `undefined` anymore
- Should get last server version and add build number for quick build
- Should push latest docker release on merge to main