### PR TITLE
chore: rename private properties to public for ease of migration

### DIFF
--- a/server/tasks/printer-websocket.task.js
+++ b/server/tasks/printer-websocket.task.js
@@ -10,11 +10,11 @@ class PrinterWebsocketTask {
   /**
    * @type {OctoPrintApiService}
    */
-  #octoPrintService;
+  octoPrintApiService;
   /**
    * @type {TaskManagerService}
    */
-  #taskManagerService;
+  taskManagerService;
 
   /**
    * @type {LoggerService}
@@ -24,9 +24,9 @@ class PrinterWebsocketTask {
   constructor({ printerSocketStore, octoPrintApiService, settingsStore, taskManagerService, loggerFactory }) {
     this.printerSocketStore = printerSocketStore;
     this.settingsStore = settingsStore;
-    this.#octoPrintService = octoPrintApiService;
-    this.#taskManagerService = taskManagerService;
-    this.logger = loggerFactory("Printer-Websocket-Task");
+    this.octoPrintApiService = octoPrintApiService;
+    this.taskManagerService = taskManagerService;
+    this.logger = loggerFactory(PrinterWebsocketTask.name);
   }
 
   async run() {

--- a/server/tasks/socketio.task.js
+++ b/server/tasks/socketio.task.js
@@ -1,7 +1,6 @@
-const { byteCount } = require("../utils/benchmark.util");
 const { IO_MESSAGES } = require("../state/socket-io.gateway");
 const { socketIoConnectedEvent } = require("../constants/event.constants");
-const { sizeKb, sizeKB, formatKB } = require("../utils/metric.utils");
+const { sizeKB, formatKB } = require("../utils/metric.utils");
 
 class SocketIoTask {
   /**


### PR DESCRIPTION
# Description

As of 1.4.x we're sticking with JSDoc quite a bit. This is a chore to step more towards removing the private property in NodeJS with `#`.