### PR TITLE
chore: add ansible script to test mongodb (requires linux, python3, pip3, ansible and pymongo)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,15 @@
-volumes:
-  mongodb-data:
-
 services:
   mongodb:
-    image: mongo:latest
+    image: mongo:5
     container_name: mongodb
     environment:
-      # MongoDB with authentication (optional)
-#      - MONGO_INITDB_ROOT_USERNAME=YOUR_ROOT_NAME
-#      - MONGO_INITDB_ROOT_PASSWORD=YOUR_ROOT_PASSWORD
-      - MONGO_INITDB_DATABASE=fdm-monster
+      # Authenticated variant, comment out for non-authenticated variant:
+      - MONGO_INITDB_ROOT_USERNAME=root
+      - MONGO_INITDB_ROOT_PASSWORD=fdm-root
     ports:
       - "21111:27017"
     volumes:
-      - ./fdm-monster/mongodb-data:/data/db
-      - ./fdm-monster/mongoconfig:/data/configdb
+      - ./fdm-monster:/data
     restart: unless-stopped
 
   fdm-monster:
@@ -24,11 +19,18 @@ services:
       context: ./server
       dockerfile: ./docker/Dockerfile
     restart: unless-stopped
+    deploy:
+      restart_policy:
+        delay: 5s
+        max_attempts: 3
+        window: 120s
     ports:
       - "4000:4000"
     environment:
-#      - MONGO=mongodb://<username>:<password>@mongodb:27017/fdm-monster?authSource=admin
-      - MONGO=mongodb://mongodb:27017/fdm-monster?readPreference=primary&ssl=false
+      # Non-authenticated variant:
+#      - MONGO=mongodb://mongodb:27017/fdm-monster
+      # Authenticated variant:
+      - MONGO=mongodb://root:fdm-root@mongodb:27017/fdm-monster?authSource=admin
       - NODE_ENV=development
       - SERVER_PORT=4000
     volumes:

--- a/docs/installations/docker_compose.md
+++ b/docs/installations/docker_compose.md
@@ -51,9 +51,8 @@ services:
     container_name: mongodb
     environment:
       # MongoDB with authentication (optional)
-#      - MONGO_INITDB_ROOT_USERNAME=YOUR_ROOT_NAME
-#      - MONGO_INITDB_ROOT_PASSWORD=YOUR_ROOT_PASSWORD
-      - MONGO_INITDB_DATABASE=fdm-monster
+      - MONGO_INITDB_ROOT_USERNAME=YOUR_ROOT_NAME
+      - MONGO_INITDB_ROOT_PASSWORD=YOUR_ROOT_PASSWORD
     ports:
       - "28017:27017"
     volumes:
@@ -69,9 +68,9 @@ services:
       - "4000:4000"
     environment:
       # MongoDB with authentication (optional) - see MONGO_INITDB_ROOT_USERNAME and MONGO_INITDB_ROOT_PASSWORD above
-#      - MONGO=mongodb://<username>:<password>@mongodb:27017/fdm-monster?authSource=admin
+      - MONGO=mongodb://YOUR_ROOT_NAME:YOUR_ROOT_PASSWORD@mongodb:27017/fdm-monster?authSource=admin
       # MongoDB without authentication
-      - MONGO=mongodb://mongodb:27017/fdm-monster?authSource=admin
+#      - MONGO=mongodb://mongodb:27017/fdm-monster?authSource=admin
     volumes:
       - ./fdm-monster/media:/media
 ```

--- a/installations/ansible/playbook.yaml
+++ b/installations/ansible/playbook.yaml
@@ -1,0 +1,108 @@
+---
+- name: Run mongodb without authentication and recreate with authentication
+  hosts: localhost
+  vars:
+    - host_port: 21112
+    - internal_port: 27017
+  tasks:
+    - set_fact:
+          random_container_name: "{{ query('community.general.random_string', upper=false, numbers=false, special=false)[0] }}MongoDB"
+
+    - name: install mongodb
+      community.docker.docker_container:
+        name: "{{ random_container_name }}"
+        image: mongo:latest
+        state: started
+        detach: true
+        restart_policy: unless-stopped
+        published_ports:
+          - "{{ host_port }}:{{ internal_port }}"
+        volumes:
+          - ./{{ random_container_name }}/mongodb:/data
+      register: mongo_docker
+
+    - name: Gather all supported information
+      community.mongodb.mongodb_info:
+        login_port: "{{ host_port }}"
+      register: result
+
+    - set_fact:
+        mongo_is_running: "{{ mongo_docker.container.State.Running }}"
+
+    - name: "Check"
+      debug:
+        msg: "{{ result }} {{ random_container_name }} localhost:{{ host_port }}"
+
+    - name: "Check!!!"
+      debug:
+        msg: "{{ mongo_is_running }} localhost:{{ host_port }}"
+
+    - name: Check container status
+      fail:
+        msg: "Mongo did not start: {{ mongo_is_running }}"
+      when: not mongo_is_running
+
+    - name: Wait for MongoDB web interface to get available
+      uri:
+        url: "http://localhost:{{ host_port }}"
+        method: GET
+      register: wait_mongodb_result
+      until: wait_mongodb_result is succeeded
+      retries: 2
+      delay: 3
+      changed_when: false
+
+    - name: remove mongodb
+      community.docker.docker_container:
+        name: "{{ random_container_name }}"
+        image: mongo:latest
+        state: absent
+
+    - name: install mongodb with authentication
+      community.docker.docker_container:
+        name: "{{ random_container_name }}2"
+        env:
+          MONGO_INITDB_ROOT_USERNAME: root
+          MONGO_INITDB_ROOT_PASSWORD: root2
+        image: mongo:latest
+        state: started
+        detach: true
+        restart_policy: unless-stopped
+        published_ports:
+          - "{{ host_port }}:{{ internal_port }}"
+        volumes:
+          - ./{{ random_container_name }}/mongodb:/data
+      register: mongo_docker2
+
+    - set_fact:
+        mongo2_is_running: "{{ mongo_docker2.container.State.Running }}"
+
+    - name: "Check!!!"
+      debug:
+        msg: "{{ mongo2_is_running }}"
+
+    - name: Check container status
+      fail:
+        msg: "Mongo did not start: {{ mongo2_is_running }}"
+      when: not mongo2_is_running
+
+    - name: Wait for MongoDB web interface to get available
+      uri:
+        url: "http://localhost:{{ host_port }}"
+        method: GET
+      register: wait_mongodb2_result
+      until: wait_mongodb2_result is succeeded
+      retries: 2
+      delay: 3
+      changed_when: false
+
+    - name: Gather all supported information
+      community.mongodb.mongodb_info:
+        login_user: root
+        login_password: root2
+        login_port: "{{ host_port }}"
+      register: result2
+
+    - name: "Check"
+      debug:
+        msg: "{{ result2 }}"


### PR DESCRIPTION
# Description

- Adds an ansible script to run mongodb through change of authentication
- Adjusts default docker-compose to be more resilient for new users wanting to change credentials (INITDB issue w.r.t. authSource configuration)  and simplifies mongo volume mapping
- adjusts docs with docker-compose template