### PR TITLE
[ci skip] docs(fix): set color scheme to match scss file name

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,6 +4,7 @@ search_enabled: true
 search.button: true
 url: "https://docs.fdm-monster.net"
 remote_theme: pmarsceill/just-the-docs
+color_scheme: "docs"
 aux_links:
   "FDM Monster GitHub":
     - "https://github.com/fdm-monster/fdm-monster"


### PR DESCRIPTION
# Description

Referring Fluidd's JTD setup, this change was missing.