### PR TITLE
feat: clear printer events on socket events store for a complete printer refresh

### DIFF
--- a/src/controllers/printer.controller.ts
+++ b/src/controllers/printer.controller.ts
@@ -294,6 +294,7 @@ export class PrinterController {
   async refreshPrinterSocket(req: Request, res: Response) {
     const { currentPrinterId } = getScopedPrinter(req);
     this.printerSocketStore.reconnectOctoPrint(currentPrinterId);
+    await this.printerEventsCache.deletePrinterSocketEvents(currentPrinterId);
     res.send({});
   }
 

--- a/src/state/printer-events.cache.ts
+++ b/src/state/printer-events.cache.ts
@@ -36,6 +36,10 @@ export class PrinterEventsCache extends KeyDiffCache<PrinterEventsCacheDto> {
     return this.settingsStore.getSettingsSensitive()?.server?.debugSettings?.debugSocketMessages;
   }
 
+  async deletePrinterSocketEvents(id: IdType) {
+    await this.deleteKeyValue(id, true);
+  }
+
   async getPrinterSocketEvents(id: IdType) {
     return this.keyValueStore[id];
   }

--- a/src/tasks/socketio.task.ts
+++ b/src/tasks/socketio.task.ts
@@ -83,7 +83,7 @@ export class SocketIoTask {
     };
 
     // Precise debugging
-    if (this.settingsStore.getServerSettings().debugSettings?.debugSocketIoBandwidth) {
+    if (this.settingsStore.getDebugSettingsSensitive()?.debugSocketIoBandwidth) {
       const kbDataString = Object.entries(socketIoData)
         .map(([id, state]) => {
           return `${id} ${formatKB(state)}`;


### PR DESCRIPTION
Remove all state.

Attempt at fixing #2194
