### PR TITLE
Fix/1948 importing existing printers can clear out floor positions 

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -12,7 +12,7 @@ GITHUB_PAT=1234567890abcdef1234567890abcdef12345678
 ENABLE_MQTT_AUTODISCOVERY=false
 
 # Sentry (partially anonimized) bug tracking
-# Use the FDM Monster Sentry for NodeJS, or set-up your own!
+# Use the FDM Monster Sentry for Node.js, or set-up your own!
 # If not specified, will fallback to "https://164b8028a8a745bba3dbcab991b84ae7@o4503975545733120.ingest.sentry.io/4505101598261248"
 SENTRY_CUSTOM_DSN=https://164b8028a8a745bba3dbcab991b84ae7@o4503975545733120.ingest.sentry.io/4505101598261248
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ FDM Monster currently consists of two active repositories:
 
 Server design
 
-- **FDM Monster server** was chosen to be a NodeJS server. The backend is currently structured as a REST API. It might be surprising that we use `awilix` as Inversion-of-Control implementation, but if you study the resulting architecture it will show its fresh and quick-to-develop benefits rapidly.
+- **FDM Monster server** was chosen to be a Node.js server. The backend is currently structured as a REST API. It might be surprising that we use `awilix` as Inversion-of-Control implementation, but if you study the resulting architecture it will show its fresh and quick-to-develop benefits rapidly.
 - **FDM Monster server** runs using MongoDB as database and Mongoose as ORM
 - **FDM Monster server** caches data in-memory using a self-written store/cache system between the database (no redis!)
 - **FDM Monster server** API is built up using `awilix-express` and uses `node-input-validation` as API validation

--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -3,7 +3,7 @@
 Fixes:
 
 - YAML Import would fail updating properly an existing floor by floor level
-
-Known issues:
-
 - YAML Import has issues updating a floor, printers positions are not consistently are updated.
+- YAML Import converted printer IDs to string, causing the printers to not show up on the printer grid until server restart. The import was done correctly on database level. 
+
+

--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,5 +1,9 @@
 # FDM Monster 13/04/2024 1.6.1
 
+Changes:
+
+- Dropped the permission check on /api/features as it made no sense
+
 Fixes:
 
 - YAML Import would fail updating properly an existing floor by floor level

--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,0 +1,9 @@
+# FDM Monster 13/04/2024 1.6.1
+
+Fixes:
+
+- YAML Import would fail updating properly an existing floor by floor level
+
+Known issues:
+
+- YAML Import has issues updating a floor, printers positions are not consistently are updated.

--- a/installations/ansible/playbook-ubuntu22.yaml
+++ b/installations/ansible/playbook-ubuntu22.yaml
@@ -51,7 +51,7 @@
     - name: "Install @fdm-monster/server as pm2 module"
       shell: "{{ bash }} 'pm2 install @fdm-monster/server@{{fdmm_version}} -n fdmm'"
 
-    - name: Set NodeJS Full Version as a variable
+    - name: Set Node.js Full Version as a variable
       command: "{{ bash }} 'nvm current'"
       register: node_fullversion
       ignore_errors: true

--- a/src/controllers/server-public.controller.ts
+++ b/src/controllers/server-public.controller.ts
@@ -153,5 +153,5 @@ export default createController(ServerPublicController)
   .prefix(AppConstants.apiRoute + "/")
   .get("", "welcome", { before: [authenticate(), authorizePermission(PERMS.ServerInfo.Get)] })
   .get("test", "test")
-  .get("features", "getFeatures", { before: [authenticate(), authorizePermission(PERMS.ServerInfo.Get)] })
+  .get("features", "getFeatures", { before: [authenticate()] })
   .get("version", "getVersion", { before: [authenticate(), authorizePermission(PERMS.ServerInfo.Get)] });

--- a/src/services/core/yaml.service.ts
+++ b/src/services/core/yaml.service.ts
@@ -178,6 +178,7 @@ export class YamlService {
           floorPosition.printerId = knownPrinterId;
           knownPrinters.push(floorPosition);
         }
+        updatedFloor.id = updateId;
         updatedFloor.printers = knownPrinters;
       }
 

--- a/src/services/floor.service.ts
+++ b/src/services/floor.service.ts
@@ -57,42 +57,6 @@ export class FloorService implements IFloorService<MongoIdType> {
       return floors;
     }
 
-    // TODO this does more harm than good
-    // for (const floor of floors) {
-    //   if (!floor.printers?.length) continue;
-
-    // const removedPositionPrinterIds: MongoIdType[] = [];
-
-    // TODO this is prone to collisions
-    // const positionsKnown: { [k: string]: any } = {};
-    // for (const fp of floor.printers) {
-    //   // Remove orphans
-    //   const stringPrinterId = fp.printerId.toString();
-    //   const printerExists = printerIds.includes(stringPrinterId);
-    //   if (!printerExists) {
-    //     removedPositionPrinterIds.push(stringPrinterId);
-    //     continue;
-    //   }
-    //
-    //   // Remove duplicate position, keeping the last added one
-    //   const xyPos = positionsKnown[`${fp.x}${fp.y}`];
-    //   if (!!xyPos) {
-    //     removedPositionPrinterIds.push(xyPos.printerId);
-    //   }
-    //
-    //   // Keep last floor printer
-    //   positionsKnown[`${fp.x}${fp.y}`] = fp;
-    // }
-    //
-    // if (removedPositionPrinterIds?.length) {
-    //   floor.printers = floor.printers.filter((fp) => !removedPositionPrinterIds.includes(fp.printerId));
-    //   await floor.save();
-    //   this.logger.warn(
-    //     `Found ${removedPositionPrinterIds} (floor printerIds) to be in need of removal for floor (duplicate position or non-existing printer)`
-    //   );
-    // }
-    // }
-
     return floors;
   }
 
@@ -141,10 +105,6 @@ export class FloorService implements IFloorService<MongoIdType> {
     const { floor: validLevel } = await validateInput({ floor: level }, updateFloorNumberRules);
     floor.floor = validLevel;
     return await floor.save();
-  }
-
-  async getFloorsOfPrinterId(printerId: MongoIdType) {
-    return Floor.find({ printers: { $elemMatch: { printerId } } });
   }
 
   async deletePrinterFromAnyFloor(printerId: MongoIdType) {

--- a/src/services/floor.service.ts
+++ b/src/services/floor.service.ts
@@ -122,23 +122,23 @@ export class FloorService implements IFloorService<MongoIdType> {
     );
   }
 
-  async addOrUpdatePrinter(floorId: MongoIdType, printerInFloor: AddOrUpdatePrinterDto<MongoIdType>) {
+  async addOrUpdatePrinter(floorId: MongoIdType, updatedPosition: AddOrUpdatePrinterDto<MongoIdType>) {
     const floor = await this.get(floorId, true);
-    const validInput = await validateInput(printerInFloor, printerInFloorRules(false));
+    const validInput = await validateInput(updatedPosition, printerInFloorRules(false));
 
     // Ensure printer exists
     await this.printerCache.getCachedPrinterOrThrowAsync(validInput.printerId);
 
     // Ensure position is not taken twice
     floor.printers = floor.printers.filter(
-      (pif: PrinterInFloorDto) => !(pif.x === printerInFloor.x && pif.y === printerInFloor.y)
+      (position: PrinterInFloorDto) => !(position.x === updatedPosition.x && position.y === updatedPosition.y)
     );
 
-    const foundPrinterInFloorIndex = floor.printers.findIndex(
-      (pif: PrinterInFloorDto) => pif.printerId.toString() === validInput.printerId
+    const positionIndex = floor.printers.findIndex(
+      (position: PrinterInFloorDto) => position.printerId.toString() === validInput.printerId.toString()
     );
-    if (foundPrinterInFloorIndex !== -1) {
-      floor.printers[foundPrinterInFloorIndex] = validInput;
+    if (positionIndex !== -1) {
+      floor.printers[positionIndex] = validInput;
     } else {
       floor.printers.push(validInput);
     }

--- a/src/services/interfaces/floor.service.interface.ts
+++ b/src/services/interfaces/floor.service.interface.ts
@@ -2,11 +2,11 @@ import { IFloor } from "@/models/Floor";
 import { IdType } from "@/shared.constants";
 import { CreateFloorDto, FloorDto, PositionDto, UpdateFloorDto } from "@/services/interfaces/floor.dto";
 import { Floor } from "@/entities";
+import { FindOptionsWhere } from "typeorm/find-options/FindOptionsWhere";
+import { FindOneOptions, FindOptions } from "typeorm";
 
 export interface IFloorService<KeyType = IdType, Entity = IFloor | Floor> {
-  toDto(floor: Entity): FloorDto<KeyType>;
-
-  list(): Promise<Entity[]>;
+  addOrUpdatePrinter(floorId: KeyType, position: PositionDto<KeyType>): Promise<Entity>;
 
   create(input: CreateFloorDto<KeyType>): Promise<Entity>;
 
@@ -14,17 +14,19 @@ export interface IFloorService<KeyType = IdType, Entity = IFloor | Floor> {
 
   delete(floorId: KeyType): Promise<any | void>;
 
-  get(floorId: KeyType): Promise<Entity>;
+  deletePrinterFromAnyFloor(printerId: KeyType): Promise<void>;
+
+  get(floorId: KeyType, throwIfNotFound?: boolean, options?: FindOneOptions<Entity>): Promise<Entity>;
+
+  list(): Promise<Entity[]>;
+
+  removePrinter(floorId: KeyType, printerId: KeyType): Promise<Entity>;
+
+  toDto(floor: Entity): FloorDto<KeyType>;
 
   update(floorId: KeyType, input: UpdateFloorDto<KeyType>): Promise<Entity>;
 
-  updateName(floorId: KeyType, name: string): Promise<Entity>;
-
   updateLevel(floorId: KeyType, level: number): Promise<Entity>;
 
-  deletePrinterFromAnyFloor(printerId: KeyType): Promise<void>;
-
-  addOrUpdatePrinter(floorId: KeyType, position: PositionDto<KeyType>): Promise<Entity>;
-
-  removePrinter(floorId: KeyType, printerId: KeyType): Promise<Entity>;
+  updateName(floorId: KeyType, name: string): Promise<Entity>;
 }

--- a/src/services/orm/base.interface.ts
+++ b/src/services/orm/base.interface.ts
@@ -1,4 +1,4 @@
-import { DeepPartial, DeleteResult, FindManyOptions, Repository } from "typeorm";
+import { DeepPartial, DeleteResult, FindManyOptions, FindOneOptions, Repository } from "typeorm";
 import { TypeormService } from "@/services/typeorm/typeorm.service";
 import { SqliteIdType } from "@/shared.constants";
 import { IPagination } from "@/services/interfaces/page.interface";
@@ -18,13 +18,13 @@ export interface IBaseService<
 
   listPaged(page: IPagination): Promise<T[]>;
 
-  get(id: number): Promise<T | null>;
+  get(id: SqliteIdType, throwIfNotFound?: boolean, options?: FindOneOptions<T>): Promise<T | null>;
 
   create(dto: CreateDTO): Promise<T>;
 
-  update(id: number, dto: UpdateDTO): Promise<T>;
+  update(id: SqliteIdType, dto: UpdateDTO): Promise<T>;
 
-  delete(id: number): Promise<DeleteResult>;
+  delete(id: SqliteIdType): Promise<DeleteResult>;
 
   deleteMany(ids: SqliteIdType[], emitEvent: boolean): Promise<DeleteResult>;
 }

--- a/src/services/orm/base.service.ts
+++ b/src/services/orm/base.service.ts
@@ -1,13 +1,20 @@
 import { IBaseService, Type } from "@/services/orm/base.interface";
 import { SqliteIdType } from "@/shared.constants";
 import { TypeormService } from "@/services/typeorm/typeorm.service";
-import { DeepPartial, DeleteResult, EntityNotFoundError, EntityTarget, FindManyOptions, Repository } from "typeorm";
+import {
+  DeepPartial,
+  DeleteResult,
+  EntityNotFoundError,
+  EntityTarget,
+  FindManyOptions,
+  FindOneOptions,
+  Repository,
+} from "typeorm";
 import { validate } from "class-validator";
 import { QueryDeepPartialEntity } from "typeorm/query-builder/QueryPartialEntity";
 import { BaseEntity } from "@/entities/base.entity";
 import { NotFoundException } from "@/exceptions/runtime.exceptions";
 import { DEFAULT_PAGE, IPagination } from "@/services/interfaces/page.interface";
-import { FindOptionsWhere } from "typeorm/find-options/FindOptionsWhere";
 
 export function BaseService<
   T extends BaseEntity,
@@ -26,9 +33,9 @@ export function BaseService<
 
     abstract toDto(entity: T): DTO;
 
-    async get(id: SqliteIdType, throwIfNotFound = true) {
+    async get(id: SqliteIdType, throwIfNotFound = true, options?: FindOneOptions<T>) {
       try {
-        return this.repository.findOneByOrFail({ id } as FindOptionsWhere<T> | FindOptionsWhere<T>[]);
+        return this.repository.findOneOrFail({ ...options, where: { id } } as FindOneOptions<T>);
       } catch (e) {
         if (throwIfNotFound && e instanceof EntityNotFoundError) {
           throw new NotFoundException(`The entity ${entity} with id '${id}' was not found.`);

--- a/src/services/orm/base.service.ts
+++ b/src/services/orm/base.service.ts
@@ -57,7 +57,7 @@ export function BaseService<
       await validate(updateDto);
       await validate(Object.assign(entity, updateDto));
       await this.repository.update(entity.id, updateDto);
-      return entity;
+      return await this.get(id);
     }
 
     async create(dto: CreateDTO) {

--- a/src/services/orm/floor-position.service.ts
+++ b/src/services/orm/floor-position.service.ts
@@ -14,10 +14,14 @@ export class FloorPositionService extends BaseService(FloorPosition, PositionDto
     return super.create(dto);
   }
 
-  findPosition(x: number, y: number) {
-    return this.repository.findOneBy({ x, y });
+  findPosition(floorId: SqliteIdType, x: number, y: number) {
+    return this.repository.findOneBy({ floorId, x, y });
   }
 
+  /**
+   * Find the printer across any floor, usually to see if it has been moved elsewhere.
+   * @param printerId The printer which position to be looked up.
+   */
   findPrinterPosition(printerId: SqliteIdType) {
     return this.repository.findOneBy({ printerId });
   }

--- a/src/services/orm/floor.service.ts
+++ b/src/services/orm/floor.service.ts
@@ -69,7 +69,13 @@ export class FloorService
 
   async update(floorId: SqliteIdType, update: UpdateFloorDto<SqliteIdType>) {
     const floor = await this.get(floorId);
-    const floorUpdate = Object.assign(floor, update);
+    const floorUpdate = {
+      ...floor,
+      name: update.name,
+      printers: update.printers,
+      floor: update.floor,
+    };
+
     await validateInput(floorUpdate, updateFloorRules);
     const printers = floorUpdate.printers;
     if (printers?.length) {

--- a/src/services/orm/floor.service.ts
+++ b/src/services/orm/floor.service.ts
@@ -110,7 +110,9 @@ export class FloorService
     }
     // Remove any printers that should not exist on floor
     const undesiredPositions = floor.printers.filter((pos) => !desiredPositions.find((dp) => dp.printerId === pos.printerId));
-    await this.floorPositionService.deleteMany(undesiredPositions.map((pos) => pos.id));
+    if (undesiredPositions?.length) {
+      await this.floorPositionService.deleteMany(undesiredPositions.map((pos) => pos.id));
+    }
     delete floorUpdate.printers;
 
     return super.update(floorId, floorUpdate);

--- a/src/services/orm/floor.service.ts
+++ b/src/services/orm/floor.service.ts
@@ -99,14 +99,14 @@ export class FloorService
   async updateName(floorId: SqliteIdType, name: string) {
     let floor = await this.get(floorId);
     floor.name = name;
-    floor = await this.update(floorId, { name });
+    floor = await this.update(floorId, floor);
     return floor;
   }
 
   async updateLevel(floorId: SqliteIdType, level: number): Promise<Floor> {
     let floor = await this.get(floorId);
     floor.floor = level;
-    floor = await this.update(floorId, { floor: level });
+    floor = await this.update(floorId, floor);
     return floor;
   }
 

--- a/test/api/test-data/create-printer.ts
+++ b/test/api/test-data/create-printer.ts
@@ -1,7 +1,7 @@
 import { AppConstants } from "@/server.constants";
 import { expectOkResponse } from "../../extensions";
 import supertest from "supertest";
-import { PrinterDto, PrinterUnsafeDto } from "@/services/interfaces/printer.dto";
+import { PrinterUnsafeDto } from "@/services/interfaces/printer.dto";
 import { SqliteIdType } from "@/shared.constants";
 
 const printerRoute = AppConstants.apiRoute + "/printer";

--- a/test/application/test-data/export-fdm-monster-1.5.2-mongodb-simple.yaml
+++ b/test/application/test-data/export-fdm-monster-1.5.2-mongodb-simple.yaml
@@ -1,0 +1,36 @@
+version: 1.5.1
+exportedAt: 2023-11-11T09:02:41.703Z
+config:
+  exportPrinters: true
+  exportFloorGrid: true
+  printerComparisonStrategiesByPriority:
+    - name
+    - url
+  exportFloors: true
+  floorComparisonStrategiesByPriority: floor
+  notes: ''
+printers:
+  - id: 648f3e6d372112628bb8e404
+    disabledReason: null
+    enabled: true
+    dateAdded: 1687109229334
+    name: Dragon Eggggg
+    printerURL: http://demo.fdm-monster.net:5001
+    apiKey: asdasdasdasdasdasdasdasdasdasdas
+floors:
+  - id: 64427f2d070a27047acd5e6e
+    floor: 15
+    name: Floor1
+    printers:
+      - floorId: 64427f2d070a27047acd5e6e
+        printerId: 648f3e6d372112628bb8e404
+        x: 0
+        'y': 0
+  - id: 64427f2d070a27047acd5e6f
+    floor: 16
+    name: Floor2
+    printers:
+      - floorId: 64427f2d070a27047acd5e6f
+        printerId: 648f3e6d372112628bb8e404
+        x: 0
+        'y': 0

--- a/test/application/test-data/export-fdm-monster-1.5.2-mongodb-simple.yaml
+++ b/test/application/test-data/export-fdm-monster-1.5.2-mongodb-simple.yaml
@@ -17,6 +17,13 @@ printers:
     name: Dragon Eggggg
     printerURL: http://demo.fdm-monster.net:5001
     apiKey: asdasdasdasdasdasdasdasdasdasdas
+  - id: 748f3e6d372112628bb8e405
+    disabledReason: null
+    enabled: true
+    dateAdded: 1687109229334
+    name: Dragon Eggggg2
+    printerURL: http://demo.fdm-monster.net:5001
+    apiKey: asdasdasdasdasdasdasdasdasdasdas
 floors:
   - id: 64427f2d070a27047acd5e6e
     floor: 15
@@ -31,6 +38,6 @@ floors:
     name: Floor2
     printers:
       - floorId: 64427f2d070a27047acd5e6f
-        printerId: 648f3e6d372112628bb8e404
+        printerId: 748f3e6d372112628bb8e405
         x: 0
         'y': 0

--- a/test/application/yaml-service.test.ts
+++ b/test/application/yaml-service.test.ts
@@ -164,7 +164,11 @@ describe(YamlService.name, () => {
     const floors = await floorService.list();
     expect(floors).toHaveLength(2);
     const newFloor2 = floors.find((f) => f.name === "Floor2");
-    expect(typeof newFloor2.id).toBe("number");
+    if (isTypeormMode) {
+      expect(typeof newFloor2.id).toBe("number");
+    } else {
+      expect(typeof newFloor2.id).toBe("string");
+    }
     expect(newFloor2).toBeDefined();
     expect(newFloor2.floor).toBe(16);
     expect(newFloor2.printers).toHaveLength(1);

--- a/test/application/yaml-service.test.ts
+++ b/test/application/yaml-service.test.ts
@@ -155,6 +155,7 @@ describe(YamlService.name, () => {
         },
       ],
     });
+    expect(defaultFloor.printers.find((p) => p.printerId.toString() === printer.id.toString())).toBeDefined();
     await printerCache.loadCache();
 
     const buffer = readFileSync(join(__dirname, "./test-data/export-fdm-monster-1.5.2-mongodb-simple.yaml"));
@@ -177,15 +178,13 @@ describe(YamlService.name, () => {
       expect(positionTemp).not.toBeNull();
     }
 
-    // The original floor's name is now gone, but the printer has not been removed from it
+    // The original floor's name is now gone, and the original printer has not been removed from it (overwrite action)
     expect(floors.find((f) => f.name === "Floor1_DifferentName")).toBeUndefined();
     const mutatedFloor1 = floors.find((f) => f.name === "Floor1" && f.floor === 15);
-    expect(mutatedFloor1.printers).toHaveLength(2);
+    expect(mutatedFloor1.printers).toHaveLength(1);
     expect(mutatedFloor1).toBeDefined();
     const originalPrinterPos = mutatedFloor1.printers.find((p) => p.printerId === printer.id);
-    expect(originalPrinterPos).toBeDefined();
-    expect(originalPrinterPos.x).toBe(0);
-    expect(originalPrinterPos.y).toBe(1);
+    expect(originalPrinterPos).toBeUndefined();
     const newPrinterPos = mutatedFloor1.printers.find((p) => p.x === 0 && p.y === 0);
     expect(newPrinterPos).toBeDefined();
 

--- a/test/application/yaml-service.test.ts
+++ b/test/application/yaml-service.test.ts
@@ -11,7 +11,6 @@ import { IFloorService } from "@/services/interfaces/floor.service.interface";
 import { PrinterGroupService } from "@/services/orm/printer-group.service";
 import { testPrinterData } from "./test-data/printer.data";
 import { FloorStore } from "@/state/floor.store";
-import { FloorPosition } from "@/entities";
 import { FloorPositionService } from "@/services/orm/floor-position.service";
 
 let container: AwilixContainer;
@@ -19,10 +18,11 @@ let yamlService: YamlService;
 let printerCache: PrinterCache;
 let printerService: IPrinterService;
 let floorService: IFloorService;
-let floorPositionService: FloorPositionService;
 let floorStore: FloorStore;
 let printerGroupService: PrinterGroupService;
 let isTypeormMode: boolean;
+// Use only when isTypeormMode is true
+let floorPositionService: FloorPositionService;
 
 beforeAll(async () => {
   const { container, isTypeormMode: _isTypeormMode } = await setupTestApp(true);
@@ -172,8 +172,10 @@ describe(YamlService.name, () => {
     expect(newFloor2).toBeDefined();
     expect(newFloor2.floor).toBe(16);
     expect(newFloor2.printers).toHaveLength(1);
-    const positionTemp = await floorPositionService.findPosition(newFloor2.id as number, 0, 0);
-    expect(positionTemp).not.toBeNull();
+    if (isTypeormMode) {
+      const positionTemp = await floorPositionService.findPosition(newFloor2.id as number, 0, 0);
+      expect(positionTemp).not.toBeNull();
+    }
 
     // The original floor's name is now gone, but the printer has not been removed from it
     expect(floors.find((f) => f.name === "Floor1_DifferentName")).toBeUndefined();

--- a/test/application/yaml-service.test.ts
+++ b/test/application/yaml-service.test.ts
@@ -132,4 +132,18 @@ describe(YamlService.name, () => {
       expect(printerGroupService).toBeNull();
     }
   });
+
+  it("should import floor over existing floor", async () => {
+    const defaultFloor = await floorService.create({
+      name: "Floor1",
+      floor: 15,
+      printers: [],
+    });
+    await printerCache.loadCache();
+
+    const buffer = readFileSync(join(__dirname, "./test-data/export-fdm-monster-1.5.2-mongodb-simple.yaml"));
+    await yamlService.importPrintersAndFloors(buffer.toString());
+    const floors = await floorService.list();
+    expect(floors).toHaveLength(2);
+  });
 });

--- a/test/setup-after-env.ts
+++ b/test/setup-after-env.ts
@@ -1,8 +1,17 @@
 import { getExpectExtensions } from "./extensions";
 import { isSqliteModeTest } from "./typeorm.manager";
 import { closeDatabase, connect } from "./mongo-memory.handler";
-
+const jestConsole = console;
 expect.extend(getExpectExtensions());
+
+// https://github.com/jestjs/jest/issues/10322
+beforeEach(() => {
+  global.console = require("console");
+});
+
+afterEach(() => {
+  global.console = jestConsole;
+});
 
 beforeAll(async () => {
   if (!isSqliteModeTest()) {


### PR DESCRIPTION
# Description

- [x] Write a test to see reproduce floor import failure
- [x] Fix bug printer positions not being updated on existing floor
- [x] Fix floor controller test failing in CI/CD
- [x] Revert & fix: sqlite import will now clear out unwanted positions for consistency (printerId comparison)
- [x] Test real import
- [x] Investigate floors are still empty after import
- [x] Investigate printers cached twice after import (fixed after server restart, not after page reload/API call)
- [x] Revert to floorStore.loadStore to ensure cache is refreshed
- [x] Investigate why floor positions are empty in cached floors (frontend/socketio)
- [x] Test to reproduce enabled flag not importing properly
- [x] Create issue that if printer exists on floor with different level, a validation error will be thrown late into import process. This will cause a semi-working import. Consider if its better to wipe all floors before import in v1.7 https://github.com/fdm-monster/fdm-monster/issues/3100
- [x] Release notes
