### PR TITLE
fix: deleting a printer position by printer id should not clear a different position

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -8,6 +8,7 @@ Fixes:
 
 - YAML Import would fail updating properly an existing floor by floor level
 - YAML Import has issues updating a floor, printers positions are not consistently are updated.
-- YAML Import converted printer IDs to string, causing the printers to not show up on the printer grid until server restart. The import was done correctly on database level. 
+- YAML Import converted printer IDs to string, causing the printers to not show up on the printer grid until server restart. The import was done correctly on database level.
+- Deleting a printer would remove the position of another printer, the removal was referring to the wrong position.
 
 

--- a/src/services/orm/floor-position.service.ts
+++ b/src/services/orm/floor-position.service.ts
@@ -27,7 +27,7 @@ export class FloorPositionService extends BaseService(FloorPosition, PositionDto
   }
 
   deletePrinterPositionsByPrinterId(printerId: SqliteIdType) {
-    return this.repository.delete({ id: printerId });
+    return this.repository.delete({ printerId });
   }
 
   findPrinterPositionOnFloor(floorId: SqliteIdType, printerId: SqliteIdType) {


### PR DESCRIPTION
This PR fixes the problem described in #3103 