### PR TITLE
Provide OctoFarm compose for quick tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ coverage
 
 installations/other/octoprint-virtual/default1.9.0/op1.9.0-backup/
 installations/other/octoprint-virtual/default1.9.0/octoprint/octoprint/
+installations/other/octofarm/OctoFarm
+installations/other/octofarm/mongodb-data
 **/*.sqlite
 
 *.sqlite-wal

--- a/installations/other/octofarm/docker-compose.yml
+++ b/installations/other/octofarm/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.4'
+
+services:
+  mongodb:
+    image: mongo:latest
+    container_name: mongodb
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: pass1234
+      MONGO_INITDB_DATABASE: octofarm
+    ports:
+      - "21111:27017"
+    volumes:
+      - ./mongodb-data:/data
+    restart: unless-stopped
+
+  octofarm:
+    container_name: octofarm
+    # choose octofarm/octofarm:1.8.0-beta.11
+    image: octofarm/octofarm:latest
+    restart: unless-stopped
+    links:
+      - mongodb
+    ports:
+      - 4111:4111 # port of SYSTEM : port of CONTAINER
+    environment:
+      - OCTOFARM_PORT=4111
+      - MONGO=mongodb://root:pass1234@host.docker.internal:21111/octofarm?authSource=admin
+    volumes:
+      - ./OctoFarm/logs:/app/logs
+      - ./OctoFarm/scripts:/app/scripts
+      - ./OctoFarm/images:/app/images

--- a/src/controllers/printer.controller.ts
+++ b/src/controllers/printer.controller.ts
@@ -145,9 +145,6 @@ export class PrinterController {
     res.send({});
   }
 
-  /**
-   * Pauses the current job
-   */
   async pausePrintJob(req: Request, res: Response) {
     const { printerLogin } = getScopedPrinter(req);
 
@@ -156,9 +153,6 @@ export class PrinterController {
     res.send({});
   }
 
-  /**
-   * Pauses the current job
-   */
   async resumePrintJob(req: Request, res: Response) {
     const { printerLogin } = getScopedPrinter(req);
 


### PR DESCRIPTION
# Description

During the work on https://github.com/fdm-monster/fdm-monster/issues/3073 the issue was mostly on client side https://github.com/fdm-monster/fdm-monster-client/pull/1186

This PR simply adds an OctoFarm docker-compose file for reference and quick testing.