### PR TITLE
fix: improve files store consistency

### DIFF
--- a/src/container.tokens.ts
+++ b/src/container.tokens.ts
@@ -54,8 +54,7 @@ export const DITokens = {
   printerEventsCache: "printerEventsCache",
   printerSocketStore: "printerSocketStore",
   testPrinterSocketStore: "testPrinterSocketStore",
-  octoPrintLogsCache: "printerTickerStore",
-  filesStore: "filesStore",
+  printerFilesStore: "printerFilesStore",
   octoPrintSockIoAdapter: "octoPrintSockIoAdapter",
   // Caches
   floorStore: "floorStore",

--- a/src/container.ts
+++ b/src/container.ts
@@ -16,7 +16,7 @@ import { PrinterWebsocketTask } from "./tasks/printer-websocket.task";
 import { SocketIoTask } from "./tasks/socketio.task";
 import { OctoPrintApiService } from "./services/octoprint/octoprint-api.service";
 import { SocketFactory } from "./services/octoprint/socket.factory";
-import { FilesStore } from "./state/files.store";
+import { PrinterFilesStore } from "./state/printer-files.store";
 import { configureEventEmitter } from "./handlers/event-emitter";
 import { AppConstants } from "./server.constants";
 import { PrinterFilesService } from "./services/printer-files.service";
@@ -136,7 +136,7 @@ export function configureContainer() {
 
     [di.fileCache]: asClass(FileCache).singleton(),
     [di.fileUploadTrackerCache]: asClass(FileUploadTrackerCache).singleton(),
-    [di.filesStore]: asClass(FilesStore).singleton(),
+    [di.printerFilesStore]: asClass(PrinterFilesStore).singleton(),
     [di.printerCache]: asClass(PrinterCache).singleton(),
     [di.printerEventsCache]: asClass(PrinterEventsCache).singleton(),
     [di.printerSocketStore]: asClass(PrinterSocketStore).singleton(),

--- a/src/controllers/printer-files.controller.ts
+++ b/src/controllers/printer-files.controller.ts
@@ -1,4 +1,3 @@
-import fs from "fs";
 import { createController } from "awilix-express";
 import { authenticate, authorizeRoles, withPermission } from "@/middleware/authenticate";
 import { getScopedPrinter, validateInput, validateMiddleware } from "@/handlers/validators";
@@ -8,16 +7,15 @@ import {
   fileUploadCommandsRules,
   getFileRules,
   getFilesRules,
-  localFileUploadRules,
   moveFileOrFolderRules,
   selectAndPrintFileRules,
   uploadFileRules,
 } from "./validation/printer-files-controller.validation";
 import { batchPrinterRules } from "@/controllers/validation/batch-controller.validation";
-import { NotFoundException, ValidationException } from "@/exceptions/runtime.exceptions";
+import { ValidationException } from "@/exceptions/runtime.exceptions";
 import { printerResolveMiddleware } from "@/middleware/printer";
 import { PERMS, ROLES } from "@/constants/authorization.constants";
-import { FilesStore } from "@/state/files.store";
+import { PrinterFilesStore } from "@/state/printer-files.store";
 import { SettingsStore } from "@/state/settings.store";
 import { OctoPrintApiService } from "@/services/octoprint/octoprint-api.service";
 import { BatchCallService } from "@/services/batch-call.service";
@@ -29,7 +27,7 @@ import { Request, Response } from "express";
 import { AxiosResponse } from "axios";
 
 export class PrinterFilesController {
-  filesStore: FilesStore;
+  printerFilesStore: PrinterFilesStore;
   settingsStore: SettingsStore;
   octoPrintApiService: OctoPrintApiService;
   batchCallService: BatchCallService;
@@ -39,7 +37,7 @@ export class PrinterFilesController {
   isTypeormMode: boolean;
 
   constructor({
-    filesStore,
+    printerFilesStore,
     octoPrintApiService,
     batchCallService,
     printerFileCleanTask,
@@ -48,7 +46,7 @@ export class PrinterFilesController {
     multerService,
     isTypeormMode,
   }: {
-    filesStore: FilesStore;
+    printerFilesStore: PrinterFilesStore;
     octoPrintApiService: OctoPrintApiService;
     batchCallService: BatchCallService;
     printerFileCleanTask: PrinterFileCleanTask;
@@ -57,7 +55,7 @@ export class PrinterFilesController {
     multerService: MulterService;
     isTypeormMode: boolean;
   }) {
-    this.filesStore = filesStore;
+    this.printerFilesStore = printerFilesStore;
     this.settingsStore = settingsStore;
     this.printerFileCleanTask = printerFileCleanTask;
     this.octoPrintApiService = octoPrintApiService;
@@ -77,7 +75,7 @@ export class PrinterFilesController {
     const { recursive } = await validateInput(req.query, getFilesRules);
 
     this.logger.log("Refreshing file storage by eager load");
-    const response = await this.filesStore.eagerLoadPrinterFiles(currentPrinterId, recursive);
+    const response = await this.printerFilesStore.eagerLoadPrinterFiles(currentPrinterId, recursive);
     this.statusResponse(res, response);
   }
 
@@ -87,7 +85,7 @@ export class PrinterFilesController {
   async getFilesCache(req: Request, res: Response) {
     const { currentPrinter } = getScopedPrinter(req);
 
-    const filesCache = await this.filesStore.getFiles(currentPrinter.id);
+    const filesCache = await this.printerFilesStore.getFiles(currentPrinter.id);
     res.send(filesCache);
   }
 
@@ -108,7 +106,7 @@ export class PrinterFilesController {
       }
     }
 
-    await this.filesStore.purgePrinterFiles(currentPrinterId);
+    await this.printerFilesStore.purgePrinterFiles(currentPrinterId);
 
     res.send({
       failedFiles,
@@ -117,7 +115,7 @@ export class PrinterFilesController {
   }
 
   async purgeIndexedFiles(req: Request, res: Response) {
-    await this.filesStore.purgeFiles();
+    await this.printerFilesStore.purgeFiles();
 
     res.send();
   }
@@ -150,7 +148,7 @@ export class PrinterFilesController {
 
     const result = await this.octoPrintApiService.deleteFileOrFolder(printerLogin, path);
 
-    await this.filesStore.deleteFile(currentPrinterId, path, false);
+    await this.printerFilesStore.deleteFile(currentPrinterId, path, false);
     this.logger.log(`File reference removed, printerId ${currentPrinterId}`, path);
 
     res.send(result);
@@ -171,7 +169,7 @@ export class PrinterFilesController {
 
     const result = await this.octoPrintApiService.selectPrintFile(printerLogin, path, print);
 
-    await this.filesStore.setExistingFileForPrint(currentPrinterId, path);
+    await this.printerFilesStore.setExistingFileForPrint(currentPrinterId, path);
     res.send(result);
   }
 
@@ -215,7 +213,7 @@ export class PrinterFilesController {
 
     if (response.success !== false) {
       const newOrUpdatedFile = response.files.local;
-      await this.filesStore.appendOrSetPrinterFile(currentPrinterId, newOrUpdatedFile);
+      await this.printerFilesStore.appendOrSetPrinterFile(currentPrinterId, newOrUpdatedFile);
     }
 
     res.send(response);

--- a/src/services/batch-call.service.ts
+++ b/src/services/batch-call.service.ts
@@ -1,4 +1,9 @@
-import { IdType } from "@/shared.constants";
+import { PrinterFilesStore } from "@/state/printer-files.store";
+import { OctoPrintApiService } from "@/services/octoprint/octoprint-api.service";
+import { PrinterSocketStore } from "@/state/printer-socket.store";
+import { PrinterCache } from "@/state/printer.cache";
+import { PrinterEventsCache } from "@/state/printer-events.cache";
+import { IPrinterService } from "@/services/interfaces/printer.service.interface";
 
 interface BatchSingletonModel {
   success?: boolean;
@@ -8,14 +13,6 @@ interface BatchSingletonModel {
   error?: string;
 }
 
-import { FilesStore } from "@/state/files.store";
-import { PrinterService } from "@/services/printer.service";
-import { OctoPrintApiService } from "@/services/octoprint/octoprint-api.service";
-import { PrinterSocketStore } from "@/state/printer-socket.store";
-import { PrinterCache } from "@/state/printer.cache";
-import { PrinterEventsCache } from "@/state/printer-events.cache";
-import { IPrinterService } from "@/services/interfaces/printer.service.interface";
-
 type BatchModel = Array<BatchSingletonModel>;
 
 export class BatchCallService {
@@ -23,7 +20,7 @@ export class BatchCallService {
   printerSocketStore: PrinterSocketStore;
   printerCache: PrinterCache;
   printerEventsCache: PrinterEventsCache;
-  filesStore: FilesStore;
+  printerFilesStore: PrinterFilesStore;
   printerService: IPrinterService;
 
   constructor({
@@ -31,21 +28,21 @@ export class BatchCallService {
     printerCache,
     printerEventsCache,
     printerSocketStore,
-    filesStore,
+    printerFilesStore,
     printerService,
   }: {
     octoPrintApiService: OctoPrintApiService;
     printerCache: PrinterCache;
     printerEventsCache: PrinterEventsCache;
     printerSocketStore: PrinterSocketStore;
-    filesStore: FilesStore;
+    printerFilesStore: PrinterFilesStore;
     printerService: IPrinterService;
   }) {
     this.octoPrintApiService = octoPrintApiService;
     this.printerCache = printerCache;
     this.printerEventsCache = printerEventsCache;
     this.printerSocketStore = printerSocketStore;
-    this.filesStore = filesStore;
+    this.printerFilesStore = printerFilesStore;
     this.printerService = printerService;
   }
 
@@ -123,7 +120,7 @@ export class BatchCallService {
       // TODO test this
       let reprintPath = await this.printerEventsCache.getPrinterSocketEvents(printerId)?.current?.job?.file?.path;
       if (!reprintPath?.length) {
-        const files = await this.filesStore.getFiles(printerId)?.files;
+        const files = await this.printerFilesStore.getFiles(printerId)?.files;
         if (files?.length) {
           files.sort((f1, f2) => {
             // Sort by date, newest first

--- a/src/state/printer-files.store.ts
+++ b/src/state/printer-files.store.ts
@@ -1,6 +1,5 @@
 import { ValidationException } from "@/exceptions/runtime.exceptions";
 import { PrinterCache } from "@/state/printer.cache";
-import { PrinterFilesService } from "@/services/printer-files.service";
 import { FileCache } from "@/state/file.cache";
 import { OctoPrintApiService } from "@/services/octoprint/octoprint-api.service";
 import { LoggerService } from "@/handlers/logger";
@@ -8,10 +7,7 @@ import { IdType } from "@/shared.constants";
 import { ILoggerFactory } from "@/handlers/logger-factory";
 import { IPrinterFilesService } from "@/services/interfaces/printer-files.service.interface";
 
-/**
- * Generic store for synchronisation of files and storage information of printers.
- */
-export class FilesStore {
+export class PrinterFilesStore {
   printerCache: PrinterCache;
   printerFilesService: IPrinterFilesService;
   fileCache: FileCache;
@@ -36,7 +32,7 @@ export class FilesStore {
     this.fileCache = fileCache;
     this.octoPrintApiService = octoPrintApiService;
 
-    this.logger = loggerFactory(FilesStore.name);
+    this.logger = loggerFactory(PrinterFilesStore.name);
   }
 
   /**
@@ -167,13 +163,12 @@ export class FilesStore {
     filePath: string,
     throwError: boolean
   ): Promise<{
-    cache: (any & { success: boolean; message?: string }) | (any & { success: boolean; message?: string });
     service: any;
   }> {
     const serviceActionResult = await this.printerFilesService.deleteFile(printerId, filePath, throwError);
 
     // Warning only
-    const cacheActionResult = this.fileCache.purgeFile(printerId, filePath);
-    return { service: serviceActionResult, cache: cacheActionResult };
+    this.fileCache.purgeFile(printerId, filePath);
+    return { service: serviceActionResult };
   }
 }

--- a/src/state/printer-files.store.ts
+++ b/src/state/printer-files.store.ts
@@ -83,7 +83,7 @@ export class PrinterFilesStore {
 
     const nonRecursiveFiles = this.getOutdatedFiles(printerId, ageDaysMax);
     const printerLogin = await this.printerCache.getLoginDtoAsync(printerId);
-    const name = await this.printerCache.getCachedPrinterOrThrowAsync(printerId).name;
+    const name = (await this.printerCache.getCachedPrinterOrThrowAsync(printerId)).name;
 
     for (let file of nonRecursiveFiles) {
       try {
@@ -155,9 +155,6 @@ export class PrinterFilesStore {
     await this.printerFilesService.setPrinterLastPrintedFile(printerId, filePath);
   }
 
-  /**
-   * Remove file reference from database and then cache.
-   */
   async deleteFile(
     printerId: IdType,
     filePath: string,

--- a/src/tasks/boot.task.ts
+++ b/src/tasks/boot.task.ts
@@ -11,7 +11,7 @@ import { FloorStore } from "@/state/floor.store";
 import { PluginFirmwareUpdateService } from "@/services/octoprint/plugin-firmware-update.service";
 import { ConfigService } from "@/services/core/config.service";
 import { PrinterSocketStore } from "@/state/printer-socket.store";
-import { FilesStore } from "@/state/files.store";
+import { PrinterFilesStore } from "@/state/printer-files.store";
 import { PermissionService } from "@/services/authentication/permission.service";
 import { RoleService } from "@/services/authentication/role.service";
 import { UserService } from "@/services/authentication/user.service";
@@ -28,7 +28,7 @@ export class BootTask {
   settingsService: ISettingsService;
   multerService: MulterService;
   printerSocketStore: PrinterSocketStore;
-  filesStore: FilesStore;
+  printerFilesStore: PrinterFilesStore;
   permissionService: PermissionService;
   roleService: RoleService;
   userService: UserService;
@@ -45,7 +45,7 @@ export class BootTask {
     settingsStore,
     multerService,
     printerSocketStore,
-    filesStore,
+    printerFilesStore,
     permissionService,
     roleService,
     userService,
@@ -62,7 +62,7 @@ export class BootTask {
     settingsStore: SettingsStore;
     multerService: MulterService;
     printerSocketStore: PrinterSocketStore;
-    filesStore: FilesStore;
+    printerFilesStore: PrinterFilesStore;
     permissionService: PermissionService;
     roleService: RoleService;
     userService: UserService;
@@ -79,7 +79,7 @@ export class BootTask {
     this.settingsStore = settingsStore;
     this.multerService = multerService;
     this.printerSocketStore = printerSocketStore;
-    this.filesStore = filesStore;
+    this.printerFilesStore = printerFilesStore;
     this.permissionService = permissionService;
     this.roleService = roleService;
     this.userService = userService;
@@ -156,7 +156,7 @@ export class BootTask {
     this.logger.log("Loading printer sockets");
     await this.printerSocketStore.loadPrinterSockets(); // New sockets
     this.logger.log("Loading files store");
-    await this.filesStore.loadFilesStore();
+    await this.printerFilesStore.loadFilesStore();
     this.logger.log("Loading floor store");
     await this.floorStore.loadStore();
 

--- a/test/application/store/files-store.test.ts
+++ b/test/application/store/files-store.test.ts
@@ -19,7 +19,7 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   container = configureContainer();
-  printerFilesStore = container.resolve(DITokens.filesStore);
+  printerFilesStore = container.resolve(DITokens.printerFilesStore);
   printerFilesService = container.resolve(DITokens.printerFilesService);
   printerService = container.resolve(DITokens.printerService);
   printerCache = container.resolve(DITokens.printerCache);

--- a/test/application/store/files-store.test.ts
+++ b/test/application/store/files-store.test.ts
@@ -2,13 +2,13 @@ import { configureContainer } from "@/container";
 import { DITokens } from "@/container.tokens";
 import { PrinterCache } from "@/state/printer.cache";
 import { PrinterFilesService } from "@/services/printer-files.service";
-import { FilesStore } from "@/state/files.store";
 import { AwilixContainer } from "awilix";
 import { closeDatabase, connect } from "../../db-handler";
+import { PrinterFilesStore } from "@/state/printer-files.store";
 import { PrinterService } from "@/services/printer.service";
 
 let container: AwilixContainer;
-let filesStore: FilesStore;
+let printerFilesStore: PrinterFilesStore;
 let printerFilesService: PrinterFilesService;
 let printerService: PrinterService;
 let printerCache: PrinterCache;
@@ -18,19 +18,14 @@ beforeAll(async () => {
 });
 
 beforeEach(async () => {
-  if (container) await container.dispose();
   container = configureContainer();
-  filesStore = container.resolve(DITokens.filesStore);
+  printerFilesStore = container.resolve(DITokens.filesStore);
   printerFilesService = container.resolve(DITokens.printerFilesService);
   printerService = container.resolve(DITokens.printerService);
   printerCache = container.resolve(DITokens.printerCache);
 });
 
-afterAll(async () => {
-  await closeDatabase();
-});
-
-describe(FilesStore.name, () => {
+describe(PrinterFilesStore.name, () => {
   const validNewPrinter = {
     apiKey: "asdasasdasdasdasdasdasdasdasdasd",
     printerURL: "https://asd.com:81",
@@ -40,12 +35,12 @@ describe(FilesStore.name, () => {
   it("old files - should deal with empty files cache correctly", async () => {
     await printerCache.loadCache();
     let testPrinterState = await printerService.create(validNewPrinter);
-    await filesStore.loadFilesStore();
+    await printerFilesStore.loadFilesStore();
 
-    const filesCache = filesStore.getFiles(testPrinterState.id);
+    const filesCache = printerFilesStore.getFiles(testPrinterState.id);
     expect(filesCache.files.length).toBe(0);
 
-    const oldFiles = filesStore.getOutdatedFiles(testPrinterState.id, 7);
+    const oldFiles = printerFilesStore.getOutdatedFiles(testPrinterState.id, 7);
     expect(oldFiles.length).toBe(0);
   });
 
@@ -59,12 +54,12 @@ describe(FilesStore.name, () => {
         },
       ],
     });
-    await filesStore.loadFilesStore();
+    await printerFilesStore.loadFilesStore();
 
-    const filesCache = filesStore.getFiles(testPrinterState.id);
+    const filesCache = printerFilesStore.getFiles(testPrinterState.id);
     expect(filesCache.files.length).toBe(1);
 
-    const oldFiles = filesStore.getOutdatedFiles(testPrinterState.id, 7);
+    const oldFiles = printerFilesStore.getOutdatedFiles(testPrinterState.id, 7);
     expect(oldFiles.length).toBe(0);
     await printerFilesService.updateFiles(testPrinterState.id, {
       files: [],
@@ -85,12 +80,12 @@ describe(FilesStore.name, () => {
         },
       ],
     });
-    await filesStore.loadFilesStore();
+    await printerFilesStore.loadFilesStore();
 
-    const filesCache = filesStore.getFiles(testPrinterState.id);
+    const filesCache = printerFilesStore.getFiles(testPrinterState.id);
     expect(filesCache.files.length).toBe(2);
 
-    const oldFiles = filesStore.getOutdatedFiles(testPrinterState.id, 7);
+    const oldFiles = printerFilesStore.getOutdatedFiles(testPrinterState.id, 7);
     expect(oldFiles.length).toBe(1);
   });
 });

--- a/test/application/store/printer-store.test.ts
+++ b/test/application/store/printer-store.test.ts
@@ -1,7 +1,7 @@
 import { validNewPrinterState } from "../test-data/printer.data";
 import { PrinterService } from "@/services/printer.service";
 import { PrinterCache } from "@/state/printer.cache";
-import { FilesStore } from "@/state/files.store";
+import { PrinterFilesStore } from "@/state/printer-files.store";
 import { AwilixContainer } from "awilix";
 jest.mock("../../../src/services/octoprint/octoprint-api.service");
 import { connect, closeDatabase } from "../../db-handler";
@@ -14,7 +14,7 @@ let container: AwilixContainer;
 let printerService: PrinterService;
 let printerCache: PrinterCache;
 let testPrinterSocketStore: TestPrinterSocketStore;
-let filesStore: FilesStore;
+let printerFilesStore: PrinterFilesStore;
 
 beforeAll(async () => {
   await connect();
@@ -23,7 +23,7 @@ beforeAll(async () => {
   testPrinterSocketStore = container.resolve(DITokens.testPrinterSocketStore);
   printerCache = container.resolve(DITokens.printerCache);
   printerService = container.resolve(DITokens.printerService);
-  filesStore = container.resolve(DITokens.filesStore);
+  printerFilesStore = container.resolve(DITokens.printerFilesStore);
   await printerCache.loadCache();
 });
 
@@ -34,7 +34,7 @@ afterAll(async () => {
 describe("PrinterSocketStore", () => {
   const invalidNewPrinterState = {
     apiKey: "asd",
-    printerURL: null,
+    printerURL: null as null | string,
   };
 
   const weakNewPrinter = {
@@ -72,7 +72,7 @@ describe("PrinterSocketStore", () => {
     expect(printerEntity).toBeTruthy();
 
     // Need the store in order to have files to refer to
-    await filesStore.loadFilesStore();
+    await printerFilesStore.loadFilesStore();
 
     const printerDto = await printerCache.getCachedPrinterOrThrowAsync(printerEntity.id);
     expect(printerDto).toMatchObject({

--- a/test/application/store/settings-store.test.ts
+++ b/test/application/store/settings-store.test.ts
@@ -2,17 +2,9 @@ import { closeDatabase, connect } from "../../db-handler";
 import { configureContainer } from "@/container";
 import { DITokens } from "@/container.tokens";
 import { AwilixContainer } from "awilix";
-import { FilesStore } from "@/state/files.store";
-import { PrinterFilesService } from "@/services/printer-files.service";
-import { PrinterService } from "@/services/printer.service";
-import { PrinterCache } from "@/state/printer.cache";
 import { SettingsStore } from "@/state/settings.store";
 
 let container: AwilixContainer;
-let filesStore: FilesStore;
-let printerFilesService: PrinterFilesService;
-let printerService: PrinterService;
-let printerCache: PrinterCache;
 let settingsStore: SettingsStore;
 
 beforeAll(async () => {
@@ -22,10 +14,6 @@ beforeAll(async () => {
 beforeEach(async () => {
   if (container) await container.dispose();
   container = configureContainer();
-  filesStore = container.resolve(DITokens.filesStore);
-  printerFilesService = container.resolve(DITokens.printerFilesService);
-  printerService = container.resolve(DITokens.printerService);
-  printerCache = container.resolve(DITokens.printerCache);
   settingsStore = container.resolve(DITokens.settingsStore);
 });
 


### PR DESCRIPTION
# Description

The files store implement does not scale well:
- files are often stale or non-consistent with the remote service (aka OctoPrint)
- the JSON structure is embedded in printers on MongoDB level which is not fully compatible with a future relational database 
- batch reprint often triggers old files
- the stored files are in OctoPrint dir/storage structure, does this scale with a distributed file storage like minio/azurite?
  - keep the file list unnested, remove storage free/folders etc