### PR TITLE
feat: add get,post log dump in ZIP format with adm-zip

### DIFF
--- a/server/container.js
+++ b/server/container.js
@@ -54,6 +54,7 @@ const { PrinterCache } = require("./state/printer.cache");
 const PrinterSocketStore = require("./state/printer-socket.store");
 const { TestPrinterSocketStore } = require("./state/test-printer-socket.store");
 const { PrinterEventsCache } = require("./state/printer-events.cache");
+const { LogDumpService } = require("./services/log-dump.service");
 
 function configureContainer() {
   // Create the container and set the injectionMode to PROXY (which is also the default).
@@ -99,6 +100,7 @@ function configureContainer() {
       });
     }),
     [DITokens.clientBundleService]: asClass(ClientBundleService),
+    [DITokens.logDumpService]: asClass(LogDumpService),
     [DITokens.simpleGitService]: asValue(SimpleGitFactory()),
     [DITokens.httpClient]: asValue(
       axios.create({

--- a/server/container.tokens.js
+++ b/server/container.tokens.js
@@ -25,6 +25,7 @@ const DITokens = {
   githubService: "githubService",
   octokitService: "octokitService",
   clientBundleService: "clientBundleService",
+  logDumpService: "logDumpService",
   userTokenService: "userTokenService",
   userService: "userService",
   permissionService: "permissionService",

--- a/server/controllers/server-private.controller.js
+++ b/server/controllers/server-private.controller.js
@@ -29,6 +29,7 @@ class ServerPrivateController {
   printerSocketStore;
   yamlService;
   multerService;
+  logDumpService;
 
   constructor({
     serverUpdateService,
@@ -36,6 +37,7 @@ class ServerPrivateController {
     printerCache,
     printerService,
     clientBundleService,
+    logDumpService,
     printerSocketStore,
     yamlService,
     multerService,
@@ -43,6 +45,7 @@ class ServerPrivateController {
     this.#serverReleaseService = serverReleaseService;
     this.#serverUpdateService = serverUpdateService;
     this.clientBundleService = clientBundleService;
+    this.logDumpService = logDumpService;
     this.printerSocketStore = printerSocketStore;
     this.printerCache = printerCache;
     this.printerService = printerService;
@@ -104,7 +107,7 @@ class ServerPrivateController {
     const readStream = new PassThrough();
     readStream.end(fileContents);
 
-    const fileName = "export-fdm-monster-" + Date.now() + ".yaml";
+    const fileName = `export-${AppConstants.serverRepoName}-` + Date.now() + ".yaml";
     res.set("Content-disposition", "attachment; filename=" + fileName);
     res.set("Content-Type", "text/plain");
     readStream.pipe(res);
@@ -115,6 +118,12 @@ class ServerPrivateController {
     const printerIds = printers.map((p) => p.id);
     await this.printerService.deleteMany(printerIds);
     res.send();
+  }
+
+  async dumpLogZips(req, res) {
+    const filePath = await this.logDumpService.dumpZip();
+    res.sendFile(filePath);
+
   }
 }
 
@@ -129,4 +138,6 @@ module.exports = createController(ServerPrivateController)
   .post("/import-printers-floors-yaml", "importPrintersAndFloorsYaml")
   .post("/git-update", "pullGitUpdates")
   .post("/restart", "restartServer")
+  .get("/dump-fdm-monster-logs", "dumpLogZips")
+  .post("/dump-fdm-monster-logs", "dumpLogZips")
   .delete("/delete-all-printers", "deleteAllPrinters");

--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,7 @@
   "name": "fdm-monster",
   "author": "David Zwart",
   "license": "AGPL-3.0-or-later",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "FDM Monster is a bulk OctoPrint manager to set up, configure and monitor 3D printers. Our aim is to provide extremely optimized websocket performance and reliability.",
   "main": "index.mjs",
   "scripts": {

--- a/server/server.constants.js
+++ b/server/server.constants.js
@@ -10,6 +10,8 @@ const AppConstants = {
 
   // @Deprecated: old storage path
   defaultFileStorageFolder: "./media",
+  defaultLogsFolder: "./media/logs",
+  defaultLogZipsFolder: "./media/log-zips",
   // New place for all downloads, files etc
   defaultClientBundleStorage: "./media/client-dist",
   defaultClientBundleZipsStorage: "./media/client-dist-zips",

--- a/server/services/log-dump.service.js
+++ b/server/services/log-dump.service.js
@@ -1,0 +1,32 @@
+const AdmZip = require("adm-zip");
+const { join } = require("path");
+const { readdir, rm } = require("node:fs/promises");
+const { superRootPath } = require("../utils/fs.utils");
+const { AppConstants } = require("../server.constants");
+
+class LogDumpService {
+  logger;
+
+  constructor({ loggerFactory }) {
+    this.logger = loggerFactory(LogDumpService.name);
+  }
+
+  async dumpZip() {
+    this.logger.log("Dumping logs as ZIP");
+    const zip = new AdmZip();
+    const path = join(superRootPath(), AppConstants.defaultLogsFolder);
+    zip.addLocalFolder(path, "/logs", "*.log");
+
+    const outputPath = join(
+      superRootPath(),
+      AppConstants.defaultLogZipsFolder,
+      `logs-${AppConstants.serverRepoName}.zip`
+    );
+    zip.writeZip(outputPath);
+    return outputPath;
+  }
+}
+
+module.exports = {
+  LogDumpService,
+};


### PR DESCRIPTION
# Description

Adds the ZIP endpoint at:
`prefix://HOSTNAME/api/server/dump-fdm-monster-logs`
For example:
`http://monsterpi.local:4000/api/server/dump-fdm-monster-logs`