### PR TITLE
fix: wrong middleware user role ids, should be role ids instead

### DIFF
--- a/src/middleware/authenticate.ts
+++ b/src/middleware/authenticate.ts
@@ -69,8 +69,7 @@ export function authorizePermission(permission: string) {
 
 export const authorizeRoles = (roles: string[], subset = true) =>
   inject(({ roleService }: { roleService: IRoleService }) => async (req: Request, res: Response, next: NextFunction) => {
-    const userRoles = req.roles as IdType[];
-    if (!roleService.authorizeRoles(roles, userRoles, subset)) {
+    if (!roleService.authorizeRoles(roles, req.roles, subset)) {
       throw new AuthorizationError({ roles });
     }
 

--- a/src/middleware/global.middleware.ts
+++ b/src/middleware/global.middleware.ts
@@ -67,7 +67,7 @@ export const interceptRoles = inject(
       const serverSettings = await settingsStore.getSettings();
 
       if (isTypeormMode) {
-        req.roles = req.user?.roles.map((r) => r.id);
+        req.roles = req.user?.roles.map((r) => r.roleId);
       } else {
         req.roles = req.user?.roles;
       }

--- a/src/services/authentication/role.service.ts
+++ b/src/services/authentication/role.service.ts
@@ -141,7 +141,7 @@ export class RoleService implements IRoleService<MongoIdType> {
     }
   }
 
-  normalizeRoleIdOrName(assignedRole: string | MongoIdType) {
+  private normalizeRoleIdOrName(assignedRole: string | MongoIdType) {
     const roleInstance = this.roles.find((r) => r.id === assignedRole || r.name === assignedRole);
     if (!roleInstance) {
       console.warn(`The role by ID ${assignedRole} did not exist in definition. Skipping.`);

--- a/src/services/interfaces/role-service.interface.ts
+++ b/src/services/interfaces/role-service.interface.ts
@@ -28,6 +28,4 @@ export interface IRoleService<KeyType = IdType, Entity = IRole> {
   getRole(roleId: KeyType): Entity;
 
   syncRoles(): Promise<void>;
-
-  normalizeRoleIdOrName(assignedRole: string | KeyType): string | undefined;
 }

--- a/src/services/orm/role.service.ts
+++ b/src/services/orm/role.service.ts
@@ -79,6 +79,12 @@ export class RoleService extends BaseService(Role, RoleDto<SqliteIdType>) implem
     return permissions;
   }
 
+  /**
+   * Checks if the role names or ids overlap
+   * @param requiredRoles list of roles that would grant access
+   * @param assignedRoles application role names or role ids (not to be confused with user role assignments)
+   * @param subset
+   */
   authorizeRoles(requiredRoles: (string | SqliteIdType)[], assignedRoles: (string | SqliteIdType)[], subset: boolean): boolean {
     let isAuthorized = false;
 
@@ -130,16 +136,6 @@ export class RoleService extends BaseService(Role, RoleDto<SqliteIdType>) implem
     return this.getRoleByName(roleName);
   }
 
-  normalizeRoleIdOrName(assignedRole: string | SqliteIdType): string | undefined {
-    const roleInstance = this.roles.find((r) => r.id === assignedRole || r.name === assignedRole);
-    if (!roleInstance) {
-      console.warn(`The role by ID ${assignedRole} did not exist in definition. Skipping.`);
-      return;
-    }
-
-    return roleInstance.name;
-  }
-
   async syncRoles(): Promise<void> {
     this._roles = [];
     for (let roleName of Object.values(ROLES)) {
@@ -153,5 +149,15 @@ export class RoleService extends BaseService(Role, RoleDto<SqliteIdType>) implem
         this._roles.push(storedRole);
       }
     }
+  }
+
+  private normalizeRoleIdOrName(assignedRole: string | SqliteIdType): string | undefined {
+    const roleInstance = this.roles.find((r) => r.id === assignedRole || r.name === assignedRole);
+    if (!roleInstance) {
+      console.warn(`The role by ID ${assignedRole} did not exist in definition. Skipping.`);
+      return;
+    }
+
+    return roleInstance.name;
   }
 }

--- a/src/types/express/index.d.ts
+++ b/src/types/express/index.d.ts
@@ -2,14 +2,16 @@
 import { AwilixContainer } from "awilix";
 import { IRole } from "@/models/Auth/Role";
 import { IUser } from "@/models/Auth/User";
+import { IdType } from "@/shared.constants";
+
+export type RequestRole = IdType;
 
 declare global {
   namespace Express {
-
     interface Request {
       user?: IUser;
       container?: AwilixContainer;
-      roles?: IRole[];
+      roles?: RequestRole[];
     }
   }
 }


### PR DESCRIPTION
# Description

Bugfix for the authorization middleware. User role ids were provided instead of role ids, causing wrong role comparison.