### PR TITLE
feat: add docker swarm stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ coverage
 **/nodemon_restart_trigger.js
 
 **/yarn-error.log
+
+installations/other/octoprint-virtual/default1.9.0/op1.9.0-backup/
+
+installations/other/octoprint-virtual/default1.9.0/octoprint/octoprint/

--- a/installations/other/octoprint-virtual/default1.9.0/octoprint.Dockerfile
+++ b/installations/other/octoprint-virtual/default1.9.0/octoprint.Dockerfile
@@ -1,0 +1,9 @@
+# Extend octoprint/octoprint:1.9.0 image with a copied folder default1.9.0 from the context to /octoprint
+
+FROM octoprint/octoprint:1.9.0
+
+COPY ./octoprint /octoprint-seed
+
+COPY ./run /etc/services.d/octoprint/run
+
+

--- a/installations/other/octoprint-virtual/default1.9.0/run
+++ b/installations/other/octoprint-virtual/default1.9.0/run
@@ -1,0 +1,7 @@
+#!/usr/bin/with-contenv sh
+
+cp -r /octoprint-seed/octoprint/ /octoprint/
+cp -r /octoprint-seed/plugins/ /octoprint/
+rm -rf /octoprint-seed
+
+exec octoprint serve --iknowwhatimdoing --host 0.0.0.0 --port 5000 --basedir /octoprint/octoprint

--- a/installations/other/octoprint-virtual/docker-compose.simple.yml
+++ b/installations/other/octoprint-virtual/docker-compose.simple.yml
@@ -1,0 +1,23 @@
+services:
+  # States MQTT plugin incompatible
+  octoprint:
+    image: davidzwa/octoprint:1.8.7
+    container_name: op0
+    privileged: true
+    restart: unless-stopped
+    ports:
+      - 80:80
+    volumes:
+      - /dev/:/dev/
+      - ./op0:/octoprint
+  # MQTT plugin works
+  octoprint2:
+    image: octoprint/octoprint:1.9.0
+    container_name: op1
+    privileged: true
+    restart: unless-stopped
+    ports:
+      - 81:80
+    volumes:
+      - /dev/:/dev/
+      - ./op1:/octoprint

--- a/installations/other/octoprint-virtual/docker-compose.yml
+++ b/installations/other/octoprint-virtual/docker-compose.yml
@@ -1,23 +1,14 @@
 services:
-  # States MQTT plugin incompatible
   octoprint:
-    image: davidzwa/octoprint:1.8.7
-    container_name: op0
-    privileged: true
-    restart: unless-stopped
+    build:
+      context: ./default1.9.0
+      dockerfile: octoprint.Dockerfile
+    # image: 127.0.0.1:5000/octoprint-virtual:latest
+    image: octoprint/octoprint-virtual:1.9.0
+    # scale up to 5
+    deploy:
+      replicas: 5
+      restart_policy:
+        condition: on-failure
     ports:
-      - 80:80
-    volumes:
-      - /dev/:/dev/
-      - ./op0:/octoprint
-  # MQTT plugin works
-  octoprint2:
-    image: octoprint/octoprint:1.9.0
-    container_name: op1
-    privileged: true
-    restart: unless-stopped
-    ports:
-      - 81:80
-    volumes:
-      - /dev/:/dev/
-      - ./op1:/octoprint
+      - 80


### PR DESCRIPTION
# Description

A swarm stack has been added which can replicate a bunch of (virtual) OctoPrints.
OctoPrint can be preconfigured by adding the `config.yaml` and `users.yaml` files of your liking.
The files will be preseeded right before and everytime the OctoPrint service is started.