### PR TITLE
docs: fix bug in child page TOC reference sections software usage

### DIFF
--- a/docs/software_usage/creating_printers.md
+++ b/docs/software_usage/creating_printers.md
@@ -1,4 +1,4 @@
-# ---
+---
 layout: default
 title: Docker Compose
 parent: Software Usage

--- a/docs/software_usage/organizing_floors.md
+++ b/docs/software_usage/organizing_floors.md
@@ -1,4 +1,4 @@
-# ---
+---
 layout: default
 title: Organizing Floors
 parent: Software Usage


### PR DESCRIPTION
# Description

Small TOC reference section issue due to a `#` typo