### PR TITLE
Fix/implement specific auth error codes

### DIFF
--- a/src/constants/authorization.constants.ts
+++ b/src/constants/authorization.constants.ts
@@ -4,6 +4,14 @@ export function serializePerm(group: string, perm: string) {
   return `${group}.${perm}`;
 }
 
+export const AUTH_ERROR_REASON = {
+  IncorrectCredentials: "IncorrectCredentials",
+  InvalidOrExpiredRefreshToken: "InvalidOrExpiredRefreshToken",
+  PasswordChangeRequired: "PasswordChangeRequired",
+  LoginRequired: "LoginRequired",
+  AccountNotVerified: "AccountNotVerified",
+};
+
 export const PERM_GROUP = {
   PrinterFiles: "PrinterFiles",
   PrinterSettings: "PrinterSettings",

--- a/src/constants/authorization.constants.ts
+++ b/src/constants/authorization.constants.ts
@@ -5,8 +5,10 @@ export function serializePerm(group: string, perm: string) {
 }
 
 export const AUTH_ERROR_REASON = {
+  // Before login
   IncorrectCredentials: "IncorrectCredentials",
   InvalidOrExpiredRefreshToken: "InvalidOrExpiredRefreshToken",
+  InvalidOrExpiredAuthToken: "InvalidOrExpiredAuthToken",
   PasswordChangeRequired: "PasswordChangeRequired",
   LoginRequired: "LoginRequired",
   AccountNotVerified: "AccountNotVerified",

--- a/src/container.ts
+++ b/src/container.ts
@@ -69,7 +69,8 @@ export function configureContainer() {
   container.register({
     // -- asValue/asFunction constants --
     [DITokens.serverTasks]: asValue(ServerTasks),
-    [DITokens.appDefaultRole]: asValue(ROLES.GUEST),
+    // TODO change the role to a non-admin role in the future once GUEST/OPERATOR have more meaningful permissions
+    [DITokens.appDefaultRole]: asValue(ROLES.ADMIN),
     [DITokens.appDefaultRoleNoLogin]: asValue(ROLES.ADMIN),
     [DITokens.serverVersion]: asFunction(() => {
       return process.env[AppConstants.VERSION_KEY];

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -13,6 +13,7 @@ import { IUserService } from "@/services/interfaces/user-service.interface";
 import { IAuthService } from "@/services/interfaces/auth.service.interface";
 import { IRoleService } from "@/services/interfaces/role-service.interface";
 import { demoUserNotAllowedInterceptor } from "@/middleware/demo.middleware";
+import { IConfigService } from "@/services/core/config.service";
 
 export class AuthController {
   authService: IAuthService;
@@ -20,6 +21,7 @@ export class AuthController {
   userService: IUserService;
   roleService: IRoleService;
   logger: LoggerService;
+  configService: IConfigService;
 
   constructor({
     authService,
@@ -27,17 +29,20 @@ export class AuthController {
     userService,
     roleService,
     loggerFactory,
+    configService,
   }: {
     authService: IAuthService;
     settingsStore: SettingsStore;
     userService: IUserService;
     roleService: IRoleService;
     loggerFactory: ILoggerFactory;
+    configService: IConfigService;
   }) {
     this.authService = authService;
     this.settingsStore = settingsStore;
     this.userService = userService;
     this.roleService = roleService;
+    this.configService = configService;
     this.logger = loggerFactory(AuthController.name);
   }
 
@@ -48,10 +53,11 @@ export class AuthController {
   }
 
   async getLoginRequired(req: Request, res: Response) {
-    const isLoginRequired = await this.settingsStore.getLoginRequired();
+    const loginRequired = await this.settingsStore.getLoginRequired();
     const registration = this.settingsStore.isRegistrationEnabled();
     const wizardState = this.settingsStore.getWizardState();
-    return res.send({ loginRequired: isLoginRequired, registration, wizardState });
+    const isDemoMode = this.configService.isDemoMode();
+    res.send({ loginRequired, registration, wizardState, isDemoMode });
   }
 
   async verifyLogin(req: Request, res: Response) {

--- a/src/controllers/first-time-setup.controller.ts
+++ b/src/controllers/first-time-setup.controller.ts
@@ -2,7 +2,7 @@ import { createController } from "awilix-express";
 import { AppConstants } from "@/server.constants";
 import { validateMiddleware } from "@/handlers/validators";
 import { wizardSettingsRules } from "./validation/setting.validation";
-import { AuthorizationError, BadRequestException } from "@/exceptions/runtime.exceptions";
+import { BadRequestException, ForbiddenError } from "@/exceptions/runtime.exceptions";
 import { ROLES } from "@/constants/authorization.constants";
 import { SettingsStore } from "@/state/settings.store";
 import { Request, Response } from "express";
@@ -44,7 +44,7 @@ export class FirstTimeSetupController {
     const { loginRequired, registration, rootUsername, rootPassword } = await validateMiddleware(req, wizardSettingsRules);
 
     if (this.settingsStore.isWizardCompleted()) {
-      throw new AuthorizationError({ reason: "Wizard already completed" });
+      throw new ForbiddenError("Wizard already completed");
     }
 
     const role = await this.roleService.getSynchronizedRoleByName(ROLES.ADMIN);

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -4,7 +4,7 @@ import { authenticate, authorizeRoles } from "@/middleware/authenticate";
 import { ROLES } from "@/constants/authorization.constants";
 import { validateInput } from "@/handlers/validators";
 import { idRules } from "./validation/generic.validation";
-import { AuthorizationError, BadRequestException, ForbiddenError } from "@/exceptions/runtime.exceptions";
+import { ForbiddenError } from "@/exceptions/runtime.exceptions";
 import { IConfigService } from "@/services/core/config.service";
 import { IUserService } from "@/services/interfaces/user-service.interface";
 import { Request, Response } from "express";
@@ -68,13 +68,13 @@ export class UserController {
     const ownUserId = req.user?.id;
     if (ownUserId) {
       if (ownUserId === id) {
-        throw new BadRequestException("Not allowed to delete own account");
+        throw new ForbiddenError("Not allowed to delete own account");
       }
     }
 
     const isRootUser = await this.userService.isUserRootUser(id);
     if (isRootUser) {
-      throw new BadRequestException("Not allowed to delete root user");
+      throw new ForbiddenError("Not allowed to delete root user");
     }
 
     if (this.configService.isDemoMode()) {
@@ -105,7 +105,7 @@ export class UserController {
     const { id } = await validateInput(req.params, idRules);
 
     if (req.user?.id !== id) {
-      throw new BadRequestException("Not allowed to change username of other users");
+      throw new ForbiddenError("Not allowed to change username of other users");
     }
 
     const { username } = await validateInput(req.body, {
@@ -119,7 +119,7 @@ export class UserController {
     const { id } = await validateInput(req.params, idRules);
 
     if (req.user?.id !== id) {
-      throw new BadRequestException("Not allowed to change password of other users");
+      throw new ForbiddenError("Not allowed to change password of other users");
     }
 
     const { oldPassword, newPassword } = await validateInput(req.body, {
@@ -136,13 +136,13 @@ export class UserController {
     const ownUserId = req.user?.id;
     if (ownUserId) {
       if (ownUserId === id) {
-        throw new BadRequestException("Not allowed to change own verified status");
+        throw new ForbiddenError("Not allowed to change own verified status");
       }
     }
 
     const isRootUser = await this.userService.isUserRootUser(id);
     if (isRootUser) {
-      throw new BadRequestException("Not allowed to change root user to unverified");
+      throw new ForbiddenError("Not allowed to change root user to unverified");
     }
 
     const { isVerified } = await validateInput(req.body, {
@@ -168,11 +168,7 @@ export class UserController {
     if (req.user?.id) {
       const isRootUser = await this.userService.isUserRootUser(userId);
       if (!isRootUser) {
-        throw new AuthorizationError({
-          permissions: [],
-          roles: ["OWNER"],
-          reason: "Not allowed to change owner (root user) without being owner yourself",
-        });
+        throw new ForbiddenError("Not allowed to change owner (root user) without being owner yourself");
       }
     }
     const { isRootUser } = await validateInput(req.body, {

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -150,13 +150,14 @@ export class UserController {
     });
     await this.userService.setVerifiedById(id, isVerified);
 
-    if (!isVerified) {
-      try {
-        await this.authService.logoutUserId(id);
-      } catch (e) {
-        this.logger.error(errorSummary(e));
-      }
-    }
+    // Note: this makes it impossible for the UI to determine if the user is verified or not
+    // if (!isVerified) {
+    //   try {
+    //     await this.authService.logoutUserId(id);
+    //   } catch (e) {
+    //     this.logger.error(errorSummary(e));
+    //   }
+    // }
 
     res.send();
   }

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -14,18 +14,21 @@ import { IAuthService } from "@/services/interfaces/auth.service.interface";
 import { LoggerService } from "@/handlers/logger";
 import { ILoggerFactory } from "@/handlers/logger-factory";
 import { errorSummary } from "@/utils/error.utils";
+import { SettingsStore } from "@/state/settings.store";
 
 export class UserController {
   userService: IUserService;
   roleService: IRoleService;
   configService: IConfigService;
   authService: IAuthService;
+  settingsStore: SettingsStore;
   logger: LoggerService;
 
   constructor({
     userService,
     configService,
     roleService,
+    settingsStore,
     authService,
     loggerFactory,
   }: {
@@ -33,12 +36,14 @@ export class UserController {
     configService: IConfigService;
     roleService: IRoleService;
     authService: IAuthService;
+    settingsStore: SettingsStore;
     loggerFactory: ILoggerFactory;
   }) {
     this.userService = userService;
     this.configService = configService;
     this.roleService = roleService;
     this.authService = authService;
+    this.settingsStore = settingsStore;
     this.logger = loggerFactory(UserController.name);
   }
 
@@ -104,7 +109,7 @@ export class UserController {
   async changeUsername(req: Request, res: Response) {
     const { id } = await validateInput(req.params, idRules);
 
-    if (req.user?.id !== id) {
+    if (req.user?.id !== id && (await this.settingsStore.getLoginRequired())) {
       throw new ForbiddenError("Not allowed to change username of other users");
     }
 
@@ -118,7 +123,7 @@ export class UserController {
   async changePassword(req: Request, res: Response) {
     const { id } = await validateInput(req.params, idRules);
 
-    if (req.user?.id !== id) {
+    if (req.user?.id !== id && (await this.settingsStore.getLoginRequired())) {
       throw new ForbiddenError("Not allowed to change password of other users");
     }
 

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -65,6 +65,13 @@ export class UserController {
     }
 
     await this.userService.deleteUser(id);
+
+    try {
+      await this.authService.logoutUserId(id);
+    } catch (e) {
+      this.logger.error(errorSummary(e));
+    }
+
     res.send();
   }
 
@@ -121,6 +128,15 @@ export class UserController {
       isVerified: "required|boolean",
     });
     await this.userService.setVerifiedById(id, isVerified);
+
+    if (!isVerified) {
+      try {
+        await this.authService.logoutUserId(id);
+      } catch (e) {
+        this.logger.error(errorSummary(e));
+      }
+    }
+
     res.send();
   }
 

--- a/src/controllers/validation/user-controller.validation.ts
+++ b/src/controllers/validation/user-controller.validation.ts
@@ -1,4 +1,6 @@
+import { AppConstants } from "@/server.constants";
+
 export const registerUserRules = {
-  username: "required|string",
-  password: "required|string",
+  username: `required|string|minLength:${AppConstants.DEFAULT_USERNAME_MINLEN}`,
+  password: `required|string|minLength:${AppConstants.DEFAULT_PASSWORD_MINLEN}`,
 };

--- a/src/exceptions/job.exceptions.ts
+++ b/src/exceptions/job.exceptions.ts
@@ -1,5 +1,5 @@
 export class JobValidationException extends Error {
-  constructor(message, taskId) {
+  constructor(message: string, taskId: string) {
     super(message);
     this.name = `JobValidationError [${taskId || "anonymous"}]`;
   }

--- a/src/exceptions/runtime.exceptions.ts
+++ b/src/exceptions/runtime.exceptions.ts
@@ -6,9 +6,11 @@ export class NotImplementedException extends Error {
 }
 
 export class AuthenticationError extends Error {
-  constructor(error?: string) {
+  reasonCode: string;
+  constructor(error?: string, reasonCode = "") {
     super(error);
     this.name = AuthenticationError.name;
+    this.reasonCode = reasonCode;
   }
 }
 
@@ -16,13 +18,6 @@ export class ForbiddenError extends Error {
   constructor(error?: string) {
     super(error);
     this.name = ForbiddenError.name;
-  }
-}
-
-export class PasswordChangeRequiredError extends Error {
-  constructor() {
-    super("Password change required");
-    this.name = PasswordChangeRequiredError.name;
   }
 }
 

--- a/src/middleware/authenticate.ts
+++ b/src/middleware/authenticate.ts
@@ -41,7 +41,7 @@ export const authenticate = () =>
       return next();
     }
 
-    throw new AuthenticationError("Not authenticated", AUTH_ERROR_REASON.LoginRequired);
+    throw new AuthenticationError("Not authenticated", AUTH_ERROR_REASON.InvalidOrExpiredAuthToken);
   });
 export const authorizeRoles = (roles: string[], subset = true) =>
   inject(({ roleService }) => async (req: Request, res: Response, next: NextFunction) => {

--- a/src/middleware/authenticate.ts
+++ b/src/middleware/authenticate.ts
@@ -1,5 +1,5 @@
 import { inject } from "awilix-express";
-import { AuthenticationError, AuthorizationError, PasswordChangeRequiredError } from "@/exceptions/runtime.exceptions";
+import { AuthenticationError, AuthorizationError } from "@/exceptions/runtime.exceptions";
 import { NextFunction, Request, Response } from "express";
 import { AUTH_ERROR_REASON } from "@/constants/authorization.constants";
 

--- a/src/middleware/authenticate.ts
+++ b/src/middleware/authenticate.ts
@@ -1,6 +1,7 @@
 import { inject } from "awilix-express";
 import { AuthenticationError, AuthorizationError, PasswordChangeRequiredError } from "@/exceptions/runtime.exceptions";
 import { NextFunction, Request, Response } from "express";
+import { AUTH_ERROR_REASON } from "@/constants/authorization.constants";
 
 export function authorizePermission(permission: string) {
   return inject(({ permissionService, roleService }) => async (req: Request, res: Response, next: NextFunction) => {
@@ -26,21 +27,21 @@ export const authenticate = () =>
 
     // Check if a password change is required
     if (req.user?.needsPasswordChange) {
-      throw new PasswordChangeRequiredError();
+      throw new AuthenticationError("Password change required", AUTH_ERROR_REASON.PasswordChangeRequired);
     }
 
     // Check if a logout was called
     const bearer = req.headers.authorization?.replace("Bearer ", "") || undefined;
     const isJwtBlacklisted = authService.isJwtTokenBlacklisted(bearer);
     if (!!bearer?.length && isJwtBlacklisted) {
-      throw new AuthenticationError("Not authenticated");
+      throw new AuthenticationError("Not authenticated", AUTH_ERROR_REASON.LoginRequired);
     }
 
     if (req.isAuthenticated()) {
       return next();
     }
 
-    throw new AuthenticationError("Not authenticated");
+    throw new AuthenticationError("Not authenticated", AUTH_ERROR_REASON.LoginRequired);
   });
 export const authorizeRoles = (roles: string[], subset = true) =>
   inject(({ roleService }) => async (req: Request, res: Response, next: NextFunction) => {

--- a/src/middleware/authenticate.ts
+++ b/src/middleware/authenticate.ts
@@ -2,6 +2,9 @@ import { inject } from "awilix-express";
 import { AuthenticationError, AuthorizationError } from "@/exceptions/runtime.exceptions";
 import { NextFunction, Request, Response } from "express";
 import { AUTH_ERROR_REASON } from "@/constants/authorization.constants";
+import { SettingsStore } from "@/state/settings.store";
+import { AuthService } from "@/services/authentication/auth.service";
+import { ILoggerFactory } from "@/handlers/logger-factory";
 
 export function authorizePermission(permission: string) {
   return inject(({ permissionService, roleService }) => async (req: Request, res: Response, next: NextFunction) => {
@@ -19,30 +22,43 @@ export function authorizePermission(permission: string) {
 }
 
 export const authenticate = () =>
-  inject(({ settingsStore, authService }) => async (req: Request, res: Response, next: NextFunction) => {
-    const isLoginRequired = await settingsStore.getLoginRequired();
-    if (!isLoginRequired) {
-      return next();
-    }
+  inject(
+    ({
+        settingsStore,
+        authService,
+        loggerFactory,
+      }: {
+        settingsStore: SettingsStore;
+        authService: AuthService;
+        loggerFactory: ILoggerFactory;
+      }) =>
+      async (req: Request, res: Response, next: NextFunction) => {
+        const logger = loggerFactory("Middleware:authenticate");
+        const isLoginRequired = await settingsStore.getLoginRequired();
+        if (!isLoginRequired) {
+          return next();
+        }
 
-    // Check if a password change is required
-    if (req.user?.needsPasswordChange) {
-      throw new AuthenticationError("Password change required", AUTH_ERROR_REASON.PasswordChangeRequired);
-    }
+        // Check if a password change is required
+        if (req.user?.needsPasswordChange) {
+          throw new AuthenticationError("Password change required", AUTH_ERROR_REASON.PasswordChangeRequired);
+        }
 
-    // Check if a logout was called
-    const bearer = req.headers.authorization?.replace("Bearer ", "") || undefined;
-    const isJwtBlacklisted = authService.isJwtTokenBlacklisted(bearer);
-    if (!!bearer?.length && isJwtBlacklisted) {
-      throw new AuthenticationError("Not authenticated", AUTH_ERROR_REASON.LoginRequired);
-    }
+        // Check if a logout was called
+        const bearer = req.headers.authorization?.replace("Bearer ", "") || undefined;
+        const isJwtBlacklisted = authService.isJwtTokenBlacklisted(bearer);
+        if (!!bearer?.length && isJwtBlacklisted) {
+          throw new AuthenticationError("Not authenticated", AUTH_ERROR_REASON.LoginRequired);
+        }
 
-    if (req.isAuthenticated()) {
-      return next();
-    }
+        if (req.isAuthenticated()) {
+          return next();
+        }
 
-    throw new AuthenticationError("Not authenticated", AUTH_ERROR_REASON.InvalidOrExpiredAuthToken);
-  });
+        logger.log(`Not authenticated for route: ${req.originalUrl}`);
+        throw new AuthenticationError("Not authenticated", AUTH_ERROR_REASON.InvalidOrExpiredAuthToken);
+      }
+  );
 export const authorizeRoles = (roles: string[], subset = true) =>
   inject(({ roleService }) => async (req: Request, res: Response, next: NextFunction) => {
     if (!roleService.authorizeRoles(roles, req.roles, subset)) {

--- a/src/middleware/exception.filter.ts
+++ b/src/middleware/exception.filter.ts
@@ -6,14 +6,14 @@ import {
   ForbiddenError,
   InternalServerException,
   NotFoundException,
-  PasswordChangeRequiredError,
   ValidationException,
 } from "@/exceptions/runtime.exceptions";
 import { AppConstants } from "@/server.constants";
 import { NextFunction, Request, Response } from "express";
 import { HttpStatusCode } from "@/constants/http-status-codes.constants";
+import { AxiosError } from "axios";
 
-export function exceptionHandler(err, req: Request, res: Response, next: NextFunction) {
+export function exceptionFilter(err: any | AxiosError, req: Request, res: Response, next: NextFunction) {
   const isTest = process.env.NODE_ENV === AppConstants.defaultTestEnv;
   if (!isTest) {
     console.error("[API Exception Handler]", err.stack || err?.response?.data);
@@ -28,7 +28,7 @@ export function exceptionHandler(err, req: Request, res: Response, next: NextFun
   }
   if (err instanceof AuthenticationError) {
     const code = err.statusCode || 401;
-    return res.status(code).send({ error: err.message });
+    return res.status(code).send({ error: err.message, reasonCode: err.reasonCode });
   }
   if (err instanceof AuthorizationError) {
     const code = err.statusCode || HttpStatusCode.FORBIDDEN;
@@ -40,10 +40,6 @@ export function exceptionHandler(err, req: Request, res: Response, next: NextFun
   }
   if (err instanceof ForbiddenError) {
     const code = err.statusCode || HttpStatusCode.FORBIDDEN;
-    return res.status(code).send({ error: err.message });
-  }
-  if (err instanceof PasswordChangeRequiredError) {
-    const code = err.statusCode || HttpStatusCode.CONFLICT;
     return res.status(code).send({ error: err.message });
   }
   if (err instanceof NotFoundException) {

--- a/src/middleware/passport.ts
+++ b/src/middleware/passport.ts
@@ -35,7 +35,7 @@ export function verifyUserCallback(userService: IUserService) {
     userService
       .getUser(jwt_payload.userId)
       .then((user: IUser) => {
-        if (user) {
+        if (user && user.isVerified && !user.needsPasswordChange) {
           return done(null, user);
         } else {
           return done(null, false);

--- a/src/middleware/passport.ts
+++ b/src/middleware/passport.ts
@@ -9,6 +9,8 @@ import { ConfigService } from "@/services/core/config.service";
 import { IUser } from "@/models/Auth/User";
 import { IUserService } from "@/services/interfaces/user-service.interface";
 import { Socket } from "socket.io";
+import { AuthenticationError } from "@/exceptions/runtime.exceptions";
+import { AUTH_ERROR_REASON } from "@/constants/authorization.constants";
 
 export interface JwtFromSocketFunction {
   (socket: Socket): string | null;
@@ -37,9 +39,17 @@ export function verifyUserCallback(userService: IUserService) {
       .then((user: IUser) => {
         if (user && user.isVerified && !user.needsPasswordChange) {
           return done(null, user);
-        } else {
-          return done(null, false);
         }
+        if (user && user.needsPasswordChange) {
+          console.log("Needs password change");
+          return done(new AuthenticationError("Password change required", AUTH_ERROR_REASON.PasswordChangeRequired), false);
+        }
+        if (user && !user?.isVerified) {
+          console.log("Needs password change");
+          return done(new AuthenticationError("User not verified", AUTH_ERROR_REASON.AccountNotVerified), false);
+        }
+
+        return done(null, false);
       })
       .catch((err) => {
         if (err) {

--- a/src/server.constants.ts
+++ b/src/server.constants.ts
@@ -29,6 +29,8 @@ export const AppConstants = {
   // Boolean string (true/false), persisted always
   OVERRIDE_REGISTRATION_ENABLED: "OVERRIDE_REGISTRATION_ENABLED",
   // Number
+  DEFAULT_USERNAME_MINLEN: 3,
+  // Number
   DEFAULT_PASSWORD_MINLEN: 8,
   // String, persisted always
   OVERRIDE_JWT_SECRET: "OVERRIDE_JWT_SECRET",

--- a/src/server.host.ts
+++ b/src/server.host.ts
@@ -4,7 +4,7 @@ import history from "connect-history-api-fallback";
 import { LoggerService } from "./handlers/logger";
 import { loadControllers } from "awilix-express";
 import { join } from "path";
-import { exceptionHandler } from "./middleware/exception.handler";
+import { exceptionFilter } from "./middleware/exception.filter";
 import { fetchServerPort } from "./server.env";
 import { NotFoundException } from "./exceptions/runtime.exceptions";
 import { AppConstants } from "./server.constants";
@@ -75,7 +75,7 @@ export class ServerHost {
         }
       })
       .use(loadControllers(`${routePath}/*.controller.*`, { cwd: __dirname, ignore: "**/*.map" }))
-      .use(exceptionHandler);
+      .use(exceptionFilter);
 
     // Serve the files for our frontend - do this later than the controllers
     const bundleDistPath = join(superRootPath(), AppConstants.defaultClientBundleStorage, "dist");
@@ -101,7 +101,7 @@ export class ServerHost {
           throw new NotFoundException(`${resource} resource was not found`, path);
         }
       })
-      .use(exceptionHandler);
+      .use(exceptionFilter);
   }
 
   async httpListen() {

--- a/src/services/authentication/refresh-token.service.ts
+++ b/src/services/authentication/refresh-token.service.ts
@@ -8,6 +8,7 @@ import { MongoIdType } from "@/shared.constants";
 import { IRefreshToken } from "@/models/Auth/RefreshToken";
 import { AuthenticationError } from "@/exceptions/runtime.exceptions";
 import { IRefreshTokenService } from "@/services/interfaces/refresh-token.service.interface";
+import { AUTH_ERROR_REASON } from "@/constants/authorization.constants";
 
 export class RefreshTokenService implements IRefreshTokenService<MongoIdType> {
   private settingsStore: SettingsStore;
@@ -24,7 +25,7 @@ export class RefreshTokenService implements IRefreshTokenService<MongoIdType> {
     });
     if (!userRefreshToken) {
       if (throwNotFoundError) {
-        throw new AuthenticationError("The refresh token was not found");
+        throw new AuthenticationError("The refresh token was not found", AUTH_ERROR_REASON.InvalidOrExpiredRefreshToken);
       }
       return null;
     }

--- a/src/services/authentication/user.service.ts
+++ b/src/services/authentication/user.service.ts
@@ -60,9 +60,9 @@ export class UserService implements IUserService<MongoIdType> {
     });
   }
 
-  async getUser(userId: MongoIdType): Promise<IUser> {
+  async getUser(userId: MongoIdType, throwNotFoundError: boolean = true): Promise<IUser> {
     const user = await User.findById(userId);
-    if (!user) throw new NotFoundException("User not found");
+    if (!user && throwNotFoundError) throw new NotFoundException("User not found");
 
     return user;
   }

--- a/src/services/authentication/user.service.ts
+++ b/src/services/authentication/user.service.ts
@@ -87,6 +87,10 @@ export class UserService implements IUserService<MongoIdType> {
     // Validate
     const user = await this.getUser(userId);
 
+    if (user.isRootUser) {
+      throw new InternalServerException("Cannot delete a root user.");
+    }
+
     // Check if the user is the last admin
     const role = this.roleService.getRoleByName(ROLES.ADMIN);
     if (user.roles.includes(role.id)) {

--- a/src/services/interfaces/user-service.interface.ts
+++ b/src/services/interfaces/user-service.interface.ts
@@ -20,7 +20,7 @@ export interface IUserService<KeyType = IdType, Entity = IUser> {
 
   findRawByUsername(username: string): Promise<Entity>;
 
-  getUser(userId: KeyType): Promise<Entity>;
+  getUser(userId: KeyType, throwNotFoundError?: boolean): Promise<Entity>;
 
   getUserRoleIds(userId: KeyType): Promise<KeyType[]>;
 

--- a/src/services/interfaces/user-service.interface.ts
+++ b/src/services/interfaces/user-service.interface.ts
@@ -1,4 +1,4 @@
-import { IdType, MongoIdType, SqliteIdType } from "@/shared.constants";
+import { IdType } from "@/shared.constants";
 import { IUser } from "@/models/Auth/User";
 import { RegisterUserDto, UserDto } from "@/services/interfaces/user.dto";
 import { DeleteResult } from "typeorm";
@@ -8,7 +8,13 @@ export interface IUserService<KeyType = IdType, Entity = IUser> {
 
   listUsers(limit?: number): Promise<Entity[]>;
 
-  findUserByRoleId(roleId: KeyType): Promise<Entity[]>;
+  findUsersByRoleId(roleId: KeyType): Promise<Entity[]>;
+
+  findVerifiedUsers(): Promise<Entity[]>;
+
+  isUserRootUser(userId: KeyType): Promise<boolean>;
+
+  findRootUsers(): Promise<Entity[]>;
 
   getDemoUserId(): Promise<KeyType>;
 

--- a/src/services/validators/user-service.validation.ts
+++ b/src/services/validators/user-service.validation.ts
@@ -1,7 +1,7 @@
 import { AppConstants } from "@/server.constants";
 
 export const registerUserRules = {
-  username: "required|string",
+  username: `required|string|minLength:${AppConstants.DEFAULT_USERNAME_MINLEN}`,
   password: `required|string|minLength:${AppConstants.DEFAULT_PASSWORD_MINLEN}`,
   needsPasswordChange: "boolean",
   roles: "required|array",

--- a/src/state/settings.store.ts
+++ b/src/state/settings.store.ts
@@ -23,8 +23,8 @@ import {
 import { ILoggerFactory } from "@/handlers/logger-factory";
 
 export class SettingsStore {
-  settingsService: ISettingsService;
-  logger: LoggerService;
+  private settingsService: ISettingsService;
+  private logger: LoggerService;
   private settings: ISettings | null = null;
 
   constructor({ settingsService, loggerFactory }: { settingsService: ISettingsService; loggerFactory: ILoggerFactory }) {

--- a/src/tasks/boot.task.ts
+++ b/src/tasks/boot.task.ts
@@ -185,14 +185,14 @@ export class BootTask {
         password: demoPassword,
         isDemoUser: true,
         isVerified: true,
-        isRootUser: true,
+        isRootUser: false,
         needsPasswordChange: false,
         roles: [adminRole.id],
       });
       this.logger.log("Created demo account");
     } else {
       await this.userService.setVerifiedById(demoUserId, true);
-      await this.userService.setIsRootUserById(demoUserId, true);
+      await this.userService.setIsRootUserById(demoUserId, false);
       await this.userService.updatePasswordUnsafeByUsername(demoUsername, demoPassword);
       await this.userService.setUserRoleIds(demoUserId, [adminRole.id]);
       this.logger.log("Updated demo account");

--- a/test/api/auth-controller.test.ts
+++ b/test/api/auth-controller.test.ts
@@ -151,6 +151,7 @@ describe(AuthController.name, () => {
     expect(response.body.loginRequired).toBe(true);
     expect(response.body.wizardState.wizardCompleted).toBe(true);
     expect(response.body.registration).toBe(true);
+    expect(response.body.isDemoMode).toBe(false);
   });
 
   it("should get verifyLogin", async () => {

--- a/test/api/first-time-setup.controller.test.ts
+++ b/test/api/first-time-setup.controller.test.ts
@@ -7,7 +7,7 @@ import { AppConstants } from "@/server.constants";
 import { AwilixContainer } from "awilix";
 import { DITokens } from "@/container.tokens";
 import { SettingsStore } from "@/state/settings.store";
-import { expectOkResponse, expectUnauthorizedResponse } from "../extensions";
+import { expectForbiddenResponse, expectOkResponse, expectUnauthorizedResponse } from "../extensions";
 import { IUserService } from "@/services/interfaces/user-service.interface";
 import { ISettingsService } from "@/services/interfaces/settings.service.interface";
 
@@ -72,6 +72,6 @@ describe(FirstTimeSetupController.name, () => {
       rootUsername: "test",
       rootPassword: "testtest",
     });
-    expectUnauthorizedResponse(response2);
+    expectForbiddenResponse(response2);
   });
 });

--- a/test/api/test-data/create-user.ts
+++ b/test/api/test-data/create-user.ts
@@ -16,7 +16,8 @@ export async function ensureTestUserCreated(
   passwordIn = "test",
   needsPasswordChange = false,
   role = ROLES.ADMIN,
-  isVerified = true
+  isVerified = true,
+  isRootUser = true
 ) {
   const roleId = (await Role.findOne({ name: role }))?.id;
   const roles = roleId ? [roleId.toString()] : [];
@@ -26,11 +27,11 @@ export async function ensureTestUserCreated(
   const hash = hashPassword(password);
 
   if (foundUser) {
-    await User.updateOne({ _id: foundUser.id }, { passwordHash: hash, needsPasswordChange, roles, isVerified });
+    await User.updateOne({ _id: foundUser.id }, { passwordHash: hash, needsPasswordChange, roles, isVerified, isRootUser });
     return {
       id: foundUser.id,
       isVerified,
-      isRootUser: role === ROLES.ADMIN,
+      isRootUser,
       isDemoUser: foundUser.isDemoUser,
       username: foundUser.username,
       needsPasswordChange: foundUser.needsPasswordChange,
@@ -43,7 +44,7 @@ export async function ensureTestUserCreated(
     passwordHash: hash,
     roles,
     isDemoUser: false,
-    isRootUser: role === ROLES.ADMIN,
+    isRootUser,
     isVerified,
     needsPasswordChange,
   });
@@ -52,7 +53,7 @@ export async function ensureTestUserCreated(
     id: user.id,
     username: user.username,
     isDemoUser: false,
-    isRootUser: role === ROLES.ADMIN,
+    isRootUser,
     isVerified,
     needsPasswordChange: user.needsPasswordChange,
     roles: user.roles,

--- a/test/api/user-controller.test.ts
+++ b/test/api/user-controller.test.ts
@@ -28,6 +28,9 @@ let container: AwilixContainer;
 beforeAll(async () => {
   await connect();
   ({ request, container } = await setupTestApp(true));
+});
+
+beforeEach(async () => {
   await container.resolve<SettingsStore>(DITokens.settingsStore).setLoginRequired(false);
 });
 

--- a/test/application/user-service.test.ts
+++ b/test/application/user-service.test.ts
@@ -35,7 +35,7 @@ describe(UserService.name, () => {
   it("should find no user by role id ", async () => {
     await roleService.syncRoles();
     const role = roleService.getRoleByName(ROLES.ADMIN);
-    const result = await userService.findUserByRoleId(role.id);
+    const result = await userService.findUsersByRoleId(role.id);
     expect(result?.length).toBeFalsy();
   });
 

--- a/test/extensions.ts
+++ b/test/extensions.ts
@@ -58,6 +58,11 @@ export function expectUnauthenticatedResponse(response: Response) {
 
 export function expectUnauthorizedResponse(response: Response) {
   expect(response.statusCode).toEqual(403);
+  expect(response.body.roles).toBeDefined();
+}
+
+export function expectForbiddenResponse(response: Response) {
+  expect(response.statusCode).toEqual(403);
 }
 
 export function expectInvalidResponse(response: Response, keys?: string[], exact = false) {

--- a/test/setup-global.ts
+++ b/test/setup-global.ts
@@ -3,4 +3,5 @@ module.exports = async () => {
   process.env.TZ = "UTC";
   process.env[AppConstants.VERSION_KEY] = "1.0.0";
   process.env[AppConstants.ENABLE_EXPERIMENTAL_WHITELIST_SETTINGS] = "true";
+  process.env[AppConstants.OVERRIDE_IS_DEMO_MODE] = "false";
 };


### PR DESCRIPTION
# Description

- Implements auth codes that the UI can handle
- Dont let socket throw auth error as those are external issues
- Fix: missing refresh token should result in 401 not 404
- Refresh token attempts were not audited when refresh limit is not set (===-1)