### PR TITLE
fix: update scripts and avoid auth when no GITHUB_PAT

### DIFF
--- a/installations/fdm-monster-node-linux/update-fdm-monster.sh
+++ b/installations/fdm-monster-node-linux/update-fdm-monster.sh
@@ -28,8 +28,26 @@ server_path="../fdm-monster/server/"
 repo_url="https://github.com/${org}/${repo}"
 
 # Step 1) Check latest release of FDM Monster
-tag=$(git ls-remote --tags $repo_url | awk -F"/" '{print $NF}' | grep -E "^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$" | sort -V | tail -1)
-echo "[1/${ts}] Found the latest release ${tag}"
+tags="$(git ls-remote --sort=-v:refname --tags $repo_url | awk -F"/" '{print $NF}')"
+newest_tag=$(echo "$tags" | sort -V | tail -1)
+
+# Check if the tag contains "-rc" or "-unstable"
+if [[ $newest_tag == *"-rc"* || $newest_tag == *"-unstable"* ]]; then
+    echo "Newest tag is $newest_tag which seems to be a release candidate or unstable version."
+    echo "Do you want to install this tag(Y) or install the latest stable(N) (Y/N)?"
+    read -r response
+
+    if [[ $response == "Y" || $response == "y" ]]; then
+        # Install the tag
+        echo "[1/${ts}] Installing tag $newest_tag"
+    else
+        # Search for the latest stable tag in x.y.z format
+        newest_tag=$(echo "$tags" | grep -E "^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$" | sort -V | tail -1)
+        echo "[1/${ts}] Installing latest stable tag: $newest_tag"
+    fi
+else
+    echo "[1/${ts}] Installing latest stable tag: $newest_tag"
+fi
 
 # Step 2) Temporarily stop FDM Monster Daemon
 # `curl 0.0.0.0:4000` will fail to connect, you can test it if you want to be sure
@@ -39,7 +57,7 @@ npm run uninstall
 # Step 3) Switch the latest FDM Monster to this tag
 pushd "${server_path}"
 echo "[3/${ts}] Finding the latest version of FDM Monster from Github"
-git fetch --prune
+git fetch --prune --tags
 git checkout "${tag}"
 
 # Step 4a) Ensure yarn is new, (optional)

--- a/installations/fdm-monster-node-windows/download-update.ps1
+++ b/installations/fdm-monster-node-windows/download-update.ps1
@@ -33,7 +33,7 @@ yarn -v
 yarn install --production --pure-lockfile
 
 # Switch to the latest release tag of FDM Monster
-git fetch --prune
+git fetch --prune --tags
 git checkout $latestTagName
 
 # Go back and enable the Windows service

--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,7 @@
   "name": "fdm-monster",
   "author": "David Zwart",
   "license": "AGPL-3.0-or-later",
-  "version": "1.4.0-rc2",
+  "version": "1.4.0-rc3",
   "description": "FDM Monster is a bulk OctoPrint manager to set up, configure and monitor 3D printers. Our aim is to provide extremely optimized websocket performance and reliability.",
   "main": "index.mjs",
   "scripts": {

--- a/server/services/github.service.js
+++ b/server/services/github.service.js
@@ -24,10 +24,6 @@ class GithubService {
     return result?.type === "token";
   }
 
-  async getAuthenticated() {
-    return this.octokitService.rest.users.getAuthenticated();
-  }
-
   async getLatestRelease(/**string**/ owner, /**string**/ repo) {
     return await this.octokitService.rest.repos
       .getLatestRelease({

--- a/server/tasks/client-bundle.task.js
+++ b/server/tasks/client-bundle.task.js
@@ -29,9 +29,6 @@ class ClientDistDownloadTask {
 
     this.logger.log(`Client bundle update required. Reason for updating: ${result.reason}`);
 
-    await this.githubService.getAuthenticated();
-    this.logger.log(`Logged into Github successfully, checking client dist update`);
-
     await this.clientBundleService.downloadClientUpdate(AppConstants.defaultClientMinimum);
   }
 }


### PR DESCRIPTION
# Description

Without a GITHUB_PAT the updater failed. Now it will not pursue an authenticated connection flow per default.