### PR TITLE
fix: add error log for failing database connections at boot

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     environment:
       MONGO_INITDB_DATABASE: fdm-monster
     ports:
-      # default is 27017
       - "21111:27017"
     volumes:
       - ./fdm-monster/mongodb-data:/data/db
@@ -18,6 +17,9 @@ services:
   fdm-monster:
     container_name: fdm-monster
     image: davidzwa/fdm-monster:latest
+    build:
+      context: ./server
+      dockerfile: ./docker/Dockerfile
     restart: unless-stopped
     ports:
       - "4000:4000"

--- a/docs/guides/docker_compose.md
+++ b/docs/guides/docker_compose.md
@@ -30,7 +30,6 @@ There are multiple tags available for the `davidzwa/fdm-monster` image.
 - `develop` - The latest development version of FDM Monster. This version is not recommended for production use.
 - `x.y.z-rc?-1234` - A specific release candidate of FDM Monster with a specific build number. For example, `1.4.0-rc1-1234`. These are development versions and are not recommended for production use.
 - `x.y.z-1234` - A specific version of FDM Monster with a specific build number. For example, `1.4.0-1234`. These are development versions and are not recommended for production use.
-   
 
 ### Step 2) Create a docker-compose.yml file
 To run a Docker Compose stack, create a file named `docker-compose.yml` and use the following contents (or look at [docker-compose.yml](../../docker-compose.yml)):

--- a/server/tasks/boot.task.js
+++ b/server/tasks/boot.task.js
@@ -87,6 +87,7 @@ class BootTask {
     // To cope with retries after failures we register this task - disabled
     this.#taskManagerService.registerJobOrTask(this.#serverTasks.SERVER_BOOT_TASK);
 
+    this.#logger.log("Running boot task once.");
     await this.run();
   }
 


### PR DESCRIPTION
# Description

There might have been database start hiccups (as often happens when MongoDB starts).

What I find fascinating is that the disabled BootTask job was rescheduled perfectly, but for some reason the SAFEMODE_ENABLED mode was triggered. This is only possible if the `bootTaskScheduler` was not provided (leaving it to false by default and thus skipping boot tasks).

Could it be that the scheduled disabled task does not perform runOnce? Yep I just confirmed this!