### PR TITLE
fix: random key should be of minimum length

### DIFF
--- a/server/constants/server-settings.constants.js
+++ b/server/constants/server-settings.constants.js
@@ -1,5 +1,5 @@
 const { AppConstants } = require("../server.constants");
-const { generateCorrelationToken } = require("../utils/correlation-token.util");
+const { v4: uuidv4 } = require("uuid");
 
 const getDefaultWhitelistIpAddresses = () => ["::12", "127.0.0.1"];
 
@@ -23,7 +23,7 @@ const credentialSettingsKey = "credentials";
 
 const getDefaultCredentialSettings = () => ({
   // Verification and signing of JWT tokens, can be changed on the fly
-  jwtSecret: generateCorrelationToken(),
+  jwtSecret: uuidv4(),
   // Signing only, verification is automatic
   jwtExpiresIn: AppConstants.DEFAULT_JWT_EXPIRES_IN,
   // Verification only, bringing into effect requires updating all stored refresh tokens

--- a/server/utils/correlation-token.util.js
+++ b/server/utils/correlation-token.util.js
@@ -3,5 +3,5 @@ function generateCorrelationToken() {
 }
 
 module.exports = {
-  generateCorrelationToken
+  generateCorrelationToken,
 };


### PR DESCRIPTION
# Description

This sets the random key to a uuid v4 which is like this:
`eec2b7cb-3e39-4034-b83e-c2ddbbe5e8cd`

So it meets the requirements of minimum 5 characters instead of 10.