### PR TITLE
dry-run the publish action

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -41,3 +41,10 @@ jobs:
       - name: print-tag
         run: |
           echo ${{ env.RELEASE_TAG }}
+
+      # Publish to NPM
+      - uses: JS-DevTools/npm-publish@v2
+        with:
+          dry-run: true
+          token: ${{ secrets.NPM_TOKEN }}
+          package: package.json


### PR DESCRIPTION
# Description

In order to ensure that release workflows work, we can dryrun the actions as well as possible.