### PR TITLE
fix: set Sentry diagnostics to disabled by default (opt-in)

### DIFF
--- a/server/controllers/settings.controller.js
+++ b/server/controllers/settings.controller.js
@@ -20,9 +20,9 @@ class SettingsController {
     res.send(settings);
   }
 
-  async updateAnonymousDiagnosticsEnabled(req, res) {
+  async updateSentryDiagnosticsEnabled(req, res) {
     const { enabled } = await validateInput(req.body, anonymousDiagnosticsEnabledRules);
-    const result = this.settingsStore.setAnonymousDiagnosticsEnabled(enabled);
+    const result = this.settingsStore.setSentryDiagnosticsEnabled(enabled);
     res.send(result);
   }
 
@@ -58,6 +58,6 @@ module.exports = createController(SettingsController)
   .get("/server", "getSettings")
   .put("/server", "updateSettings")
   .put("/server/server", "updateServerSettings")
-  .patch("/server/anonymous-diagnostics", "updateAnonymousDiagnosticsEnabled")
+  .patch("/server/sentry-diagnostics", "updateSentryDiagnosticsEnabled")
   .put("/server/whitelist", "updateWhitelistSettings")
   .put("/server/frontend", "updateFrontendSettings");

--- a/server/controllers/settings.controller.js
+++ b/server/controllers/settings.controller.js
@@ -3,7 +3,7 @@ const { authenticate, authorizeRoles } = require("../middleware/authenticate");
 const { AppConstants } = require("../server.constants");
 const { ROLES } = require("../constants/authorization.constants");
 const { validateInput } = require("../handlers/validators");
-const { whitelistSettingRules, anonymousDiagnosticsEnabledRules } = require("./validation/setting.validation");
+const { whitelistSettingRules, anonymousDiagnosticsEnabledRules, sentryDiagnosticsEnabledRules } = require("./validation/setting.validation");
 
 class SettingsController {
   /**
@@ -21,7 +21,7 @@ class SettingsController {
   }
 
   async updateSentryDiagnosticsEnabled(req, res) {
-    const { enabled } = await validateInput(req.body, anonymousDiagnosticsEnabledRules);
+    const { enabled } = await validateInput(req.body, sentryDiagnosticsEnabledRules);
     const result = this.settingsStore.setSentryDiagnosticsEnabled(enabled);
     res.send(result);
   }

--- a/server/controllers/validation/setting.validation.js
+++ b/server/controllers/validation/setting.validation.js
@@ -4,7 +4,7 @@ module.exports = {
     "whitelistedIpAddresses.*": "required|string",
     whitelistEnabled: "required|boolean",
   },
-  anonymousDiagnosticsEnabledRules: {
+  sentryDiagnosticsEnabledRules: {
     enabled: "required|boolean",
   },
 };

--- a/server/models/ServerSettings.js
+++ b/server/models/ServerSettings.js
@@ -30,9 +30,9 @@ const ServerSettingsSchema = new mongoose.Schema({
       type: String,
       default: AppConstants.defaultFileStorageFolder,
     },
-    anonymousDiagnosticsEnabled: {
+    sentryDiagnosticsEnabled: {
       type: Boolean,
-      default: true,
+      default: false,
       required: true,
     },
     debugSettings: {

--- a/server/services/settings.service.js
+++ b/server/services/settings.service.js
@@ -60,9 +60,9 @@ class SettingsService {
     return knownSettings;
   }
 
-  async setAnonymousDiagnosticsEnabled(enabled) {
+  async setSentryDiagnosticsEnabled(enabled) {
     const settingsDoc = await this.getOrCreate();
-    settingsDoc[serverSettingsKey].anonymousDiagnosticsEnabled = enabled;
+    settingsDoc[serverSettingsKey].sentryDiagnosticsEnabled = enabled;
     return SettingsModel.findOneAndUpdate({ _id: settingsDoc._id }, settingsDoc, {
       new: true,
     });

--- a/server/state/settings.store.js
+++ b/server/state/settings.store.js
@@ -86,8 +86,8 @@ class SettingsStore {
     return this.getSettings();
   }
 
-  async setAnonymousDiagnosticsEnabled(enabled) {
-    this.settings = await this.settingsService.setAnonymousDiagnosticsEnabled(enabled);
+  async setSentryDiagnosticsEnabled(enabled) {
+    this.settings = await this.settingsService.setSentryDiagnosticsEnabled(enabled);
     await this.processSentryEnabled();
     return this.getSettings();
   }
@@ -100,9 +100,9 @@ class SettingsStore {
     if (isTestEnvironment()) return;
     const sentryEnabled = await this.getAnonymousDiagnosticsEnabled();
     if (sentryEnabled) {
-      this.logger.log("Enabling Sentry for anonymous diagnostics");
+      this.logger.log("Enabling Sentry for remote diagnostics");
     } else {
-      this.logger.log("Disabling anonymous diagnostics");
+      this.logger.log("Disabling remote diagnostics");
     }
     Sentry.getCurrentHub().getClient().getOptions().enabled = sentryEnabled;
   }

--- a/server/state/settings.store.js
+++ b/server/state/settings.store.js
@@ -102,7 +102,7 @@ class SettingsStore {
     if (sentryEnabled) {
       this.logger.log("Enabling Sentry for remote diagnostics");
     } else {
-      this.logger.log("Disabling remote diagnostics");
+      this.logger.log("Disabling Sentry for remote diagnostics");
     }
     Sentry.getCurrentHub().getClient().getOptions().enabled = sentryEnabled;
   }

--- a/server/state/settings.store.js
+++ b/server/state/settings.store.js
@@ -31,7 +31,7 @@ class SettingsStore {
   }
 
   async getAnonymousDiagnosticsEnabled() {
-    return this.settings.server.anonymousDiagnosticsEnabled;
+    return this.settings[serverSettingsKey].sentryDiagnosticsEnabled;
   }
 
   isRegistrationEnabled() {


### PR DESCRIPTION
# Description

Sentry is now disabled by default and the word 'anonymous' has been removed to ensure transparency to the user.