### PR TITLE
fix: bring both sqlite and mongodb versions up to date

### DIFF
--- a/src/services/printer-files.service.ts
+++ b/src/services/printer-files.service.ts
@@ -70,6 +70,9 @@ export class PrinterFilesService implements IPrinterFilesService<MongoIdType> {
   async appendOrReplaceFile(printerId: MongoIdType, addedFile: CreateOrUpdatePrinterFileDto<MongoIdType>) {
     const printer = await this.printerService.get(printerId);
     addedFile.printerId = printer.id;
+    if (!addedFile.customData) {
+      addedFile.customData = {};
+    }
 
     const foundFile = await this.getPrinterFile(printer.id, addedFile.path);
     if (!foundFile) {

--- a/test/application/store/files-store.test.ts
+++ b/test/application/store/files-store.test.ts
@@ -55,7 +55,6 @@ describe(PrinterFilesStore.name, () => {
         display: "displayvalue",
         name: "123.file",
         hash: "123",
-        customData: {},
       },
     ]);
     await printerFilesStore.loadFilesStore();
@@ -80,7 +79,6 @@ describe(PrinterFilesStore.name, () => {
         display: "displayvalue",
         name: "125.file",
         hash: "125",
-        customData: {},
       },
       {
         date: Date.now() / 1000 - 8 * 86400,
@@ -89,7 +87,6 @@ describe(PrinterFilesStore.name, () => {
         display: "displayvalue",
         name: "124.file",
         hash: "124",
-        customData: {},
       },
     ]);
     await printerFilesStore.loadFilesStore();


### PR DESCRIPTION
# Description

Fixes the mongodb-based version to be up-to-date with the SQLite service which automatically sets the customData field for a printer file, preventing unnecessary database validation errors.