### PR TITLE
fix: path issues uninstall js script and update bash script

### DIFF
--- a/installations/fdm-monster-node-linux/uninstall-fdm-monster.js
+++ b/installations/fdm-monster-node-linux/uninstall-fdm-monster.js
@@ -9,7 +9,7 @@ const { Service } = require('node-linux');
 const { join } = require("path");
 
 // Create a new service object
-const rootPath = join(__dirname, "/pi/fdm-monster/server/");
+const rootPath = join("../../server/");
 const svc = new Service({
   name: 'FDM Monster',
   description: "The 3D Printer Farm server for managing your 100+ OctoPrints printers.",

--- a/installations/fdm-monster-node-linux/update-fdm-monster.sh
+++ b/installations/fdm-monster-node-linux/update-fdm-monster.sh
@@ -24,7 +24,7 @@ fi
 ts=6 # total steps
 org=fdm-monster
 repo=fdm-monster
-server_path="../fdm-monster/server/"
+server_path="../../server/"
 repo_url="https://github.com/${org}/${repo}"
 
 # Step 1) Check latest release of FDM Monster


### PR DESCRIPTION
# Description

These are not perfect changes, as the scripts depend on the repo being downloaded... this is not a good approach in the long run.

The linux service bootstrapping should be redone from the ground up similar to how the windows service install is done.