### PR TITLE
fix: nightly develop docker build, drop run build number

### DIFF
--- a/.github/workflows/docker_quick_build.yml
+++ b/.github/workflows/docker_quick_build.yml
@@ -2,6 +2,9 @@ name: Docker
 on:
   pull_request:
   workflow_dispatch:
+  # Runs from default branch, which is develop
+  schedule:
+    - cron: '0 0 * * *'
 jobs:
   meta:
     runs-on: ubuntu-latest
@@ -23,6 +26,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       # Login to DockerHub with environment variables
       - name: Login to DockerHub
         uses: docker/login-action@v3
@@ -46,11 +50,10 @@ jobs:
         uses: HackerHappyHour/tagging-strategy@v3
         with:
           image_name: davidzwa/fdm-monster
-          tag_name: ${{ env.SERVER_VERSION }}-${{ github.run_number }}
+          tag_name: ${{ env.SERVER_VERSION }}-develop
           tags: |
             %X.Y.Z%
           extra_tags: |
-            main::${{ github.ref == 'refs/heads/main' || github.event.pull_request.base.ref == 'main' }}
             develop::${{ github.ref == 'refs/heads/develop' || github.event.pull_request.base.ref == 'develop' }}
 
       # Show docker tags to be (conditionally) pushed


### PR DESCRIPTION
# Description

1) The github run build number was leaving behind too many tags on the docker.io CR. Instead I've decided for a develop suffix.
2) The GHA workflow will run at night.