### PR TITLE
Feat/2093 add stream definition

### DIFF
--- a/server/container.js
+++ b/server/container.js
@@ -55,6 +55,7 @@ const PrinterSocketStore = require("./state/printer-socket.store");
 const { TestPrinterSocketStore } = require("./state/test-printer-socket.store");
 const { PrinterEventsCache } = require("./state/printer-events.cache");
 const { LogDumpService } = require("./services/logs-manager.service");
+const { CameraStreamService } = require("./services/camera-stream.service");
 
 function configureContainer() {
   // Create the container and set the injectionMode to PROXY (which is also the default).
@@ -116,6 +117,7 @@ function configureContainer() {
     [DITokens.yamlService]: asClass(YamlService),
     [DITokens.printCompletionService]: asClass(PrintCompletionService).singleton(),
     [DITokens.octoPrintApiService]: asClass(OctoPrintApiService).singleton(),
+    [DITokens.cameraStreamService]: asClass(CameraStreamService),
     [DITokens.batchCallService]: asClass(BatchCallService).singleton(),
     [DITokens.pluginFirmwareUpdateService]: asClass(PluginFirmwareUpdateService).singleton(),
 

--- a/server/container.tokens.js
+++ b/server/container.tokens.js
@@ -31,6 +31,7 @@ const DITokens = {
   permissionService: "permissionService",
   roleService: "roleService",
   octoPrintApiService: "octoPrintApiService",
+  cameraStreamService: "cameraStreamService",
   socketFactory: "socketFactory",
   batchCallService: "batchCallService",
   pluginRepositoryCache: "pluginRepositoryCache",

--- a/server/controllers/camera-stream.controller.js
+++ b/server/controllers/camera-stream.controller.js
@@ -1,0 +1,51 @@
+const { createController } = require("awilix-express");
+const { AppConstants } = require("../server.constants");
+const { authenticate } = require("../middleware/authenticate");
+const { validateInput } = require("../handlers/validators");
+const { idRules } = require("./validation/generic.validation");
+
+class CameraStreamController {
+  /**
+   * @type {CameraStreamService}
+   */
+  cameraStreamService;
+  constructor({ cameraStreamService }) {
+    this.cameraStreamService = cameraStreamService;
+  }
+  async list(req, res) {
+    const result = await this.cameraStreamService.list();
+    res.send(result);
+  }
+
+  async get(req, res) {
+    const { id } = await validateInput(req.params, idRules);
+    const result = await this.cameraStreamService.get(id);
+    res.send(result);
+  }
+
+  async create(req, res) {
+    const result = await this.cameraStreamService.create(req.body);
+    res.send(result);
+  }
+
+  async update(req, res) {
+    const { id } = await validateInput(req.params, idRules);
+    const result = await this.cameraStreamService.update(id, req.body);
+    res.send(result);
+  }
+
+  async delete(req, res) {
+    const { id } = await validateInput(req.params, idRules);
+    await this.cameraStreamService.delete(id);
+    res.send({});
+  }
+}
+
+module.exports = createController(CameraStreamController)
+  .prefix(AppConstants.apiRoute + "/camera-stream")
+  .before([authenticate()])
+  .get("/", "list")
+  .get("/:id", "get")
+  .post("/", "create")
+  .delete("/:id", "delete")
+  .patch("/:id", "update");

--- a/server/controllers/floor.controller.js
+++ b/server/controllers/floor.controller.js
@@ -24,18 +24,18 @@ class FloorController {
   }
 
   async updateName(req, res) {
-    const { id: groupId } = await validateInput(req.params, idRules);
+    const { id: floorId } = await validateInput(req.params, idRules);
 
     // Has internal validation
-    const floor = await this.floorStore.updateName(groupId, req.body);
+    const floor = await this.floorStore.updateName(floorId, req.body);
     res.send(floor);
   }
 
   async updateFloorNumber(req, res) {
-    const { id: groupId } = await validateInput(req.params, idRules);
+    const { id: floorId } = await validateInput(req.params, idRules);
 
     // Has internal validation
-    const floor = await this.floorStore.updateFloorNumber(groupId, req.body);
+    const floor = await this.floorStore.updateFloorNumber(floorId, req.body);
     res.send(floor);
   }
 

--- a/server/controllers/server-public.controller.js
+++ b/server/controllers/server-public.controller.js
@@ -74,6 +74,11 @@ class ServerPublicController {
         available: true,
         version: 1,
       },
+      cameraStream: {
+        available: true,
+        version: 1,
+        subFeatures: {},
+      },
     });
   }
 

--- a/server/models/CameraStream.js
+++ b/server/models/CameraStream.js
@@ -1,0 +1,43 @@
+const { Schema, model } = require("mongoose");
+
+const CameraStreamSchema = new Schema({
+  streamURL: {
+    type: String,
+    required: true,
+  },
+  printerId: {
+    type: Schema.Types.ObjectId,
+    ref: "Printer",
+    required: false,
+    unique: true,
+  },
+  settings: {
+    type: {
+      aspectRatio: {
+        type: String,
+        required: true,
+        default: "16:9",
+      },
+      rotationClockwise: {
+        type: Number,
+        required: true,
+        default: 0,
+      },
+      flipHorizontal: {
+        type: Boolean,
+        required: true,
+        default: false,
+      },
+      flipVertical: {
+        type: Boolean,
+        required: true,
+        default: false,
+      },
+    },
+    required: true,
+  },
+});
+
+module.exports = {
+  CameraStream: model("CameraStream", CameraStreamSchema),
+};

--- a/server/models/CameraStream.js
+++ b/server/models/CameraStream.js
@@ -3,13 +3,17 @@ const { Schema, model } = require("mongoose");
 const CameraStreamSchema = new Schema({
   streamURL: {
     type: String,
+    unique: true,
     required: true,
   },
   printerId: {
     type: Schema.Types.ObjectId,
     ref: "Printer",
     required: false,
-    unique: true,
+    index: {
+      unique: true,
+      partialFilterExpression: { printerId: { $type: Schema.Types.ObjectId } },
+    },
   },
   settings: {
     type: {

--- a/server/services/camera-stream.service.js
+++ b/server/services/camera-stream.service.js
@@ -1,0 +1,65 @@
+const { CameraStream } = require("../models/CameraStream");
+const { validateInput } = require("../handlers/validators");
+const { NotFoundException } = require("../exceptions/runtime.exceptions");
+
+const createCameraStreamRules = {
+  printerId: "mongoId",
+  streamURL: "required|httpurl",
+  settings: "required|object",
+  "settings.aspectRatio": "required|string",
+  "settings.rotationClockwise": "required|integer|in:0,90,180,270",
+  "settings.flipHorizontally": "required|boolean",
+  "settings.flipVertically": "required|boolean",
+};
+
+class CameraStreamService {
+  model = CameraStream;
+  /**
+   * @type {PrinterCache}
+   */
+  printerCache;
+  constructor({ printerCache }) {
+    this.printerCache = printerCache;
+  }
+
+  async list() {
+    return this.model.find();
+  }
+
+  /**
+   * Get a camera stream by id
+   * @param id
+   * @param throwError
+   * @returns {Promise<CameraStream>}
+   */
+  async get(id, throwError = true) {
+    const cameraStream = await this.model.findById(id);
+    if (!cameraStream && throwError) {
+      throw new NotFoundException(`Floor with id ${id} does not exist.`);
+    }
+
+    return cameraStream;
+  }
+
+  async create(data) {
+    const input = await validateInput(data, createCameraStreamRules);
+    await this.printerCache.getCachedPrinterOrThrow(input.printerId);
+    return this.model.create(input);
+  }
+
+  async delete(id) {
+    return this.model.findByIdAndDelete(id);
+  }
+
+  async update(id, input) {
+    await this.get(id);
+    const updateInput = await validateInput(input, createCameraStreamRules);
+    await this.printerCache.getCachedPrinterOrThrow(input.printerId);
+    await this.model.updateOne(id, updateInput);
+    return this.get(id);
+  }
+}
+
+module.exports = {
+  CameraStreamService,
+};

--- a/server/services/camera-stream.service.js
+++ b/server/services/camera-stream.service.js
@@ -8,8 +8,8 @@ const createCameraStreamRules = {
   settings: "required|object",
   "settings.aspectRatio": ["required", "string", ["in", "16:9", "4:3", "1:1"]],
   "settings.rotationClockwise": "required|integer|in:0,90,180,270",
-  "settings.flipHorizontally": "required|boolean",
-  "settings.flipVertically": "required|boolean",
+  "settings.flipHorizontal": "required|boolean",
+  "settings.flipVertical": "required|boolean",
 };
 
 class CameraStreamService {
@@ -43,7 +43,9 @@ class CameraStreamService {
 
   async create(data) {
     const input = await validateInput(data, createCameraStreamRules);
-    await this.printerCache.getCachedPrinterOrThrow(input.printerId);
+    if (input.printerId) {
+      await this.printerCache.getCachedPrinterOrThrow(input.printerId);
+    }
     return this.model.create(input);
   }
 
@@ -54,7 +56,9 @@ class CameraStreamService {
   async update(id, input) {
     await this.get(id);
     const updateInput = await validateInput(input, createCameraStreamRules);
-    await this.printerCache.getCachedPrinterOrThrow(input.printerId);
+    if (input.printerId) {
+      await this.printerCache.getCachedPrinterOrThrow(input.printerId);
+    }
     await this.model.updateOne({ id }, updateInput);
     return this.get(id);
   }

--- a/server/services/camera-stream.service.js
+++ b/server/services/camera-stream.service.js
@@ -6,7 +6,7 @@ const createCameraStreamRules = {
   printerId: "mongoId",
   streamURL: "required|httpurl",
   settings: "required|object",
-  "settings.aspectRatio": "required|string",
+  "settings.aspectRatio": ["required", "string", ["in", "16:9", "4:3", "1:1"]],
   "settings.rotationClockwise": "required|integer|in:0,90,180,270",
   "settings.flipHorizontally": "required|boolean",
   "settings.flipVertically": "required|boolean",
@@ -55,7 +55,7 @@ class CameraStreamService {
     await this.get(id);
     const updateInput = await validateInput(input, createCameraStreamRules);
     await this.printerCache.getCachedPrinterOrThrow(input.printerId);
-    await this.model.updateOne(id, updateInput);
+    await this.model.updateOne({ id }, updateInput);
     return this.get(id);
   }
 }

--- a/server/test/api/camera-stream.controller.test.js
+++ b/server/test/api/camera-stream.controller.test.js
@@ -32,12 +32,19 @@ describe("CameraStreamController", () => {
     rotationClockwise: 0,
   };
   const defaultTestURL = "https://test.url/stream";
-  const defaultCameraStreamInput = {
-    streamURL: defaultTestURL,
+  const defaultCameraStreamInput = (url) => ({
+    streamURL: url,
     printerId: null,
     settings: defaultSettings,
-  };
-  const createTestCameraStream = async () => await request.post(listRoute).send(defaultCameraStreamInput);
+  });
+  const matchedBody = (url) => ({
+    _id: expect.any(String),
+    __v: 0,
+    streamURL: url,
+    printerId: null,
+    settings: defaultSettings,
+  });
+  const createTestCameraStream = async (url) => await request.post(listRoute).send(defaultCameraStreamInput(url));
   const deleteTestCameraStream = async (id) => await request.delete(deleteRoute(id));
 
   it("should list streams", async () => {
@@ -47,25 +54,20 @@ describe("CameraStreamController", () => {
   });
 
   it("should create stream", async () => {
-    const res = await createTestCameraStream();
-    expectOkResponse(res.statusCode, {
-      _id: expect.any(String),
-      __v: 0,
-      streamURL: defaultTestURL,
-      printerId: null,
-      settings: defaultSettings,
-    });
+    const res = await createTestCameraStream(defaultTestURL);
+    expectOkResponse(res, matchedBody(defaultTestURL));
+  });
+
+  it("should create two streams with null printerId", async () => {
+    const res = await createTestCameraStream(defaultTestURL + "2");
+    expectOkResponse(res, matchedBody(defaultTestURL + "2"));
+    const res2 = await createTestCameraStream(defaultTestURL + "3");
+    expectOkResponse(res2, matchedBody(defaultTestURL + "3"));
   });
 
   it("should create and delete stream", async () => {
-    const res = await createTestCameraStream();
-    await expectOkResponse(res, {
-      _id: expect.any(String),
-      __v: 0,
-      streamURL: defaultTestURL,
-      printerId: null,
-      settings: defaultSettings,
-    });
+    const res = await createTestCameraStream(defaultTestURL + "4");
+    await expectOkResponse(res, matchedBody(defaultTestURL + "4"));
     const deleteResponse = await deleteTestCameraStream(res.body._id);
     await expectOkResponse(deleteResponse);
   });

--- a/server/test/api/camera-stream.controller.test.js
+++ b/server/test/api/camera-stream.controller.test.js
@@ -1,0 +1,72 @@
+const dbHandler = require("../db-handler");
+const { setupTestApp } = require("../test-server");
+const DITokens = require("../../container.tokens");
+const { AppConstants } = require("../../server.constants");
+const { CameraStream } = require("../../models/CameraStream");
+const { expectOkResponse } = require("../extensions");
+let Model = CameraStream;
+
+const listRoute = `${AppConstants.apiRoute}/camera-stream`;
+const getRoute = (id) => `${listRoute}/${id}`;
+const deleteRoute = (id) => `${listRoute}/${id}`;
+const updateRoute = (id) => `${getRoute(id)}`;
+
+let request;
+let container;
+let printerSocketStore;
+beforeAll(async () => {
+  await dbHandler.connect();
+  ({ request, container } = await setupTestApp(true));
+  printerSocketStore = container.resolve(DITokens.printerSocketStore);
+});
+
+beforeEach(async () => {
+  Model.deleteMany({});
+});
+
+describe("CameraStreamController", () => {
+  const defaultSettings = {
+    flipHorizontal: false,
+    flipVertical: false,
+    aspectRatio: "16:9",
+    rotationClockwise: 0,
+  };
+  const defaultTestURL = "https://test.url/stream";
+  const defaultCameraStreamInput = {
+    streamURL: defaultTestURL,
+    printerId: null,
+    settings: defaultSettings,
+  };
+  const createTestCameraStream = async () => await request.post(listRoute).send(defaultCameraStreamInput);
+  const deleteTestCameraStream = async (id) => await request.delete(deleteRoute(id));
+
+  it("should list streams", async () => {
+    const res = await request.get(listRoute);
+    expect(res.statusCode).toEqual(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it("should create stream", async () => {
+    const res = await createTestCameraStream();
+    expectOkResponse(res.statusCode, {
+      _id: expect.any(String),
+      __v: 0,
+      streamURL: defaultTestURL,
+      printerId: null,
+      settings: defaultSettings,
+    });
+  });
+
+  it("should create and delete stream", async () => {
+    const res = await createTestCameraStream();
+    await expectOkResponse(res, {
+      _id: expect.any(String),
+      __v: 0,
+      streamURL: defaultTestURL,
+      printerId: null,
+      settings: defaultSettings,
+    });
+    const deleteResponse = await deleteTestCameraStream(res.body._id);
+    await expectOkResponse(deleteResponse);
+  });
+});

--- a/server/test/api/floor-controller.test.js
+++ b/server/test/api/floor-controller.test.js
@@ -16,6 +16,7 @@ const updateNameRoute = (id) => `${getRoute(id)}/name`;
 const updateFloorNumberRoute = (id) => `${getRoute(id)}/floor-number`;
 
 let request;
+let container;
 let printerSocketStore;
 
 beforeAll(async () => {


### PR DESCRIPTION
# Description

Implements a separate database object which contains a CameraStream definition. 
This object carries an optional printerId property in such a way that the printer can be attached if so desired.
Only one stream can be coupled to a printer.

Tests:
- unique printerId is enforced
- streamURL must be an http url
- aspect ratio must be one of the specified options 16:9, 5:4, 1:1

Caveats:
- Does not cascade delete the stream if the printer is removed