### PR TITLE
fix: drop correlationId from completion table

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,12 +16,8 @@ jobs:
       - run: yarn set version berry
       - run: yarn install --immutable
       - run: yarn run build
-      # non-coverage sqlite tests
-      - run: yarn run test:sqlite
-        env:
-          NODE_OPTIONS: '--max_old_space_size=8192'
-      # run mongodb tests with coverage
-      - run: yarn run test:cov
+      # run sqlite tests with coverage
+      - run: yarn run test:cov-sqlite
         env:
           NODE_OPTIONS: '--max_old_space_size=8192'
 

--- a/.github/workflows/nodejs_mongodb.yml
+++ b/.github/workflows/nodejs_mongodb.yml
@@ -1,0 +1,24 @@
+name: Node.js CI MongoDB
+
+on:
+  pull_request:
+  workflow_dispatch:
+  # Runs from default branch, which is develop
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  nodejs-build-mongodb:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+
+      - run: yarn set version berry
+      - run: yarn install --immutable
+      - run: yarn run build
+      # non-coverage sqlite tests
+      - run: yarn run test
+        env:
+          NODE_OPTIONS: '--max_old_space_size=8192'

--- a/src/controllers/printer.controller.ts
+++ b/src/controllers/printer.controller.ts
@@ -175,7 +175,7 @@ export class PrinterController {
   }
 
   async create(req: Request, res: Response) {
-    let newPrinter = req.body;
+    const newPrinter = req.body;
 
     // Has internal validation, but might add some here above as well
     const createdPrinter = await this.printerService.create(newPrinter);

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -42,6 +42,7 @@ import { PrintCompletionCorrelationId1699189686327 } from "@/migrations/16991896
 import { NullableColsPrinterFile1699810905182 } from "@/migrations/1699810905182-NullableColsPrinterFile";
 import { DropFloorPositionIdPrinter1703406837191 } from "@/migrations/1703406837191-DropFloorPositionIdPrinter";
 import { CustomDataUserDataPrinterFile1703411779907 } from "@/migrations/1703411779907-CustomDataUserDataPrinterFile";
+import { DropCorrelationIdCompletion1706821653681 } from "@/migrations/1706821653681-DropCorrelationIdCompletion";
 
 dotenv.config({
   path: join(superRootPath(), ".env"),
@@ -104,6 +105,7 @@ export const AppDataSource = new DataSource({
     NullableColsPrinterFile1699810905182,
     DropFloorPositionIdPrinter1703406837191,
     CustomDataUserDataPrinterFile1703411779907,
+    DropCorrelationIdCompletion1706821653681,
   ],
   subscribers: [],
 });

--- a/src/entities/print-completion.entity.ts
+++ b/src/entities/print-completion.entity.ts
@@ -2,7 +2,6 @@ import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, PrimaryGenerat
 import { Printer } from "@/entities/printer.entity";
 import { BaseEntity } from "@/entities/base.entity";
 import { PrintCompletionContextDto } from "@/services/interfaces/print-completion-context.dto";
-import { Unique } from "typeorm/browser";
 
 @Entity()
 export class PrintCompletion extends BaseEntity {
@@ -14,9 +13,6 @@ export class PrintCompletion extends BaseEntity {
 
   @CreateDateColumn({ type: "int" })
   createdAt!: number;
-
-  @Column({ unique: false })
-  correlationId!: string;
 
   @Column()
   status!: string;

--- a/src/migrations/1706821653681-DropCorrelationIdCompletion.ts
+++ b/src/migrations/1706821653681-DropCorrelationIdCompletion.ts
@@ -1,0 +1,97 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DropCorrelationIdCompletion1706821653681 implements MigrationInterface {
+    name = 'DropCorrelationIdCompletion1706821653681'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            CREATE TABLE "temporary_print_completion" (
+                "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+                "fileName" varchar NOT NULL,
+                "createdAt" integer NOT NULL DEFAULT (datetime('now')),
+                "status" varchar NOT NULL,
+                "printerId" integer NOT NULL,
+                "completionLog" varchar,
+                "context" text,
+                "printerReference" varchar,
+                CONSTRAINT "FK_c078b1dfe5f87f79f131520d856" FOREIGN KEY ("printerId") REFERENCES "printer" ("id") ON DELETE
+                SET NULL ON UPDATE NO ACTION
+            )
+        `);
+        await queryRunner.query(`
+            INSERT INTO "temporary_print_completion"(
+                    "id",
+                    "fileName",
+                    "createdAt",
+                    "status",
+                    "printerId",
+                    "completionLog",
+                    "context",
+                    "printerReference"
+                )
+            SELECT "id",
+                "fileName",
+                "createdAt",
+                "status",
+                "printerId",
+                "completionLog",
+                "context",
+                "printerReference"
+            FROM "print_completion"
+        `);
+        await queryRunner.query(`
+            DROP TABLE "print_completion"
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "temporary_print_completion"
+                RENAME TO "print_completion"
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "print_completion"
+                RENAME TO "temporary_print_completion"
+        `);
+        await queryRunner.query(`
+            CREATE TABLE "print_completion" (
+                "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+                "fileName" varchar NOT NULL,
+                "createdAt" integer NOT NULL DEFAULT (datetime('now')),
+                "status" varchar NOT NULL,
+                "printerId" integer NOT NULL,
+                "completionLog" varchar,
+                "context" text,
+                "printerReference" varchar,
+                "correlationId" varchar NOT NULL,
+                CONSTRAINT "FK_c078b1dfe5f87f79f131520d856" FOREIGN KEY ("printerId") REFERENCES "printer" ("id") ON DELETE
+                SET NULL ON UPDATE NO ACTION
+            )
+        `);
+        await queryRunner.query(`
+            INSERT INTO "print_completion"(
+                    "id",
+                    "fileName",
+                    "createdAt",
+                    "status",
+                    "printerId",
+                    "completionLog",
+                    "context",
+                    "printerReference"
+                )
+            SELECT "id",
+                "fileName",
+                "createdAt",
+                "status",
+                "printerId",
+                "completionLog",
+                "context",
+                "printerReference"
+            FROM "temporary_print_completion"
+        `);
+        await queryRunner.query(`
+            DROP TABLE "temporary_print_completion"
+        `);
+    }
+
+}

--- a/src/services/interfaces/print-completion.interface.ts
+++ b/src/services/interfaces/print-completion.interface.ts
@@ -1,6 +1,7 @@
 import { IdType } from "@/shared.constants";
 import { CreatePrintCompletionDto, PrintCompletionContext, PrintCompletionDto } from "@/services/interfaces/print-completion.dto";
 import { IPrintCompletion } from "@/models/PrintCompletion";
+import { PrintCompletion } from "@/entities";
 
 export interface IPrintCompletionService<KeyType = IdType, Entity = IPrintCompletion> {
   toDto(printCompletion: Entity): PrintCompletionDto<KeyType>;
@@ -13,7 +14,7 @@ export interface IPrintCompletionService<KeyType = IdType, Entity = IPrintComple
 
   updateContext(correlationId: string, context: PrintCompletionContext): Promise<void>;
 
-  loadPrintContexts(): Promise<Record<string, IPrintCompletion[]>>;
+  loadPrintContexts(): Promise<Record<string, (IPrintCompletion | PrintCompletion)[]>>;
 
   listGroupByPrinterStatus(): Promise<any[]>;
 }

--- a/src/services/orm/base.service.ts
+++ b/src/services/orm/base.service.ts
@@ -54,9 +54,14 @@ export function BaseService<
     }
 
     async create(dto: CreateDTO) {
+      // Safety mechanism against upserts
+      if (dto.id) {
+        delete dto.id;
+      }
       await validate(dto);
       const entity = this.repository.create(dto) as T;
       await validate(entity);
+
       return await this.repository.save(entity);
     }
 

--- a/src/services/orm/print-completion.service.ts
+++ b/src/services/orm/print-completion.service.ts
@@ -2,7 +2,7 @@ import { BaseService } from "@/services/orm/base.service";
 import { PrintCompletion } from "@/entities";
 import { CreatePrintCompletionDto, PrintCompletionContext, PrintCompletionDto } from "@/services/interfaces/print-completion.dto";
 import { SqliteIdType } from "@/shared.constants";
-import { IPrintCompletionService } from "@/services/interfaces/print-completion.service";
+import { IPrintCompletionService } from "@/services/interfaces/print-completion.interface";
 import { In, Not } from "typeorm";
 import { EVENT_TYPES } from "@/services/octoprint/constants/octoprint-websocket.constants";
 import { groupArrayBy } from "@/utils/array.util";

--- a/src/services/orm/print-completion.service.ts
+++ b/src/services/orm/print-completion.service.ts
@@ -26,7 +26,6 @@ export class PrintCompletionService
     return {
       id: entity.id,
       completionLog: entity.completionLog,
-      correlationId: entity.correlationId,
       context: entity.context,
       fileName: entity.fileName,
       createdAt: entity.createdAt,
@@ -41,12 +40,12 @@ export class PrintCompletionService
   }
 
   async findPrintCompletion(correlationId: string) {
-    return this.repository.findBy({ correlationId });
+    return this.repository.findBy({ context: { correlationId } });
   }
 
   async updateContext(correlationId: string, context: PrintCompletionContext): Promise<void> {
     const completionEntry = await this.repository.findOneBy({
-      correlationId,
+      context: { correlationId },
       status: EVENT_TYPES.PrintStarted,
     });
     if (!completionEntry) {

--- a/src/services/orm/print-completion.service.ts
+++ b/src/services/orm/print-completion.service.ts
@@ -40,7 +40,9 @@ export class PrintCompletionService
   }
 
   async findPrintCompletion(correlationId: string) {
-    return this.repository.findBy({ context: { correlationId } });
+    const completions = await this.repository.findBy({});
+    console.log({ context: { correlationId } });
+    return completions.filter((c) => c.context?.correlationId === correlationId);
   }
 
   async updateContext(correlationId: string, context: PrintCompletionContext): Promise<void> {

--- a/src/services/orm/printer.service.ts
+++ b/src/services/orm/printer.service.ts
@@ -63,7 +63,11 @@ export class PrinterService
   /**
    * Stores a new printer into the database.
    */
-  async create(newPrinter: PrinterDto<SqliteIdType>, emitEvent = true): Promise<Printer> {
+  async create(newPrinter: PrinterUnsafeDto<SqliteIdType>, emitEvent = true): Promise<Printer> {
+    if (newPrinter.id) {
+      delete newPrinter.id;
+    }
+
     const mergedPrinter = await this.validateAndDefault(newPrinter);
     mergedPrinter.dateAdded = Date.now();
     const printer = await super.create(mergedPrinter);

--- a/src/tasks/print-completion.socketio.task.ts
+++ b/src/tasks/print-completion.socketio.task.ts
@@ -1,7 +1,7 @@
 import { fdmMonsterPrinterStoppedEvent, octoPrintWebsocketEvent } from "@/constants/event.constants";
 import { EVENT_TYPES } from "@/services/octoprint/constants/octoprint-websocket.constants";
 import { generateCorrelationToken } from "@/utils/correlation-token.util";
-import { IO_MESSAGES, SocketIoGateway } from "@/state/socket-io.gateway";
+import { SocketIoGateway } from "@/state/socket-io.gateway";
 import EventEmitter2 from "eventemitter2";
 import { LoggerService } from "@/handlers/logger";
 import { PrintCompletionService } from "@/services/print-completion.service";

--- a/test/api/print-completion-controller.test.ts
+++ b/test/api/print-completion-controller.test.ts
@@ -6,7 +6,7 @@ import { EVENT_TYPES } from "@/services/octoprint/constants/octoprint-websocket.
 import { DITokens } from "@/container.tokens";
 import { SqliteIdType } from "@/shared.constants";
 import { PrintCompletionDto } from "@/services/interfaces/print-completion.dto";
-import { IPrintCompletionService } from "@/services/interfaces/print-completion.service";
+import { IPrintCompletionService } from "@/services/interfaces/print-completion.interface";
 import supertest from "supertest";
 import { PrintCompletionController } from "@/controllers/print-completion.controller";
 import { createTestPrinter } from "./test-data/create-printer";
@@ -48,7 +48,6 @@ describe(PrintCompletionController.name, () => {
       completionLog: "some log happened here",
       status: EVENT_TYPES.PrintStarted,
       fileName: "mycode.gcode",
-      correlationId: "123",
       context: {
         correlationId: "123",
       },
@@ -59,7 +58,6 @@ describe(PrintCompletionController.name, () => {
       completionLog: "some log happened here",
       status: EVENT_TYPES.PrintDone,
       fileName: "mycode.gcode",
-      correlationId: "123",
       context: {
         correlationId: "123",
       },


### PR DESCRIPTION
# Description

Drop the print completion correlation Id as it was required but not available for all code paths.

⚠️ 
In hindsight this is a really, really bad idea. This feature needs to be fixed first.
Now Im listing all the prints in order to find a couple.