### PR TITLE
fix: yaml export should use the right printer name property

### DIFF
--- a/server/services/yaml.service.js
+++ b/server/services/yaml.service.js
@@ -293,7 +293,7 @@ class YamlService {
           enabled: p.enabled,
           dateAdded: p.dateAdded,
           settingsAppearance: {
-            name: p.printerName,
+            name: p.settingsAppearance.name,
           },
           printerURL: p.printerURL,
           apiKey,


### PR DESCRIPTION
# Description

The YAML export was not correctly using the printer name property to export, resulting in an empty settingsAppearance.