### PR TITLE
docs(fix): adjust index text, brighten layout color, add back to top [ci skip]

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,13 +6,17 @@ url: "https://docs.fdm-monster.net"
 remote_theme: pmarsceill/just-the-docs
 color_scheme: "docs"
 aux_links:
-  "FDM Monster GitHub":
+  "GitHub":
     - "https://github.com/fdm-monster/fdm-monster"
-  "FDM Monster Home":
+  "Main site":
     - "https://fdm-monster.net"
-  "FDM Monster Discord":
+  "Discord":
     - "https://discord.gg/mwA8uP8CMc"
 aux_links_new_tab: true
+
+# Back to top link
+back_to_top: true
+back_to_top_text: "Back to top"
 
 footer_content: "Copyright &copy; 2023-now David Zwart. Distributed by an <a href=\"https://github.com/fdm-monster/fdm-monster/blob/main/LICENSE\">GNU AFFERO GENERAL PUBLIC LICENSE v3.0.</a>"
 

--- a/docs/_sass/color_schemes/docs.scss
+++ b/docs/_sass/color_schemes/docs.scss
@@ -1,4 +1,4 @@
-$brand-color: #9B0505;
+$brand-color: #cc0a0a;
 
 $link-color: $brand-color;
 $btn-primary-color: $brand-color;

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,14 +3,15 @@ layout: default
 title: Home
 nav_order: 1
 permalink: /
-last_modified_at: 2023-07-04T21:50:00+02:00
+last_modified_at: 2023-07-07T08:00:00+02:00
 ---
 
-# FDM Monster - Connect 100+ OctoPrint instances
+# FDM Monster
 Welcome to the FDM Monster documentation. You should find all the documentation required to setup your own FDM Monster server here. 
 Please choose an installation type below to get started.
 
 ![Image](./images/server-running.png)
+_Connect 100+ OctoPrint instances and manage your 3D Printing Farm with FDM Monster!_
 
 ## Getting started - MonsterPi
 **Skill level required: low**


### PR DESCRIPTION
# Description

- Adjust the main page text
- Brighten the main theme color
- Add the 'back to top' link