### PR TITLE
Fix/2098 url validation and normalization

### DIFF
--- a/server/controllers/printer.controller.js
+++ b/server/controllers/printer.controller.js
@@ -328,7 +328,7 @@ class PrinterController {
     try {
       await this.testPrinterSocketStore.setupTestPrinter(newPrinter);
     } catch (e) {
-      res.send({ correlationToken: newPrinter.correlationToken, failure: true });
+      res.send({ correlationToken: newPrinter.correlationToken, failure: true, error: e.toString() });
       return;
     }
     res.send({ correlationToken: newPrinter.correlationToken });

--- a/server/controllers/printer.controller.js
+++ b/server/controllers/printer.controller.js
@@ -17,6 +17,7 @@ const { printerResolveMiddleware } = require("../middleware/printer");
 const { generateCorrelationToken } = require("../utils/correlation-token.util");
 const { ROLES } = require("../constants/authorization.constants");
 const { Floor } = require("../models/Floor");
+const PrinterService = require("../services/printer.service");
 
 class PrinterController {
   /**
@@ -320,6 +321,9 @@ class PrinterController {
    * @returns {Promise<void>}
    */
   async testConnection(req, res) {
+    if (req.body.printerURL?.length) {
+      req.body.printerURL = PrinterService.normalizeURLWithProtocol(req.body.printerURL);
+    }
     const newPrinter = await validateMiddleware(req, testPrinterApiRules);
     newPrinter.correlationToken = generateCorrelationToken();
     this.logger.log(`Testing printer with correlation token ${newPrinter.correlationToken}`);

--- a/server/handlers/validators.js
+++ b/server/handlers/validators.js
@@ -6,14 +6,22 @@ const { normalizeUrl } = require("../utils/normalize-url");
 function getExtendedValidator() {
   nodeInputValidator.extend("wsurl", ({ value, args }, validator) => {
     if (!value) return false;
-    const url = normalizeUrl(value);
-    return url.startsWith("ws://") || url.startsWith("wss://");
+    try {
+      const url = normalizeUrl(value);
+      return url.startsWith("ws://") || url.startsWith("wss://");
+    } catch (e) {
+      return false;
+    }
   });
   nodeInputValidator.extend("httpurl", ({ value, args }, validator) => {
     if (!value) return false;
 
-    const url = normalizeUrl(value);
-    return url.startsWith("http://") || url.startsWith("https://");
+    try {
+      const url = normalizeUrl(value);
+      return url.startsWith("http://") || url.startsWith("https://");
+    } catch (e) {
+      return false;
+    }
   });
   nodeInputValidator.extend("not", ({ value, args }, validator) => {
     return !value && value !== false;

--- a/server/handlers/validators.js
+++ b/server/handlers/validators.js
@@ -1,17 +1,19 @@
 const nodeInputValidator = require("node-input-validator");
 const { ValidationException, InternalServerException } = require("../exceptions/runtime.exceptions");
 const { printerLoginToken, currentPrinterToken, printerIdToken } = require("../middleware/printer");
+const { normalizeUrl } = require("../utils/normalize-url");
 
 function getExtendedValidator() {
   nodeInputValidator.extend("wsurl", ({ value, args }, validator) => {
     if (!value) return false;
-    const url = new URL(value).href;
-    return url.includes("ws://") || url.includes("wss://");
+    const url = normalizeUrl(value);
+    return url.startsWith("ws://") || url.startsWith("wss://");
   });
   nodeInputValidator.extend("httpurl", ({ value, args }, validator) => {
     if (!value) return false;
-    const url = new URL(value).href;
-    return url.includes("http://") || url.includes("https://");
+
+    const url = normalizeUrl(value);
+    return url.startsWith("http://") || url.startsWith("https://");
   });
   nodeInputValidator.extend("not", ({ value, args }, validator) => {
     return !value && value !== false;

--- a/server/handlers/validators.js
+++ b/server/handlers/validators.js
@@ -17,8 +17,10 @@ function getExtendedValidator() {
     if (!value) return false;
 
     try {
-      const url = normalizeUrl(value);
-      return url.startsWith("http://") || url.startsWith("https://");
+      if (!value.startsWith("http://") && !value.startsWith("https://")) {
+        return false;
+      }
+      return new URL(normalizeUrl(value));
     } catch (e) {
       return false;
     }

--- a/server/server.constants.js
+++ b/server/server.constants.js
@@ -50,7 +50,7 @@ const AppConstants = {
   clientRepoName: "fdm-monster-client",
   serverRepoName: "fdm-monster",
   orgName: "fdm-monster",
-  defaultClientMinimum: "1.2.9",
+  defaultClientMinimum: "1.2.12",
   serverPath: "./",
 
   influxUrl: "INFLUX_URL",

--- a/server/services/octoprint/octoprint-api.routes.js
+++ b/server/services/octoprint/octoprint-api.routes.js
@@ -1,6 +1,7 @@
 const { jsonContentType, contentTypeHeaderKey } = require("./constants/octoprint-service.constants");
 const { validateLogin, constructHeaders } = require("./utils/api.utils");
 const { getDefaultTimeout } = require("../../constants/server-settings.constants");
+const { normalizeUrl } = require("../../utils/normalize-url");
 
 class OctoPrintRoutes {
   octoPrintBase = "/";
@@ -155,7 +156,7 @@ class OctoPrintRoutes {
     }
 
     return {
-      url: new URL(path, printerURL).href,
+      url: new URL(path, normalizeUrl(printerURL)).href,
       options: {
         headers,
         timeout,

--- a/server/services/octoprint/octoprint-api.service.js
+++ b/server/services/octoprint/octoprint-api.service.js
@@ -32,7 +32,7 @@ class OctoPrintApiService extends OctoPrintRoutes {
 
   /**
    *
-   * @param {LoginDto} printer
+   * @param {LoginDto} login
    * @param responseOptions
    * @returns {Promise<{data, status}|*>}
    */

--- a/server/services/octoprint/octoprint-sockio.adapter.js
+++ b/server/services/octoprint/octoprint-sockio.adapter.js
@@ -3,6 +3,7 @@ const HttpStatusCode = require("../../constants/http-status-codes.constants");
 const { AppConstants } = require("../../server.constants");
 const { AuthenticationError } = require("../../exceptions/runtime.exceptions");
 const { httpToWsUrl } = require("../../utils/url.utils");
+const { normalizeUrl } = require("../../utils/normalize-url");
 
 /**
  * @typedef {1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10} ThrottleRate
@@ -18,7 +19,7 @@ const { httpToWsUrl } = require("../../utils/url.utils");
  * @typedef {Object} CredentialsDto
  * @property {LoginDto} loginDto
  * @property {string} printerId
- * @property {'ws'|'wss'} protocol
+ * @property {"ws"|"wss"} protocol
  */
 
 /**
@@ -159,7 +160,7 @@ class OctoPrintSockIoAdapter extends WebsocketAdapter {
     this.printerId = printerId;
     this.loginDto = loginDto;
 
-    const httpUrl = new URL(this.loginDto.printerURL);
+    const httpUrl = normalizeUrl(this.loginDto.printerURL);
     const wsUrl = httpToWsUrl(httpUrl, protocol);
     wsUrl.pathname = "/sockjs/websocket";
     this.socketURL = wsUrl;

--- a/server/services/printer.service.js
+++ b/server/services/printer.service.js
@@ -261,7 +261,7 @@ class PrinterService {
   }
 
   static normalizeURLWithProtocol(printerURL) {
-    if (!printerURL.startsWith("http") || !printerURL.startsWith("https")) {
+    if (!printerURL.startsWith("http://") && !printerURL.startsWith("https://")) {
       printerURL = `http://${printerURL}`;
     }
 

--- a/server/services/printer.service.js
+++ b/server/services/printer.service.js
@@ -70,10 +70,11 @@ class PrinterService {
   async update(printerId, updateData) {
     const printer = await this.get(printerId);
 
+    updateData.printerURL = PrinterService.normalizeURLWithProtocol(updateData.printerURL);
     const { printerURL, apiKey, enabled, settingsAppearance } = await validateInput(updateData, createPrinterRules);
     await this.get(printerId);
 
-    printer.printerURL = normalizeUrl(printerURL);
+    printer.printerURL = printerURL;
     printer.apiKey = apiKey;
     if (enabled !== undefined) {
       printer.enabled = enabled;
@@ -174,7 +175,7 @@ class PrinterService {
 
   async updateConnectionSettings(printerId, { printerURL, apiKey }) {
     const update = {
-      printerURL: normalizeUrl(printerURL),
+      printerURL: PrinterService.normalizeURLWithProtocol(printerURL),
       apiKey,
     };
 
@@ -253,7 +254,18 @@ class PrinterService {
       enabled: true,
       ...printer,
     };
+    if (mergedPrinter.printerURL?.length) {
+      mergedPrinter.printerURL = PrinterService.normalizeURLWithProtocol(mergedPrinter.printerURL);
+    }
     return await validateInput(mergedPrinter, createPrinterRules);
+  }
+
+  static normalizeURLWithProtocol(printerURL) {
+    if (!printerURL.startsWith("http") || !printerURL.startsWith("https")) {
+      printerURL = `http://${printerURL}`;
+    }
+
+    return normalizeUrl(printerURL);
   }
 }
 

--- a/server/services/printer.service.js
+++ b/server/services/printer.service.js
@@ -1,6 +1,5 @@
 const { Printer } = require("../models/Printer");
 const { NotFoundException } = require("../exceptions/runtime.exceptions");
-const { sanitizeURL, httpToWsUrl } = require("../utils/url.utils");
 const { validateInput } = require("../handlers/validators");
 const {
   createPrinterRules,
@@ -10,6 +9,7 @@ const {
 } = require("./validators/printer-service.validation");
 const { getDefaultPrinterEntry } = require("../constants/service.constants");
 const { printerEvents } = require("../constants/event.constants");
+const { normalizeUrl } = require("../utils/normalize-url");
 
 class PrinterService {
   /**
@@ -73,7 +73,7 @@ class PrinterService {
     const { printerURL, apiKey, enabled, settingsAppearance } = await validateInput(updateData, createPrinterRules);
     await this.get(printerId);
 
-    printer.printerURL = printerURL;
+    printer.printerURL = normalizeUrl(printerURL);
     printer.apiKey = apiKey;
     if (enabled !== undefined) {
       printer.enabled = enabled;
@@ -174,7 +174,7 @@ class PrinterService {
 
   async updateConnectionSettings(printerId, { printerURL, apiKey }) {
     const update = {
-      printerURL: sanitizeURL(printerURL),
+      printerURL: normalizeUrl(printerURL),
       apiKey,
     };
 
@@ -252,6 +252,7 @@ class PrinterService {
       ...getDefaultPrinterEntry(),
       enabled: true,
       ...printer,
+      printerURL: normalizeUrl(printer.printerURL),
     };
     return await validateInput(mergedPrinter, createPrinterRules);
   }

--- a/server/services/printer.service.js
+++ b/server/services/printer.service.js
@@ -252,7 +252,6 @@ class PrinterService {
       ...getDefaultPrinterEntry(),
       enabled: true,
       ...printer,
-      printerURL: normalizeUrl(printer.printerURL),
     };
     return await validateInput(mergedPrinter, createPrinterRules);
   }

--- a/server/test/api/printer-controller.test.js
+++ b/server/test/api/printer-controller.test.js
@@ -161,7 +161,7 @@ describe("PrinterController", () => {
     };
     const updatePatch = await request.patch(updateRoute(printer.id)).send(patch);
     expectOkResponse(updatePatch, {
-      printerURL: "https://test.com/",
+      printerURL: "https://test.com",
       enabled: false,
       printerName: "asd124",
     });
@@ -175,7 +175,7 @@ describe("PrinterController", () => {
       apiKey,
     });
     expectOkResponse(updatePatch, {
-      printerURL: "https://test.com/",
+      printerURL: "https://test.com",
       apiKey,
     });
   });

--- a/server/utils/normalize-url.js
+++ b/server/utils/normalize-url.js
@@ -1,0 +1,281 @@
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
+const DATA_URL_DEFAULT_MIME_TYPE = "text/plain";
+const DATA_URL_DEFAULT_CHARSET = "us-ascii";
+
+const testParameter = (name, filters) =>
+  filters.some((filter) => (filter instanceof RegExp ? filter.test(name) : filter === name));
+
+const supportedProtocols = new Set(["https:", "http:", "file:"]);
+
+const hasCustomProtocol = (urlString) => {
+  try {
+    const { protocol } = new URL(urlString);
+    return protocol.endsWith(":") && !supportedProtocols.has(protocol);
+  } catch {
+    return false;
+  }
+};
+
+const normalizeDataURL = (urlString, { stripHash }) => {
+  const match = /^data:(?<type>[^,]*?),(?<data>[^#]*?)(?:#(?<hash>.*))?$/.exec(urlString);
+
+  if (!match) {
+    throw new Error(`Invalid URL: ${urlString}`);
+  }
+
+  let { type, data, hash } = match.groups;
+  const mediaType = type.split(";");
+  hash = stripHash ? "" : hash;
+
+  let isBase64 = false;
+  if (mediaType[mediaType.length - 1] === "base64") {
+    mediaType.pop();
+    isBase64 = true;
+  }
+
+  // Lowercase MIME type
+  const mimeType = mediaType.shift()?.toLowerCase() ?? "";
+  const attributes = mediaType
+    .map((attribute) => {
+      let [key, value = ""] = attribute.split("=").map((string) => string.trim());
+
+      // Lowercase `charset`
+      if (key === "charset") {
+        value = value.toLowerCase();
+
+        if (value === DATA_URL_DEFAULT_CHARSET) {
+          return "";
+        }
+      }
+
+      return `${key}${value ? `=${value}` : ""}`;
+    })
+    .filter(Boolean);
+
+  const normalizedMediaType = [...attributes];
+
+  if (isBase64) {
+    normalizedMediaType.push("base64");
+  }
+
+  if (normalizedMediaType.length > 0 || (mimeType && mimeType !== DATA_URL_DEFAULT_MIME_TYPE)) {
+    normalizedMediaType.unshift(mimeType);
+  }
+
+  return `data:${normalizedMediaType.join(";")},${isBase64 ? data.trim() : data}${hash ? `#${hash}` : ""}`;
+};
+
+function normalizeUrl(urlString, options) {
+  options = {
+    defaultProtocol: "http",
+    normalizeProtocol: true,
+    forceHttp: false,
+    forceHttps: false,
+    stripAuthentication: true,
+    stripHash: false,
+    stripTextFragment: true,
+    stripWWW: true,
+    removeQueryParameters: [/^utm_\w+/i],
+    removeTrailingSlash: true,
+    removeSingleSlash: true,
+    removeDirectoryIndex: false,
+    removeExplicitPort: false,
+    sortQueryParameters: true,
+    ...options,
+  };
+
+  // Legacy: Append `:` to the protocol if missing.
+  if (typeof options.defaultProtocol === "string" && !options.defaultProtocol.endsWith(":")) {
+    options.defaultProtocol = `${options.defaultProtocol}:`;
+  }
+
+  urlString = urlString.trim();
+
+  // Data URL
+  if (/^data:/i.test(urlString)) {
+    return normalizeDataURL(urlString, options);
+  }
+
+  if (hasCustomProtocol(urlString)) {
+    return urlString;
+  }
+
+  const hasRelativeProtocol = urlString.startsWith("//");
+  const isRelativeUrl = !hasRelativeProtocol && /^\.*\//.test(urlString);
+
+  // Prepend protocol
+  if (!isRelativeUrl) {
+    urlString = urlString.replace(/^(?!(?:\w+:)?\/\/)|^\/\//, options.defaultProtocol);
+  }
+
+  const urlObject = new URL(urlString);
+
+  if (options.forceHttp && options.forceHttps) {
+    throw new Error("The `forceHttp` and `forceHttps` options cannot be used together");
+  }
+
+  if (options.forceHttp && urlObject.protocol === "https:") {
+    urlObject.protocol = "http:";
+  }
+
+  if (options.forceHttps && urlObject.protocol === "http:") {
+    urlObject.protocol = "https:";
+  }
+
+  // Remove auth
+  if (options.stripAuthentication) {
+    urlObject.username = "";
+    urlObject.password = "";
+  }
+
+  // Remove hash
+  if (options.stripHash) {
+    urlObject.hash = "";
+  } else if (options.stripTextFragment) {
+    urlObject.hash = urlObject.hash.replace(/#?:~:text.*?$/i, "");
+  }
+
+  // Remove duplicate slashes if not preceded by a protocol
+  // NOTE: This could be implemented using a single negative lookbehind
+  // regex, but we avoid that to maintain compatibility with older js engines
+  // which do not have support for that feature.
+  if (urlObject.pathname) {
+    // TODO: Replace everything below with `urlObject.pathname = urlObject.pathname.replace(/(?<!\b[a-z][a-z\d+\-.]{1,50}:)\/{2,}/g, '/');` when Safari supports negative lookbehind.
+
+    // Split the string by occurrences of this protocol regex, and perform
+    // duplicate-slash replacement on the strings between those occurrences
+    // (if any).
+    const protocolRegex = /\b[a-z][a-z\d+\-.]{1,50}:\/\//g;
+
+    let lastIndex = 0;
+    let result = "";
+    for (;;) {
+      const match = protocolRegex.exec(urlObject.pathname);
+      if (!match) {
+        break;
+      }
+
+      const protocol = match[0];
+      const protocolAtIndex = match.index;
+      const intermediate = urlObject.pathname.slice(lastIndex, protocolAtIndex);
+
+      result += intermediate.replace(/\/{2,}/g, "/");
+      result += protocol;
+      lastIndex = protocolAtIndex + protocol.length;
+    }
+
+    const remnant = urlObject.pathname.slice(lastIndex, urlObject.pathname.length);
+    result += remnant.replace(/\/{2,}/g, "/");
+
+    urlObject.pathname = result;
+  }
+
+  // Decode URI octets
+  if (urlObject.pathname) {
+    try {
+      urlObject.pathname = decodeURI(urlObject.pathname);
+    } catch {}
+  }
+
+  // Remove directory index
+  if (options.removeDirectoryIndex === true) {
+    options.removeDirectoryIndex = [/^index\.[a-z]+$/];
+  }
+
+  if (Array.isArray(options.removeDirectoryIndex) && options.removeDirectoryIndex.length > 0) {
+    let pathComponents = urlObject.pathname.split("/");
+    const lastComponent = pathComponents[pathComponents.length - 1];
+
+    if (testParameter(lastComponent, options.removeDirectoryIndex)) {
+      pathComponents = pathComponents.slice(0, -1);
+      urlObject.pathname = pathComponents.slice(1).join("/") + "/";
+    }
+  }
+
+  if (urlObject.hostname) {
+    // Remove trailing dot
+    urlObject.hostname = urlObject.hostname.replace(/\.$/, "");
+
+    // Remove `www.`
+    if (options.stripWWW && /^www\.(?!www\.)[a-z\-\d]{1,63}\.[a-z.\-\d]{2,63}$/.test(urlObject.hostname)) {
+      // Each label should be max 63 at length (min: 1).
+      // Source: https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_host_names
+      // Each TLD should be up to 63 characters long (min: 2).
+      // It is technically possible to have a single character TLD, but none currently exist.
+      urlObject.hostname = urlObject.hostname.replace(/^www\./, "");
+    }
+  }
+
+  // Remove query unwanted parameters
+  if (Array.isArray(options.removeQueryParameters)) {
+    // eslint-disable-next-line unicorn/no-useless-spread -- We are intentionally spreading to get a copy.
+    for (const key of [...urlObject.searchParams.keys()]) {
+      if (testParameter(key, options.removeQueryParameters)) {
+        urlObject.searchParams.delete(key);
+      }
+    }
+  }
+
+  if (!Array.isArray(options.keepQueryParameters) && options.removeQueryParameters === true) {
+    urlObject.search = "";
+  }
+
+  // Keep wanted query parameters
+  if (Array.isArray(options.keepQueryParameters) && options.keepQueryParameters.length > 0) {
+    // eslint-disable-next-line unicorn/no-useless-spread -- We are intentionally spreading to get a copy.
+    for (const key of [...urlObject.searchParams.keys()]) {
+      if (!testParameter(key, options.keepQueryParameters)) {
+        urlObject.searchParams.delete(key);
+      }
+    }
+  }
+
+  // Sort query parameters
+  if (options.sortQueryParameters) {
+    urlObject.searchParams.sort();
+
+    // Calling `.sort()` encodes the search parameters, so we need to decode them again.
+    try {
+      urlObject.search = decodeURIComponent(urlObject.search);
+    } catch {}
+  }
+
+  if (options.removeTrailingSlash) {
+    urlObject.pathname = urlObject.pathname.replace(/\/$/, "");
+  }
+
+  // Remove an explicit port number, excluding a default port number, if applicable
+  if (options.removeExplicitPort && urlObject.port) {
+    urlObject.port = "";
+  }
+
+  const oldUrlString = urlString;
+
+  // Take advantage of many of the Node `url` normalizations
+  urlString = urlObject.toString();
+
+  if (!options.removeSingleSlash && urlObject.pathname === "/" && !oldUrlString.endsWith("/") && urlObject.hash === "") {
+    urlString = urlString.replace(/\/$/, "");
+  }
+
+  // Remove ending `/` unless removeSingleSlash is false
+  if ((options.removeTrailingSlash || urlObject.pathname === "/") && urlObject.hash === "" && options.removeSingleSlash) {
+    urlString = urlString.replace(/\/$/, "");
+  }
+
+  // Restore relative protocol, if applicable
+  if (hasRelativeProtocol && !options.normalizeProtocol) {
+    urlString = urlString.replace(/^http:\/\//, "//");
+  }
+
+  // Remove http/https
+  if (options.stripProtocol) {
+    urlString = urlString.replace(/^(?:https?:)?\/\//, "");
+  }
+
+  return urlString;
+}
+
+module.exports = {
+  normalizeUrl,
+};

--- a/server/utils/normalize-url.js
+++ b/server/utils/normalize-url.js
@@ -65,6 +65,12 @@ const normalizeDataURL = (urlString, { stripHash }) => {
   return `data:${normalizedMediaType.join(";")},${isBase64 ? data.trim() : data}${hash ? `#${hash}` : ""}`;
 };
 
+/**
+ * https://github.com/sindresorhus/normalize-url v8.0.0 downloaded at 13/08/2023
+ * @param urlString
+ * @param options
+ * @return {*|string}
+ */
 function normalizeUrl(urlString, options) {
   options = {
     defaultProtocol: "http",

--- a/server/utils/url.utils.js
+++ b/server/utils/url.utils.js
@@ -1,29 +1,12 @@
-function sanitizeURL(url) {
-  if (!url) return;
-  return new URL(url).href;
-}
+const { normalizeUrl } = require("./normalize-url");
 
 function httpToWsUrl(url, protocol = "ws") {
-  const wsUrl = new URL("/sockjs/websocket", url.origin);
+  const wsUrl = new URL("/sockjs/websocket", normalizeUrl(url));
   wsUrl.protocol = `${protocol}`;
   wsUrl.pathname = "/sockjs/websocket";
   return wsUrl;
 }
 
-function convertHttpUrlToWebsocket(url) {
-  const urlInstance = new URL(url);
-  const protocol = urlInstance.protocol;
-  if (protocol === "https:") {
-    urlInstance.protocol = "wss:";
-  } else {
-    urlInstance.protocol = "ws:";
-  }
-
-  return urlInstance.href;
-}
-
 module.exports = {
-  convertHttpUrlToWebsocket,
   httpToWsUrl,
-  sanitizeURL,
 };


### PR DESCRIPTION
# Description

Should fix #2098 by leaving URLs alone, except for normalizing them w.r.t defaulting to http and slashes, etc.

Needs tests:
- `octopi.local`
- `octopi`
- `https://mysecurepi`
- `localhost`