### PR TITLE
fix: remove unused ServerSettings properties to avoid confusion, clean up multer service

### DIFF
--- a/server/constants/server-settings.constants.js
+++ b/server/constants/server-settings.constants.js
@@ -4,7 +4,6 @@ const getDefaultWhitelistIpAddresses = () => ["::12", "127.0.0.1"];
 
 const serverSettingsKey = "server";
 const getDefaultServerSettings = () => ({
-  port: AppConstants.defaultServerPort,
   debugSettings: {
     debugSocketIoEvents: false,
     debugSocketReconnect: false,

--- a/server/constants/server-settings.constants.js
+++ b/server/constants/server-settings.constants.js
@@ -13,7 +13,6 @@ const getDefaultServerSettings = () => ({
     debugSocketMessages: false,
     debugSocketIoBandwidth: false,
   },
-  uploadFolder: AppConstants.defaultFileStorageFolder,
   registration: true,
   whitelistEnabled: false,
   whitelistedIpAddresses: getDefaultWhitelistIpAddresses(),
@@ -30,9 +29,6 @@ const getDefaultFrontendSettings = () => ({
 const timeoutSettingKey = "timeout";
 const getDefaultTimeout = () => ({
   apiTimeout: 1000,
-  apiRetryCutoff: 10000,
-  apiRetry: 30000,
-  webSocketRetry: 5000,
 });
 
 const printerFileCleanSettingKey = "printerFileClean";

--- a/server/models/ServerSettings.js
+++ b/server/models/ServerSettings.js
@@ -1,5 +1,4 @@
-const mongoose = require("mongoose");
-const { AppConstants } = require("../server.constants");
+const { Schema, model } = require("mongoose");
 const {
   printerFileCleanSettingKey,
   serverSettingsKey,
@@ -7,7 +6,7 @@ const {
   frontendSettingKey,
 } = require("../constants/server-settings.constants");
 
-const ServerSettingsSchema = new mongoose.Schema({
+const ServerSettingsSchema = new Schema({
   [printerFileCleanSettingKey]: {
     autoRemoveOldFilesBeforeUpload: {
       type: Boolean,
@@ -26,10 +25,6 @@ const ServerSettingsSchema = new mongoose.Schema({
     },
   },
   [serverSettingsKey]: {
-    uploadFolder: {
-      type: String,
-      default: AppConstants.defaultFileStorageFolder,
-    },
     sentryDiagnosticsEnabled: {
       type: Boolean,
       default: false,
@@ -67,16 +62,12 @@ const ServerSettingsSchema = new mongoose.Schema({
         required: true,
       },
     },
-    port: {
-      type: Number,
-      default: AppConstants.defaultServerPort,
-      required: true,
-    },
     loginRequired: {
       type: Boolean,
       default: false,
       required: true,
     },
+    // TODO: Feature not fully tested/implemented yet
     whitelistEnabled: {
       type: Boolean,
       default: false,
@@ -116,24 +107,9 @@ const ServerSettingsSchema = new mongoose.Schema({
       default: 1000,
       required: true,
     },
-    apiRetryCutoff: {
-      type: Number,
-      default: 10000,
-      required: true,
-    },
-    apiRetry: {
-      type: Number,
-      default: 30000,
-      required: true,
-    },
-    webSocketRetry: {
-      type: Number,
-      default: 5000,
-      required: true,
-    },
   },
 });
 
-const ServerSettings = mongoose.model("ServerSettings", ServerSettingsSchema);
+const ServerSettings = model("ServerSettings", ServerSettingsSchema);
 
 module.exports = ServerSettings;

--- a/server/services/settings.service.js
+++ b/server/services/settings.service.js
@@ -26,18 +26,19 @@ class SettingsService {
       return defaultSettings;
     } else {
       // Perform patch of settings
-      settings = this.#migrateSettingsRuntime(settings);
+      settings = this.migrateSettingsRuntime(settings);
 
       return SettingsModel.findOneAndUpdate({ _id: settings.id }, settings, { new: true });
     }
   }
 
   /**
+   * @private
    * Patch the given settings object manually - runtime migration strategy
    * @param knownSettings
    * @returns {*}
    */
-  #migrateSettingsRuntime(knownSettings) {
+  migrateSettingsRuntime(knownSettings) {
     const doc = knownSettings; // alias _doc also works
     if (!doc[printerFileCleanSettingKey]) {
       doc[printerFileCleanSettingKey] = getDefaultPrinterFileCleanSettings();


### PR DESCRIPTION
# Description

Now that the project is gaining more traction from users and developers, it is important to avoid confusion in the code.

This chore involves removing properties from the ServerSettings model/schema which are not used internally, undocumented nor exposed to the UI in any way. They were future ideas, but for now its best to remove them.