### PR TITLE
fix: add curl and ca-certificates for f.e. optional healthcheck 

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,6 +10,8 @@ RUN yarn run build
 FROM node:18-bookworm-slim as production
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y ca-certificates curl
+
 RUN yarn global add pm2
 COPY .yarn/releases ./.yarn/releases
 RUN yarn set version berry

--- a/docker/alpha.Dockerfile
+++ b/docker/alpha.Dockerfile
@@ -10,6 +10,8 @@ RUN yarn run build
 FROM node:18-bookworm-slim as production
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y ca-certificates curl
+
 RUN yarn global add pm2
 COPY .yarn/releases ./.yarn/releases
 RUN yarn set version berry

--- a/docker/test.Dockerfile
+++ b/docker/test.Dockerfile
@@ -1,6 +1,8 @@
 FROM node:18-bookworm-slim as production
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y ca-certificates curl
+
 RUN yarn global add pm2
 
 COPY .swcrc tsconfig.json package.json jest.config.js yarn.lock ./


### PR DESCRIPTION
# Description

Adds `curl` and `ca-certificates` to the fdm monster images.