### PR TITLE
fix: client bundle was extracted to the wrong folder

### DIFF
--- a/server/services/client-bundle.service.js
+++ b/server/services/client-bundle.service.js
@@ -144,7 +144,7 @@ class ClientBundleService {
   async extractClientBundleZip(downloadedZipPath) {
     const zip = new AdmZip(downloadedZipPath);
 
-    const distPath = AppConstants.defaultClientBundleStorage;
+    const distPath = join(superRootPath(), AppConstants.defaultClientBundleStorage);
     ensureDirExists(distPath);
 
     this.logger.debug(`Clearing contents of ${distPath}`);


### PR DESCRIPTION
# Description

The client bundle extraction path was inside the server folder, which is wrong.