### PR TITLE
feat: split out fileList from printer model for forward compatibility

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -44,3 +44,10 @@ OVERRIDE_DEMO_ROLE=ADMIN
 
 # Debug express routes
 DEBUG_ROUTES=false
+
+# Enables TypeORM
+ENABLE_EXPERIMENTAL_TYPEORM=false
+# Saves SQLite database to ./database/fdm-monster.sqlite
+DATABASE_PATH=./database
+# Optional, default: fdm-monster.sqlite
+DATABASE_FILE=fdm-monster.sqlite

--- a/docker/test.Dockerfile
+++ b/docker/test.Dockerfile
@@ -1,0 +1,24 @@
+FROM node:18-bookworm-slim as production
+WORKDIR /app
+
+RUN yarn global add pm2
+
+COPY .swcrc tsconfig.json package.json jest.config.js yarn.lock ./
+# Timeout is needed for yarn install to work on arm64 emulation (qemu)
+RUN yarn install 
+
+COPY src/ ./src/
+COPY test/ ./test/
+COPY .env.template \
+    migrate-mongo-config.js \
+    README.md \
+    LICENSE CODE_OF_CONDUCT.md \
+    CONTRIBUTING.md \
+    SECURITY.md \
+    .dockerignore ./
+
+ENV NODE_OPTIONS="--max_old_space_size=4096"
+CMD [ "yarn", "test:cov"]
+
+# docker build . -f .\docker\test.Dockerfile -t fdm-monster:test
+# docker run fdm-monster:test

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,7 @@ module.exports = {
   },
   modulePathIgnorePatterns: [
     "src/migrate-mongo-config.js",
+    "src/consoles",
     ".eslintrc.js",
     "src/assets",
     "coverage",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "console:upload": "yarn build && cross-env NODE_ENV=development node ./dist/consoles/upload-test.js",
     "dev": "concurrently \"yarn build:watch\" \"yarn watch-dev\"",
     "watch-dev": "cross-env NODE_ENV=development nodemon --watch \"dist/**/*\" -e js ./dist/index.js",
+    "console:torm": "yarn build && cross-env NODE_ENV=development nodemon --watch \"dist/**/*\" -e js ./dist/consoles/sqlite-torm.js",
+    "console:migrate": "yarn build && cross-env NODE_ENV=development nodemon --watch \"dist/**/*\" -e js ./dist/consoles/typeorm-migrate.js",
+    "console:generate": "yarn build && cross-env NODE_ENV=development node ./dist/consoles/typeorm-generate.js",
     "build": "swc src -d dist",
     "build:watch": "swc src -w -d dist",
     "start:dev": "ts-node src/index.ts",
@@ -31,7 +34,11 @@
     "tsc": "tsc --noEmit",
     "test": "jest --forceExit  --maxConcurrency=8 --runInBand ",
     "test:cov": "jest --forceExit --coverage  --maxConcurrency=8 --runInBand ",
-    "cov:show": "./coverage/lcov-report/index.html"
+    "cov:show": "./coverage/lcov-report/index.html",
+    "torm": "ts-node --swc -r tsconfig-paths/register ./node_modules/typeorm/cli.js",
+    "typeorm:generate": "yarn torm migration:generate -d src/data-source.ts --pretty src/migrations/CustomGCode",
+    "typeorm:migrate": "yarn torm migration:run -d src/data-source.ts",
+    "typeorm:revert": "yarn torm migration:revert -d src/data-source.ts"
   },
   "keywords": [
     "fdm-monster",
@@ -52,6 +59,7 @@
     "awilix-express": "8.0.0",
     "axios": "1.6.2",
     "bcryptjs": "2.4.3",
+    "better-sqlite3": "8.6.0",
     "cache-manager": "4.1.0",
     "class-validator": "0.14.0",
     "connect-history-api-fallback": "2.0.0",
@@ -83,6 +91,7 @@
     "simple-git": "3.21.0",
     "socket.io": "4.7.2",
     "toad-scheduler": "3.0.0",
+    "typeorm": "0.3.7",
     "uuid": "9.0.1",
     "winston": "3.11.0",
     "ws": "8.15.1"

--- a/src/constants/service.constants.ts
+++ b/src/constants/service.constants.ts
@@ -1,8 +1,2 @@
-export function getDefaultPrinterEntry() {
-  return {
-    fileList: [],
-  };
-}
-
 export const UUID_LENGTH = 32;
 export const minFloorNameLength = 3;

--- a/src/controllers/print-completion.controller.ts
+++ b/src/controllers/print-completion.controller.ts
@@ -5,7 +5,7 @@ import { PERMS } from "@/constants/authorization.constants";
 import { validateInput } from "@/handlers/validators";
 import { PrintCompletionSocketIoTask } from "@/tasks/print-completion.socketio.task";
 import { Request, Response } from "express";
-import { IPrintCompletionService } from "@/services/interfaces/print-completion.service";
+import { IPrintCompletionService } from "@/services/interfaces/print-completion.interface";
 
 export class PrintCompletionController {
   private printCompletionService: IPrintCompletionService;

--- a/src/controllers/printer-files.controller.ts
+++ b/src/controllers/printer-files.controller.ts
@@ -7,13 +7,12 @@ import {
   fileUploadCommandsRules,
   getFileRules,
   getFilesRules,
-  localFileUploadRules,
   moveFileOrFolderRules,
   selectAndPrintFileRules,
   uploadFileRules,
 } from "./validation/printer-files-controller.validation";
 import { batchPrinterRules } from "@/controllers/validation/batch-controller.validation";
-import { NotFoundException, ValidationException } from "@/exceptions/runtime.exceptions";
+import { ValidationException } from "@/exceptions/runtime.exceptions";
 import { printerResolveMiddleware } from "@/middleware/printer";
 import { PERMS, ROLES } from "@/constants/authorization.constants";
 import { PrinterFilesStore } from "@/state/printer-files.store";
@@ -26,6 +25,7 @@ import { LoggerService } from "@/handlers/logger";
 import { ILoggerFactory } from "@/handlers/logger-factory";
 import { Request, Response } from "express";
 import { createReadStream, existsSync, lstatSync } from "node:fs";
+import { AxiosResponse } from "axios";
 
 export class PrinterFilesController {
   printerFilesStore: PrinterFilesStore;
@@ -169,7 +169,6 @@ export class PrinterFilesController {
     const { filePath: path, print } = await validateInput(req.body, selectAndPrintFileRules);
 
     const result = await this.octoPrintApiService.selectPrintFile(printerLogin, path, print);
-
     res.send(result);
   }
 
@@ -200,7 +199,7 @@ export class PrinterFilesController {
       await this.printerFileCleanTask.cleanPrinterFiles(currentPrinterId);
     }
 
-    const token = this.multerService.startTrackingSession(files);
+    const token = this.multerService.startTrackingSession(uploadedFile);
     const response = await this.octoPrintApiService.uploadFileAsMultiPart(
       printerLogin,
       uploadedFile,
@@ -211,47 +210,9 @@ export class PrinterFilesController {
       token
     );
 
-    if (response.success !== false) {
-      const newOrUpdatedFile = response.files.local;
-      await this.printerFilesStore.appendOrSetPrinterFile(currentPrinterId, newOrUpdatedFile);
-    }
-
-    res.send(response);
-  }
-
-  /**
-   * This endpoint is not actively used. Its better to introduce a virtual file system (VFS) to be able to manage centralized uploads.
-   */
-  async localUploadFile(req: Request, res: Response) {
-    const { currentPrinterId, printerLogin } = getScopedPrinter(req);
-    const { select, print, localLocation } = await validateInput(req.body, localFileUploadRules);
-
-    if (!localLocation.endsWith(".gcode")) {
-      throw new ValidationException({
-        localLocation: "The indicated file extension did not match '.gcode'",
-      });
-    }
-
-    if (!existsSync(localLocation)) {
-      throw new NotFoundException("The indicated file was not found.");
-    }
-
-    if (lstatSync(localLocation).isDirectory()) {
-      throw new ValidationException({
-        localLocation: "The indicated file was not correctly found.",
-      });
-    }
-
-    const stream = createReadStream(localLocation);
-    const response = await this.octoPrintApiService.uploadFileAsMultiPart(printerLogin, stream, {
-      select,
-      print,
-    });
-
-    // TODO update file cache with files store
-    if (response.success !== false) {
-      const newOrUpdatedFile = response.files.local;
-      await this.printerFilesStore.appendOrSetPrinterFile(currentPrinterId, newOrUpdatedFile);
+    if (response.success !== false && response?.files?.local?.path?.length) {
+      const file = await this.octoPrintApiService.getFile(printerLogin, response?.files?.local?.path);
+      await this.printerFilesStore.appendOrSetPrinterFile(currentPrinterId, file);
     }
 
     res.send(response);
@@ -270,7 +231,6 @@ export default createController(PrinterFilesController)
   .post("/batch/reprint-files", "batchReprintFiles", withPermission(PERMS.PrinterFiles.Actions))
   .get("/:id", "getFiles", withPermission(PERMS.PrinterFiles.Get))
   .get("/:id/cache", "getFilesCache", withPermission(PERMS.PrinterFiles.Get))
-  .post("/:id/local-upload", "localUploadFile", withPermission(PERMS.PrinterFiles.Upload))
   .post("/:id/upload", "uploadFile", withPermission(PERMS.PrinterFiles.Upload))
   .post("/:id/create-folder", "createFolder", withPermission(PERMS.PrinterFiles.Actions))
   .post("/:id/select", "selectAndPrintFile", withPermission(PERMS.PrinterFiles.Actions))

--- a/src/entities/base.entity.ts
+++ b/src/entities/base.entity.ts
@@ -1,0 +1,6 @@
+import { PrimaryGeneratedColumn } from "typeorm";
+
+export class BaseEntity {
+  @PrimaryGeneratedColumn()
+  id!: number;
+}

--- a/src/models/Printer.ts
+++ b/src/models/Printer.ts
@@ -7,9 +7,9 @@ export interface IPrinter {
   enabled: boolean;
   disabledReason: string;
   name: string;
+  assignee: string;
   currentUser: string;
   dateAdded: number;
-  fileList: [];
   feedRate: number;
   flowRate: number;
 }
@@ -32,6 +32,10 @@ export const PrinterSchema = new Schema<IPrinter>({
     type: String,
     required: false,
   },
+  assignee: {
+    type: String,
+    required: false,
+  },
   name: {
     type: String,
     required: true,
@@ -44,12 +48,6 @@ export const PrinterSchema = new Schema<IPrinter>({
   dateAdded: {
     type: Number,
     required: false,
-  },
-  // Obsolete in v1.6.0
-  fileList: {
-    type: Array,
-    default: [],
-    required: true,
   },
   feedRate: {
     type: Number,

--- a/src/models/PrinterFile.ts
+++ b/src/models/PrinterFile.ts
@@ -1,0 +1,81 @@
+import { model, Schema } from "mongoose";
+
+export interface IPrinterFile {
+  id: string;
+  printerId: Schema.Types.ObjectId;
+  name: string;
+  date: number;
+  display: string;
+  gcodeAnalysis?: any;
+  hash: string;
+  origin: string;
+  path: string;
+  prints?: any;
+  refs?: any;
+  size?: number;
+  statistics?: any;
+  type?: string;
+  typePath?: string[];
+}
+
+export const PrinterFileSchema = new Schema<IPrinterFile>({
+  printerId: {
+    type: Schema.Types.ObjectId,
+    required: true,
+  },
+  name: {
+    type: String,
+    required: true,
+  },
+  date: {
+    type: Number,
+    required: true,
+  },
+  display: {
+    type: String,
+    required: true,
+  },
+  gcodeAnalysis: {
+    type: Object,
+    default: null,
+    required: false,
+  },
+  hash: {
+    type: String,
+    required: true,
+  },
+  origin: {
+    type: String,
+    required: true,
+  },
+  path: {
+    type: String,
+    required: true,
+  },
+  prints: {
+    type: Object,
+    required: false,
+  },
+  refs: {
+    type: Object,
+    required: false,
+  },
+  size: {
+    type: Number,
+    required: false,
+  },
+  statistics: {
+    type: Object,
+    required: false,
+  },
+  type: {
+    type: String,
+    required: false,
+  },
+  typePath: {
+    type: Array(String),
+    required: false,
+  },
+});
+
+export const PrinterFile = model("PrinterFile", PrinterFileSchema);

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -8,5 +8,18 @@ import { PrintCompletion } from "./PrintCompletion";
 import { RefreshToken } from "./Auth/RefreshToken";
 import { CameraStream } from "./CameraStream";
 import { CustomGcode } from "./CustomGcode";
+import { PrinterFile } from "./PrinterFile";
 
-export { Printer, Floor, PrintCompletion, CustomGcode, Settings, User, Role, Permission, RefreshToken, CameraStream };
+export {
+  Printer,
+  PrinterFile,
+  Floor,
+  PrintCompletion,
+  CustomGcode,
+  Settings,
+  User,
+  Role,
+  Permission,
+  RefreshToken,
+  CameraStream,
+};

--- a/src/services/interfaces/print-completion.interface.ts
+++ b/src/services/interfaces/print-completion.interface.ts
@@ -1,7 +1,6 @@
-import { IdType, SqliteIdType } from "@/shared.constants";
+import { IdType } from "@/shared.constants";
 import { CreatePrintCompletionDto, PrintCompletionContext, PrintCompletionDto } from "@/services/interfaces/print-completion.dto";
 import { IPrintCompletion } from "@/models/PrintCompletion";
-import { PrintCompletion } from "@/entities";
 
 export interface IPrintCompletionService<KeyType = IdType, Entity = IPrintCompletion> {
   toDto(printCompletion: Entity): PrintCompletionDto<KeyType>;
@@ -14,7 +13,7 @@ export interface IPrintCompletionService<KeyType = IdType, Entity = IPrintComple
 
   updateContext(correlationId: string, context: PrintCompletionContext): Promise<void>;
 
-  loadPrintContexts(): Promise<Record<string, (IPrintCompletion | PrintCompletion)[]>>;
+  loadPrintContexts(): Promise<Record<string, IPrintCompletion[]>>;
 
   listGroupByPrinterStatus(): Promise<any[]>;
 }

--- a/src/services/interfaces/printer-file.dto.ts
+++ b/src/services/interfaces/printer-file.dto.ts
@@ -1,4 +1,5 @@
 import { GcodeAnalysisDto } from "@/services/interfaces/gcode-analysis.dto";
+import { IdDto, IdType } from "@/shared.constants";
 
 export interface LastPrintMoment {
   date: number;
@@ -26,7 +27,9 @@ export interface Statistics {
   };
 }
 
-export class PrinterFileDto {
+export class PrinterFileDto<KeyType = IdType> extends IdDto<KeyType> {
+  printerId: KeyType;
+
   name: string;
   date: number;
   display: string;

--- a/src/services/interfaces/printer-files.service.interface.ts
+++ b/src/services/interfaces/printer-files.service.interface.ts
@@ -1,18 +1,17 @@
 import { IdType } from "@/shared.constants";
+import { PrinterFileDto } from "@/services/interfaces/printer-file.dto";
+import { IPrinterFile } from "@/models/PrinterFile";
 
-export interface IPrinterFilesService<KeyType = IdType> {
-  getPrinterFiles(printerId: KeyType): Promise<any[]>;
+export interface IPrinterFilesService<KeyType = IdType, Entity = IPrinterFile | PrinterFileDto> {
+  toDto(entity: Entity): PrinterFileDto;
 
-  updateFiles(printerId: KeyType, fileList): Promise<any>;
+  getPrinterFiles(printerId: KeyType): Promise<Entity[]>;
 
-  appendOrReplaceFile(printerId: KeyType, addedFile): Promise<{ lastPrintedFile: {}; fileList: any }>;
+  updateFiles(printerId: KeyType, newFiles: PrinterFileDto[]): Promise<Entity[]>;
 
-  setPrinterLastPrintedFile(printerId: KeyType, fileName: string): Promise<any>;
+  appendOrReplaceFile(printerId: KeyType, addedFile: PrinterFileDto): Promise<Entity[]>;
 
   clearFiles(printerId: KeyType): Promise<void>;
 
-  /**
-   * Perform delete action on database
-   **/
-  deleteFile(printerId: KeyType, filePath: string, throwError: boolean): Promise<void>;
+  deletePrinterFiles(printerId: KeyType, filePath: string[], throwError: boolean): Promise<void>;
 }

--- a/src/services/octoprint/octoprint-api.service.ts
+++ b/src/services/octoprint/octoprint-api.service.ts
@@ -1,4 +1,4 @@
-import fs, { createReadStream, ReadStream, statSync } from "fs";
+import fs, { createReadStream, ReadStream } from "fs";
 import path from "path";
 import FormData from "form-data";
 import { multiPartContentType, pluginRepositoryUrl } from "./constants/octoprint-service.constants";
@@ -12,7 +12,6 @@ import { LoginDto } from "@/services/interfaces/login.dto";
 import { IdType } from "@/shared.constants";
 import { SettingsStore } from "@/state/settings.store";
 import { ILoggerFactory } from "@/handlers/logger-factory";
-import Throttle from "throttle";
 
 export class OctoPrintApiService extends OctoPrintRoutes {
   eventEmitter2: EventEmitter2;

--- a/src/services/orm/base.interface.ts
+++ b/src/services/orm/base.interface.ts
@@ -1,0 +1,34 @@
+import { DeepPartial, DeleteResult, FindManyOptions, Repository } from "typeorm";
+import { TypeormService } from "@/services/typeorm/typeorm.service";
+import { SqliteIdType } from "@/shared.constants";
+import { IPagination } from "@/services/interfaces/page.interface";
+
+export interface IBaseService<
+  T extends object,
+  DTO extends object,
+  CreateDTO extends object = DeepPartial<T>,
+  UpdateDTO extends object = DTO
+> {
+  repository: Repository<T>;
+  typeormService: TypeormService;
+
+  toDto(entity: T): DTO;
+
+  list(options?: FindManyOptions<T>): Promise<T[]>;
+
+  listPaged(page: IPagination): Promise<T[]>;
+
+  get(id: number): Promise<T | null>;
+
+  create(dto: CreateDTO): Promise<T>;
+
+  update(id: number, dto: UpdateDTO): Promise<T>;
+
+  delete(id: number): Promise<DeleteResult>;
+
+  deleteMany(ids: SqliteIdType[], emitEvent: boolean): Promise<DeleteResult>;
+}
+
+export interface Type<T = any> extends Function {
+  new (...args: any[]): T;
+}

--- a/src/services/orm/base.service.ts
+++ b/src/services/orm/base.service.ts
@@ -1,0 +1,74 @@
+import { IBaseService, Type } from "@/services/orm/base.interface";
+import { SqliteIdType } from "@/shared.constants";
+import { TypeormService } from "@/services/typeorm/typeorm.service";
+import { DeepPartial, DeleteResult, EntityNotFoundError, EntityTarget, FindManyOptions, Repository } from "typeorm";
+import { validate } from "class-validator";
+import { QueryDeepPartialEntity } from "typeorm/query-builder/QueryPartialEntity";
+import { BaseEntity } from "@/entities/base.entity";
+import { NotFoundException } from "@/exceptions/runtime.exceptions";
+import { DEFAULT_PAGE, IPagination } from "@/services/interfaces/page.interface";
+import { FindOptionsWhere } from "typeorm/find-options/FindOptionsWhere";
+
+export function BaseService<
+  T extends BaseEntity,
+  DTO extends object,
+  CreateDTO extends object = DeepPartial<T>,
+  UpdateDTO extends object = QueryDeepPartialEntity<T>
+>(entity: EntityTarget<T>, dto: Type<DTO>, createDTO?: Type<CreateDTO>, updateDto?: Type<UpdateDTO>) {
+  abstract class BaseServiceHost implements IBaseService<T, DTO, CreateDTO, UpdateDTO> {
+    typeormService: TypeormService;
+    repository: Repository<T>;
+
+    constructor({ typeormService }: { typeormService: TypeormService }) {
+      this.typeormService = typeormService;
+      this.repository = typeormService.getDataSource().getRepository(entity);
+    }
+
+    abstract toDto(entity: T): DTO;
+
+    async get(id: SqliteIdType, throwIfNotFound = true) {
+      try {
+        return this.repository.findOneByOrFail({ id } as FindOptionsWhere<T> | FindOptionsWhere<T>[]);
+      } catch (e) {
+        if (throwIfNotFound && e instanceof EntityNotFoundError) {
+          throw new NotFoundException(`The entity ${entity} with id '${id}' was not found.`);
+        }
+        return undefined;
+      }
+    }
+
+    async list(options?: FindManyOptions<T>) {
+      return this.repository.find(options);
+    }
+
+    async listPaged(page: IPagination = DEFAULT_PAGE, options?: FindManyOptions<T>) {
+      return this.repository.find({ take: page.pageSize, skip: page.pageSize * page.page, ...options });
+    }
+
+    async update(id: SqliteIdType, updateDto: UpdateDTO) {
+      const entity = await this.get(id);
+      await validate(updateDto);
+      await validate(Object.assign(entity, updateDto));
+      await this.repository.update(entity.id, updateDto);
+      return entity;
+    }
+
+    async create(dto: CreateDTO) {
+      await validate(dto);
+      const entity = this.repository.create(dto) as T;
+      await validate(entity);
+      return await this.repository.save(entity);
+    }
+
+    async delete(id: SqliteIdType, throwIfNotFound = true) {
+      const entity = await this.get(id, throwIfNotFound);
+      return await this.repository.delete(entity.id);
+    }
+
+    async deleteMany(ids: SqliteIdType[], emitEvent = true): Promise<DeleteResult> {
+      return await this.repository.delete(ids);
+    }
+  }
+
+  return BaseServiceHost;
+}

--- a/src/services/print-completion.service.ts
+++ b/src/services/print-completion.service.ts
@@ -5,7 +5,7 @@ import { EVENT_TYPES } from "./octoprint/constants/octoprint-websocket.constants
 import { LoggerService } from "@/handlers/logger";
 import { ILoggerFactory } from "@/handlers/logger-factory";
 import { MongoIdType } from "@/shared.constants";
-import { IPrintCompletionService } from "@/services/interfaces/print-completion.service";
+import { IPrintCompletionService } from "@/services/interfaces/print-completion.interface";
 import { CreatePrintCompletionDto, PrintCompletionContext, PrintCompletionDto } from "@/services/interfaces/print-completion.dto";
 import { IPrintCompletion } from "@/models/PrintCompletion";
 import { processCompletions } from "@/services/print-completion.shared";

--- a/src/services/printer-files.service.ts
+++ b/src/services/printer-files.service.ts
@@ -5,6 +5,9 @@ import { ILoggerFactory } from "@/handlers/logger-factory";
 import { IPrinterFilesService } from "@/services/interfaces/printer-files.service.interface";
 import { IPrinterService } from "@/services/interfaces/printer.service.interface";
 import { IPrinter } from "@/models/Printer";
+import { PrinterFile } from "@/models";
+import { PrinterFileDto } from "@/services/interfaces/printer-file.dto";
+import { IPrinterFile } from "@/models/PrinterFile";
 
 /**
  * An extension repository for managing printer files in database
@@ -17,75 +20,113 @@ export class PrinterFilesService implements IPrinterFilesService<MongoIdType> {
     printerService,
     loggerFactory,
   }: {
-    printerService: IPrinterService<MongoIdType>;
+    printerService: IPrinterService<MongoIdType, IPrinter>;
     loggerFactory: ILoggerFactory;
   }) {
     this.printerService = printerService;
     this.logger = loggerFactory(PrinterFilesService.name);
   }
 
+  toDto(entity: IPrinterFile): PrinterFileDto<MongoIdType> {
+    return {
+      id: entity.id,
+      printerId: entity.printerId?.toString(),
+      name: entity.name,
+      date: entity.date,
+      display: entity.display,
+      gcodeAnalysis: entity.gcodeAnalysis,
+      hash: entity.hash,
+      origin: entity.origin,
+      path: entity.path,
+      prints: entity.prints,
+      refs: entity.refs,
+      size: entity.size,
+      statistics: entity.statistics,
+      type: entity.type,
+      typePath: entity.typePath,
+    };
+  }
+
   async getPrinterFiles(printerId: MongoIdType) {
     const printer = await this.printerService.get(printerId);
-
-    return printer.fileList;
+    return PrinterFile.find({ printerId: printer.id });
   }
 
-  async updateFiles(printerId: MongoIdType, fileList) {
-    const printer = await this.printerService.get(printerId);
+  async updateFiles(printerId: MongoIdType, newFiles: PrinterFileDto[]) {
+    const savedFiles = await this.getPrinterFiles(printerId);
 
-    printer.fileList = fileList;
+    const newPaths = newFiles.map((f) => f.path);
+    const deletableSavedFiles = savedFiles.filter((f) => !newPaths.includes(f.path));
+    const deletableSavedFilePaths = deletableSavedFiles.map((f) => f.path);
+    await this.deletePrinterFiles(printerId, deletableSavedFilePaths, false);
 
-    printer.markModified("fileList");
-    await printer.save();
-
-    return printer.fileList;
-  }
-
-  async appendOrReplaceFile(printerId: MongoIdType, addedFile) {
-    const printer = await this.printerService.get(printerId);
-
-    // TODO replace with file storage
-    const foundFileIndex = printer.fileList.findIndex((f) => f.path === addedFile.path);
-    if (foundFileIndex === -1) {
-      printer.fileList.push(addedFile);
-    } else {
-      printer.fileList[foundFileIndex] = addedFile;
+    for (const newFile of newFiles) {
+      await this.appendOrReplaceFile(printerId, newFile);
     }
 
-    printer.markModified("fileList");
-    await printer.save();
+    return await this.getPrinterFiles(printerId);
+  }
 
-    return { fileList: printer.fileList };
+  async appendOrReplaceFile(printerId: MongoIdType, addedFile: PrinterFileDto) {
+    const printer = await this.printerService.get(printerId);
+    addedFile.printerId = printer.id;
+
+    const foundFile = await this.getPrinterFile(printer.id, addedFile.path);
+    if (!foundFile) {
+      await PrinterFile.create(addedFile);
+    } else {
+      await PrinterFile.replaceOne(
+        {
+          printerId: printer.id,
+          id: foundFile.id,
+        },
+        addedFile
+      );
+    }
+
+    return await this.getPrinterFiles(printer.id);
   }
 
   async clearFiles(printerId: MongoIdType) {
     const printer = await this.printerService.get(printerId);
-    printer.fileList = [];
-    printer.markModified("fileList");
-    await printer.save();
+    await PrinterFile.deleteMany({
+      printerId: printer.id,
+    });
   }
 
-  /**
-   * Perform delete action on database
-   **/
-  async deleteFile(printerId: MongoIdType, filePath: string, throwError = true) {
+  async deletePrinterFiles(printerId: MongoIdType, filePaths: string[], throwError = true) {
     const printer = await this.printerService.get(printerId);
 
-    const fileIndex = printer.fileList.findIndex((f) => f.path === filePath);
-
-    if (fileIndex === -1) {
-      if (throwError) {
-        throw new NotFoundException(
-          `A file removal was ordered but this file was not found in database for printer Id ${printerId}`,
-          filePath
-        );
-      } else {
-        this.logger.warn("File was not found in printer fileList");
-      }
+    if (!filePaths?.length) {
+      throw new Error("Cant delete specific printer files without specific file path array being provided");
     }
 
-    printer.fileList.splice(fileIndex, 1);
-    printer.markModified("fileList");
-    await printer.save();
+    for (const filePath of filePaths) {
+      const file = await this.getPrinterFile(printerId, filePath);
+      if (!file) {
+        if (throwError) {
+          throw new NotFoundException(
+            `A file removal was ordered but this file was not found in database for printer Id ${printerId}`,
+            filePath
+          );
+        } else {
+          this.logger.warn("File was not found in PrinterFile table");
+          return;
+        }
+      }
+
+      await PrinterFile.deleteOne({
+        printerId: printer.id,
+        path: filePath,
+      });
+    }
+  }
+
+  private async getPrinterFile(printerId: MongoIdType, filePath: string) {
+    const printer = await this.printerService.get(printerId);
+    return PrinterFile.findOne({
+      printerId: printer.id,
+      path: filePath,
+    });
   }
 }

--- a/src/services/printer-files.service.ts
+++ b/src/services/printer-files.service.ts
@@ -97,7 +97,9 @@ export class PrinterFilesService implements IPrinterFilesService<MongoIdType> {
   async deletePrinterFiles(printerId: MongoIdType, filePaths: string[], throwError = true) {
     const printer = await this.printerService.get(printerId);
 
-    if (!filePaths?.length) {
+    if (!!filePaths && !filePaths?.length) {
+      return;
+    } else if (!filePaths) {
       throw new Error("Cant delete specific printer files without specific file path array being provided");
     }
 

--- a/src/services/printer.service.ts
+++ b/src/services/printer.service.ts
@@ -7,7 +7,6 @@ import {
   updatePrinterDisabledReasonRule,
   updatePrinterEnabledRule,
 } from "./validators/printer-service.validation";
-import { getDefaultPrinterEntry } from "@/constants/service.constants";
 import { printerEvents } from "@/constants/event.constants";
 import { LoggerService } from "@/handlers/logger";
 import { normalizeURLWithProtocol } from "@/utils/url.utils";
@@ -68,7 +67,7 @@ export class PrinterService implements IPrinterService<MongoIdType> {
    * @param {boolean} emitEvent
    * @throws {Error} If the printer is not correctly provided.
    */
-  async create(newPrinter, emitEvent = true) {
+  async create(newPrinter: IPrinter, emitEvent = true) {
     if (!newPrinter) throw new Error("Missing printer");
 
     const mergedPrinter = await this.validateAndDefault(newPrinter);
@@ -86,7 +85,7 @@ export class PrinterService implements IPrinterService<MongoIdType> {
    * @param updateData
    * @returns {Promise<Query<Document<any, any, unknown> | null, Document<any, any, unknown>, {}, unknown>>}
    */
-  async update(printerId: MongoIdType, updateData) {
+  async update(printerId: MongoIdType, updateData: Partial<IPrinter>) {
     const printer = await this.get(printerId);
     updateData.printerURL = normalizeURLWithProtocol(updateData.printerURL);
     const { printerURL, apiKey, enabled, name } = await validateInput(updateData, createMongoPrinterRules);
@@ -227,9 +226,8 @@ export class PrinterService implements IPrinterService<MongoIdType> {
     return printer;
   }
 
-  private async validateAndDefault(printer): Promise<Object> {
+  private async validateAndDefault(printer): Promise<IPrinter> {
     const mergedPrinter = {
-      ...getDefaultPrinterEntry(),
       enabled: true,
       ...printer,
     };

--- a/src/state/printer.cache.ts
+++ b/src/state/printer.cache.ts
@@ -18,12 +18,6 @@ interface CachedPrinter {
   disabledReason: string;
   name: string;
   dateAdded: number;
-  fileList: {
-    files: Array<any>;
-    folders: Array<any>;
-    free: number;
-    total: number;
-  };
   feedRate: number;
   flowRate: number;
 }

--- a/test/api/print-completion-controller.test.ts
+++ b/test/api/print-completion-controller.test.ts
@@ -6,7 +6,7 @@ import { AppConstants } from "@/server.constants";
 import { PrintCompletion as Model } from "@/models";
 import { EVENT_TYPES } from "@/services/octoprint/constants/octoprint-websocket.constants";
 import { DITokens } from "@/container.tokens";
-import { IPrintCompletionService } from "@/services/interfaces/print-completion.service";
+import { IPrintCompletionService } from "@/services/interfaces/print-completion.interface";
 import supertest from "supertest";
 import { createTestPrinter } from "./test-data/create-printer";
 

--- a/test/api/printer-files-controller.test.ts
+++ b/test/api/printer-files-controller.test.ts
@@ -140,17 +140,93 @@ describe(PrinterFilesController.name, () => {
   it("should allow POST upload file", async () => {
     const printer = await createTestPrinter(request);
 
-    nock(printer.printerURL)
-      .post("/api/files/local")
-      .reply(200, {
-        files: {
-          local: {
-            path: "/home/yes",
-            name: "3xP1234A_PLA_ParelWit_1h31m.gcode",
+    const apiMock = nock(printer.printerURL);
+    apiMock.post("/api/files/local").reply(200, {
+      files: {
+        local: {
+          path: "file.gcode",
+          name: "file.gcode",
+        },
+      },
+    });
+    octoPrintApiService.storeResponse(
+      {
+        DisplayLayerProgress: {
+          totalLayerCountWithoutOffset: "19",
+        },
+        date: 1689190590,
+        display: "file.gcode",
+        gcodeAnalysis: {
+          analysisFirstFilamentPrintTime: 11.23491561690389,
+          analysisLastFilamentPrintTime: 7657.739990697696,
+          analysisPending: false,
+          analysisPrintTime: 7664.035725705694,
+          compensatedPrintTime: 7811.063505072208,
+          dimensions: {
+            depth: 171.8769989013672,
+            height: 3.799999952316284,
+            width: 128.8769989013672,
+          },
+          estimatedPrintTime: 7811.063505072208,
+          filament: {
+            tool0: {
+              length: 12463.312793658377,
+              volume: 29.977780370085828,
+            },
+          },
+          firstFilament: 0.00556784805395266,
+          lastFilament: 0.9944192313637905,
+          printingArea: {
+            maxX: 188.8769989013672,
+            maxY: 168.8769989013672,
+            maxZ: 3.799999952316284,
+            minX: 60.0,
+            minY: -3.0,
+            minZ: 0,
+          },
+          progress: [
+            [0, 7811.063505072208],
+            // ...
+            [0.9882939524753298, 77.78355728284184],
+            [0.9934423430553024, 17.78153162482447],
+            [0.9944192313637905, 7.3489461642040395],
+            [1, 0],
+          ],
+        },
+        hash: "a791a7c44a92e4c46827992a1c5a62281e5a2d13",
+        name: "file.gcode",
+        origin: "local",
+        path: "file.gcode",
+        prints: {
+          failure: 0,
+          last: {
+            date: 1689197785.1172757,
+            printTime: 7194.159933987998,
+            success: true,
+          },
+          success: 1,
+        },
+        refs: {
+          download: "http://minipi.local/downloads/files/local/file.gcode",
+          resource: "http://minipi.local/api/files/local/file.gcode",
+        },
+        size: 2167085,
+        statistics: {
+          averagePrintTime: {
+            _default: 7194.159933987998,
+          },
+          lastPrintTime: {
+            _default: 7194.159933987998,
           },
         },
-      })
-      .persist();
+        thumbnail: "plugin/prusaslicerthumbnails/thumbnail/file.png?20230712213630",
+        thumbnail_src: "prusaslicerthumbnails",
+        type: "machinecode",
+        typePath: ["machinecode", "gcode"],
+      },
+
+      200
+    );
 
     const response = await request.post(uploadFileRoute(printer.id)).field("print", true).attach("file", gcodePath);
     expectOkResponse(response);
@@ -166,6 +242,9 @@ describe(PrinterFilesController.name, () => {
           local: {
             path: "/home/yes",
             name: "3xP1234A_PLA_ParelWit_1h31m.gcode",
+            hash: "123",
+            origin: "local",
+            display: "123",
           },
         },
       })
@@ -189,6 +268,9 @@ describe(PrinterFilesController.name, () => {
           local: {
             path: "/home/yes",
             name: "3xP1234A_PLA_ParelWit_1h31m.gcode",
+            hash: "123",
+            origin: "local",
+            display: "123",
           },
         },
       })

--- a/test/api/printer-files-controller.test.ts
+++ b/test/api/printer-files-controller.test.ts
@@ -19,7 +19,6 @@ const moveFileOrFolderRoute = (id: string) => `${getRoute(id)}/move`;
 const deleteFileOrFolderRoute = (id: string, path: string) => `${getRoute(id)}?path=${path}`;
 const selectAndPrintRoute = (id: string) => `${getRoute(id)}/select`;
 const uploadFileRoute = (id: string) => `${getRoute(id)}/upload`;
-const localUploadFileRoute = (id: string) => `${getRoute(id)}/local-upload`;
 const createFolderRoute = (id: string) => `${getRoute(id)}/create-folder`;
 const getFilesRoute = (id: string, recursive: boolean) => `${getRoute(id)}?recursive=${recursive}`;
 const getCacheRoute = (id: string) => `${getRoute(id)}/cache`;
@@ -196,7 +195,7 @@ describe(PrinterFilesController.name, () => {
         hash: "a791a7c44a92e4c46827992a1c5a62281e5a2d13",
         name: "file.gcode",
         origin: "local",
-        path: "file.gcode",
+        path: gcodePath,
         prints: {
           failure: 0,
           last: {
@@ -285,31 +284,5 @@ describe(PrinterFilesController.name, () => {
     const printer = await createTestPrinter(request);
     const response = await request.post(uploadFileRoute(printer.id)).send();
     expectInvalidResponse(response);
-  });
-
-  it("should error 400 on POST to upload local file being a folder", async () => {
-    // We let it fail as late as possible checking the error to not be related to our API
-    const printer = await createTestPrinter(request);
-    octoPrintApiService.storeResponse({}, 200);
-    const response = await request.post(localUploadFileRoute(printer.id)).send({
-      localLocation: "node_modules",
-      select: true,
-      print: true,
-    });
-
-    expectInvalidResponse(response, ["localLocation"]);
-  });
-
-  it("should error 404 on POST to upload local non-existing file", async () => {
-    // We let it fail as late as possible checking the error to not be related to our API
-    const printer = await createTestPrinter(request);
-    octoPrintApiService.storeResponse({}, 200);
-    const response = await request.post(localUploadFileRoute(printer.id)).send({
-      localLocation: "test-file.gcode",
-      select: true,
-      print: true,
-    });
-
-    expectNotFoundResponse(response);
   });
 });

--- a/test/application/store/file-cache.test.ts
+++ b/test/application/store/file-cache.test.ts
@@ -12,11 +12,11 @@ beforeEach(() => {
 });
 
 const testPrinterId = "asd";
-const fileStorageEntry = [1];
+const fileStorageEntry = [{ id: "1", name: "123" }];
 
 describe(FileCache.name, function () {
   it("should generate printer file cache", function () {
-    fileCache.cachePrinterFileStorage(testPrinterId, fileStorageEntry);
-    expect(fileCache.getPrinterFiles(testPrinterId)).toEqual([1]);
+    fileCache.cachePrinterFiles(testPrinterId, fileStorageEntry);
+    expect(fileCache.getPrinterFiles(testPrinterId)).toStrictEqual(fileStorageEntry);
   });
 });

--- a/test/application/store/files-store.test.ts
+++ b/test/application/store/files-store.test.ts
@@ -50,6 +50,11 @@ describe(PrinterFilesStore.name, () => {
     await printerFilesService.updateFiles(testPrinterState.id, [
       {
         date: Date.now() / 1000,
+        path: "123.file",
+        origin: "local",
+        display: "displayvalue",
+        name: "123.file",
+        hash: "123",
       },
     ]);
     await printerFilesStore.loadFilesStore();
@@ -69,9 +74,19 @@ describe(PrinterFilesStore.name, () => {
     await printerFilesService.updateFiles(testPrinterState.id, [
       {
         date: Date.now() / 1000,
+        path: "125.file",
+        origin: "local",
+        display: "displayvalue",
+        name: "125.file",
+        hash: "125",
       },
       {
         date: Date.now() / 1000 - 8 * 86400,
+        path: "124.file",
+        origin: "local",
+        display: "displayvalue",
+        name: "124.file",
+        hash: "124",
       },
     ]);
     await printerFilesStore.loadFilesStore();

--- a/test/test-server.ts
+++ b/test/test-server.ts
@@ -15,9 +15,6 @@ jest.mock("../src/utils/env.utils", () => ({
 }));
 require("../src/utils/env.utils");
 
-/**
- * Setup the application without hassle
- */
 export async function setupTestApp(
   loadPrinterStore = false,
   mocks: any = undefined,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1884,6 +1884,11 @@
   resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz#96116f2a912e0c02817345b3c10751069920d553"
   integrity sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==
 
+"@sqltools/formatter@^1.2.2":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@sqltools/formatter/-/formatter-1.2.5.tgz#3abc203c79b8c3e90fd6c156a0c62d5403520e12"
+  integrity sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==
+
 "@swc/cli@0.1.63":
   version "0.1.63"
   resolved "https://registry.yarnpkg.com/@swc/cli/-/cli-0.1.63.tgz#b4ab850f8c285d06d593428b14ffa3df782adcbb"
@@ -2550,6 +2555,11 @@ ansi-styles@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
+any-promise@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
+  integrity sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==
+
 anymatch@^3.0.3, anymatch@~3.1.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
@@ -2557,6 +2567,11 @@ anymatch@^3.0.3, anymatch@~3.1.2:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+app-root-path@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-3.1.0.tgz#5971a2fc12ba170369a7a1ef018c71e6e47c2e86"
+  integrity sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA==
 
 append-field@^1.0.0:
   version "1.0.0"
@@ -2808,6 +2823,14 @@ before-after-hook@^2.2.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.3.tgz#c51e809c81a4e354084422b9b26bad88249c517c"
   integrity sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==
 
+better-sqlite3@8.6.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-8.6.0.tgz#a20717993742f816158f17e2cccd88a979e77e58"
+  integrity sha512-jwAudeiTMTSyby+/SfbHDebShbmC2MCH8mU2+DXi0WJfv13ypEJm47cd3kljmy/H130CazEvkf2Li//ewcMJ1g==
+  dependencies:
+    bindings "^1.5.0"
+    prebuild-install "^7.1.1"
+
 bin-check@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/bin-check/-/bin-check-4.1.0.tgz#fc495970bdc88bb1d5a35fc17e65c4a149fc4a49"
@@ -2837,6 +2860,22 @@ binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+bindings@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
+bl@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
 
 bl@^6.0.8:
   version "6.0.9"
@@ -2951,7 +2990,7 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
-buffer@^5.6.0:
+buffer@^5.5.0, buffer@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -3052,7 +3091,7 @@ chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.2:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -3080,6 +3119,11 @@ chokidar@3.5.3, chokidar@^3.5.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
+chownr@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
+  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
+
 ci-info@^3.2.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
@@ -3104,6 +3148,18 @@ clean-stack@^2.0.0:
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
+cli-highlight@^2.1.11:
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/cli-highlight/-/cli-highlight-2.1.11.tgz#49736fa452f0aaf4fae580e30acb26828d2dc1bf"
+  integrity sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==
+  dependencies:
+    chalk "^4.0.0"
+    highlight.js "^10.7.1"
+    mz "^2.4.0"
+    parse5 "^5.1.1"
+    parse5-htmlparser2-tree-adapter "^6.0.0"
+    yargs "^16.0.0"
+
 cli-table3@^0.6.1:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.3.tgz#61ab765aac156b52f222954ffc607a6f01dbeeb2"
@@ -3112,6 +3168,15 @@ cli-table3@^0.6.1:
     string-width "^4.2.0"
   optionalDependencies:
     "@colors/colors" "1.5.0"
+
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
 
 cliui@^8.0.1:
   version "8.0.1"
@@ -3389,7 +3454,7 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@4.x, debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@~4.3.1, debug@~4.3.2:
+debug@4, debug@4.x, debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4, debug@~4.3.1, debug@~4.3.2:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -3414,6 +3479,11 @@ dedent@^1.0.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-1.5.1.tgz#4f3fc94c8b711e9bb2800d185cd6ad20f2a90aff"
   integrity sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==
+
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@^0.1.3:
   version "0.1.4"
@@ -3468,6 +3538,11 @@ destroy@1.2.0:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
 
+detect-libc@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.2.tgz#8ccf2ba9315350e1241b88d0ac3b0e1fbd99605d"
+  integrity sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==
+
 detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
@@ -3505,7 +3580,7 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dotenv@16.3.1:
+dotenv@16.3.1, dotenv@^16.0.0:
   version "16.3.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
   integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
@@ -3547,7 +3622,7 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
 
-end-of-stream@^1.1.0:
+end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
@@ -3940,6 +4015,11 @@ exit@^0.1.2:
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==
 
+expand-template@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
+  integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
+
 expect@^29.0.0, expect@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-29.7.0.tgz#578874590dcb3214514084c08115d8aee61e11bc"
@@ -4115,6 +4195,11 @@ file-type@^17.1.6:
     strtok3 "^7.0.0-alpha.9"
     token-types "^5.0.0-alpha.2"
 
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
 filename-reserved-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz#3d5dd6d4e2d73a3fed2ebc4cd0b3448869a081f7"
@@ -4246,6 +4331,11 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
 
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
+
 fs-extra@^10.0.1:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
@@ -4335,6 +4425,11 @@ get-symbol-description@^1.0.0:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
 
+github-from-package@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
+  integrity sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==
+
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
@@ -4349,7 +4444,7 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob@^7.1.3, glob@^7.1.4:
+glob@^7.1.3, glob@^7.1.4, glob@^7.2.0:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -4489,6 +4584,11 @@ hexoid@^1.0.0:
   resolved "https://registry.yarnpkg.com/hexoid/-/hexoid-1.0.0.tgz#ad10c6573fb907de23d9ec63a711267d9dc9bc18"
   integrity sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==
 
+highlight.js@^10.7.1:
+  version "10.7.3"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
+  integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
+
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
@@ -4602,10 +4702,15 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+ini@~1.3.0:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 internal-slot@^1.0.5:
   version "1.0.6"
@@ -5641,10 +5746,15 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimist@^1.2.0, minimist@^1.2.6, minimist@^1.2.8:
+minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.6, minimist@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
+mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
+  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
 mkdirp@^0.5.4:
   version "0.5.6"
@@ -5652,6 +5762,11 @@ mkdirp@^0.5.4:
   integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
   dependencies:
     minimist "^1.2.6"
+
+mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 moment@^2.29.1:
   version "2.29.4"
@@ -5817,6 +5932,20 @@ multer@1.4.5-lts.1:
     type-is "^1.6.4"
     xtend "^4.0.0"
 
+mz@^2.4.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
+  integrity sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==
+  dependencies:
+    any-promise "^1.0.0"
+    object-assign "^4.0.1"
+    thenify-all "^1.0.0"
+
+napi-build-utils@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-1.0.2.tgz#b1fddc0b2c46e380a0b7a76f984dd47c41a13806"
+  integrity sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -5850,6 +5979,13 @@ nock@13.4.0:
     debug "^4.1.0"
     json-stringify-safe "^5.0.1"
     propagate "^2.0.0"
+
+node-abi@^3.3.0:
+  version "3.47.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.47.0.tgz#6cbfa2916805ae25c2b7156ca640131632eb05e8"
+  integrity sha512-2s6B2CWZM//kPgwnuI0KrYwNjfdByE25zvAaEpq9IH4zcNsarH8Ihu/UuX6XMPEogDAxkuUFeZn60pXNHAqn3A==
+  dependencies:
+    semver "^7.3.5"
 
 node-input-validator@4.5.1:
   version "4.5.1"
@@ -5929,7 +6065,7 @@ number-allocator@^1.0.14:
     debug "^4.3.1"
     js-sdsl "4.3.0"
 
-object-assign@^4, object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -6119,6 +6255,23 @@ parse-json@^5.2.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parse5-htmlparser2-tree-adapter@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz#2cdf9ad823321140370d4dbf5d3e92c7c8ddc6e6"
+  integrity sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==
+  dependencies:
+    parse5 "^6.0.1"
+
+parse5@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
+  integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
+
+parse5@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
+  integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
+
 parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
@@ -6242,6 +6395,24 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+prebuild-install@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.1.tgz#de97d5b34a70a0c81334fd24641f2a1702352e45"
+  integrity sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==
+  dependencies:
+    detect-libc "^2.0.0"
+    expand-template "^2.0.3"
+    github-from-package "0.0.0"
+    minimist "^1.2.3"
+    mkdirp-classic "^0.5.3"
+    napi-build-utils "^1.0.1"
+    node-abi "^3.3.0"
+    pump "^3.0.0"
+    rc "^1.2.7"
+    simple-get "^4.0.0"
+    tar-fs "^2.0.0"
+    tunnel-agent "^0.6.0"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -6384,6 +6555,16 @@ raw-body@2.5.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+rc@^1.2.7:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
+  dependencies:
+    deep-extend "^0.6.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
+
 react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
@@ -6410,7 +6591,7 @@ readable-stream@^2.2.2:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.0.2, readable-stream@^3.4.0, readable-stream@^3.6.0:
+readable-stream@^3.0.2, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
   integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
@@ -6448,6 +6629,11 @@ reflect-metadata@0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.2.1.tgz#8d5513c0f5ef2b4b9c3865287f3c0940c1f67f74"
   integrity sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw==
+
+reflect-metadata@^0.1.13:
+  version "0.1.14"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.14.tgz#24cf721fe60677146bb77eeb0e1f9dece3d65859"
+  integrity sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==
 
 regenerator-runtime@^0.14.0:
   version "0.14.1"
@@ -6591,6 +6777,11 @@ safe-stable-stringify@^2.3.1:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+sax@>=0.6.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
 semver-regex@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-4.0.5.tgz#fbfa36c7ba70461311f5debcb3928821eb4f9180"
@@ -6668,6 +6859,14 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
+sha.js@^2.4.11:
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
+  integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -6715,6 +6914,20 @@ signal-exit@^3.0.0, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
+
+simple-concat@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
+  integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
+
+simple-get@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543"
+  integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
+  dependencies:
+    decompress-response "^6.0.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
 
 simple-git@3.21.0:
   version "3.21.0"
@@ -6964,6 +7177,11 @@ strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+  integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
+
 strip-outer@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-outer/-/strip-outer-2.0.0.tgz#c45c724ed9b1ff6be5f660503791404f4714084b"
@@ -7040,6 +7258,27 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+tar-fs@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
+  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
+  dependencies:
+    chownr "^1.1.1"
+    mkdirp-classic "^0.5.2"
+    pump "^3.0.0"
+    tar-stream "^2.1.4"
+
+tar-stream@^2.1.4:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
+  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
+  dependencies:
+    bl "^4.0.3"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
+
 tar-stream@^3.0.0:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-3.1.6.tgz#6520607b55a06f4a2e2e04db360ba7d338cc5bab"
@@ -7067,6 +7306,20 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
+
+thenify-all@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
+  integrity sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==
+  dependencies:
+    thenify ">= 3.1.0 < 4"
+
+"thenify@>= 3.1.0 < 4":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.1.tgz#8932e686a4066038a016dd9e2ca46add9838a95f"
+  integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
+  dependencies:
+    any-promise "^1.0.0"
 
 tmpl@1.0.5:
   version "1.0.5"
@@ -7188,6 +7441,13 @@ tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.6
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
+  dependencies:
+    safe-buffer "^5.0.1"
+
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
@@ -7261,6 +7521,29 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
+
+typeorm@0.3.7:
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/typeorm/-/typeorm-0.3.7.tgz#5776ed5058f0acb75d64723b39ff458d21de64c1"
+  integrity sha512-MsPJeP6Zuwfe64c++l80+VRqpGEGxf0CkztIEnehQ+CMmQPSHjOnFbFxwBuZ2jiLqZTjLk2ZqQdVF0RmvxNF3Q==
+  dependencies:
+    "@sqltools/formatter" "^1.2.2"
+    app-root-path "^3.0.0"
+    buffer "^6.0.3"
+    chalk "^4.1.0"
+    cli-highlight "^2.1.11"
+    date-fns "^2.28.0"
+    debug "^4.3.3"
+    dotenv "^16.0.0"
+    glob "^7.2.0"
+    js-yaml "^4.1.0"
+    mkdirp "^1.0.4"
+    reflect-metadata "^0.1.13"
+    sha.js "^2.4.11"
+    tslib "^2.3.1"
+    uuid "^8.3.2"
+    xml2js "^0.4.23"
+    yargs "^17.3.1"
 
 typescript@5.3.3:
   version "5.3.3"
@@ -7528,6 +7811,19 @@ ws@~8.11.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.11.0.tgz#6a0d36b8edfd9f96d8b25683db2f8d7de6e8e143"
   integrity sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==
 
+xml2js@^0.4.23:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
+  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+
 xtend@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
@@ -7553,10 +7849,28 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
+yargs-parser@^20.2.2:
+  version "20.2.9"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
+  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+
 yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs@^16.0.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 yargs@^17.3.1, yargs@^17.7.2:
   version "17.7.2"


### PR DESCRIPTION
# Description

In order to bring SQLite into the picture as a database, the fileList property of the MongoDB collection is in the way.

- This PR moves the fileList (with all risks associated) to a separate table.
- It introduces the typeorm dependency

