### PR TITLE
fix: prevent floor position database constraints by removing printer position from any floor beforehand

### DIFF
--- a/src/services/orm/floor.service.ts
+++ b/src/services/orm/floor.service.ts
@@ -136,7 +136,7 @@ export class FloorService
     // Validation only
     await this.get(floorId, true);
 
-    const position = await this.floorPositionService.findPrinterPositionOnFloor(floorId, positionDto.printerId as SqliteIdType);
+    const position = await this.floorPositionService.findPrinterPosition(positionDto.printerId as SqliteIdType);
     // Optimization if position is in desired state already
     if (
       position &&


### PR DESCRIPTION
Without this quick bugfix, import might fail due to printers already existing on a different floor. It's an edge case and its a regression, so this fix ensures that we can wait with issue https://github.com/fdm-monster/fdm-monster/issues/3100