### PR TITLE
Update playbook-ubuntu22.yaml

### DIFF
--- a/installations/ansible/playbook-ubuntu22.yaml
+++ b/installations/ansible/playbook-ubuntu22.yaml
@@ -51,8 +51,14 @@
     - name: "Install @fdm-monster/server as pm2 module"
       shell: "{{ bash }} 'pm2 install @fdm-monster/server@{{fdmm_version}} -n fdmm'"
 
+    - name: Set NodeJS Full Version as a variable
+      command: "{{ bash }} 'nvm current'"
+      register: node_fullversion
+      ignore_errors: true
+
     - name: Set PM2 to start on reboot
-      command: "{{ bash }} 'pm2 startup {{ pm2_startup_type }} -u {{ ansible_user }} --hp /home/{{ ansible_user }}'"
+      become: yes
+      command: "{{ bash }} 'env PATH=$PATH:/home/{{ ansible_user }}/.nvm/versions/node/{{ node_fullversion.stdout }}/bin pm2 startup {{ pm2_startup_type }} -u {{ ansible_user }} --hp /home/{{ ansible_user }}'"
 
     - name: Save PM2
       command: "{{ bash }} 'pm2 save'"


### PR DESCRIPTION
Added node_fullversion variable (and dynamic filling) Corrected $PATH and pm2 startup on reboot

# Description

Please include a summary of the change and which issue is fixed.

Fixes ansible run error and no automatic pm2 startup on reboot

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Vue test
- [ ] Node test 
- [x] Ansible run
- [x] Server reboot

**Test Configuration**:
* Node version: 20.10.0
* OctoPrint version: N/A
* Nodemon/PM2/docker: pm2

# Checklist:

- [x] I checked my changes
- [x] I have commented my code concisely
- [x] I have covered my changes with tests
