### PR TITLE
fix: first time setup should not be completed in demo mode

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -55,8 +55,12 @@ export class AuthController {
   async getLoginRequired(req: Request, res: Response) {
     const loginRequired = await this.settingsStore.getLoginRequired();
     const registration = this.settingsStore.isRegistrationEnabled();
-    const wizardState = this.settingsStore.getWizardState();
+    let wizardState = this.settingsStore.getWizardState();
     const isDemoMode = this.configService.isDemoMode();
+    wizardState = {
+      ...wizardState,
+      wizardCompleted: isDemoMode ? false : wizardState.wizardCompleted,
+    };
     res.send({ loginRequired, registration, wizardState, isDemoMode });
   }
 

--- a/src/controllers/server-public.controller.ts
+++ b/src/controllers/server-public.controller.ts
@@ -1,4 +1,4 @@
-import { createController, inject } from "awilix-express";
+import { createController } from "awilix-express";
 import { AppConstants } from "@/server.constants";
 import { isNode, isNodemon, isPm2 } from "@/utils/env.utils";
 import { authenticate, authorizePermission } from "@/middleware/authenticate";

--- a/src/middleware/global.middleware.ts
+++ b/src/middleware/global.middleware.ts
@@ -4,13 +4,22 @@ import { ForbiddenError } from "@/exceptions/runtime.exceptions";
 import { NextFunction, Request, Response } from "express";
 import { SettingsStore } from "@/state/settings.store";
 import { ILoggerFactory } from "@/handlers/logger-factory";
+import { IConfigService } from "@/services/core/config.service";
 
 export const validateWizardCompleted = inject(
-  ({ settingsStore, loggerFactory }: { settingsStore: SettingsStore; loggerFactory: ILoggerFactory }) =>
+  ({
+      configService,
+      settingsStore,
+      loggerFactory,
+    }: {
+      configService: IConfigService;
+      settingsStore: SettingsStore;
+      loggerFactory: ILoggerFactory;
+    }) =>
     async (req: Request, res: Response, next: NextFunction) => {
       const logger = loggerFactory(validateWhitelistedIp.name);
-      const serverSettings = settingsStore.getSettings();
-      if (!!settingsStore.getWizardSettings()?.wizardCompleted) {
+      const isDemoMode = configService.isDemoMode();
+      if (isDemoMode || !!settingsStore.getWizardSettings()?.wizardCompleted) {
         next();
         return;
       }

--- a/src/tasks/boot.task.ts
+++ b/src/tasks/boot.task.ts
@@ -210,8 +210,6 @@ export class BootTask {
       await this.userService.setUserRoleIds(demoUserId, [adminRole.id]);
       this.logger.log("Updated demo account");
     }
-
-    await this.settingsStore.setWizardCompleted(1);
   }
 
   async createConnection() {


### PR DESCRIPTION
# Description

When first time setup has not been completed as normal, disabling demo mode can cause the server to be in illegal state: no admin/root user, but also no way to create one.

This PR fixes the demo mode: the first time setting is not touched, and avoided in middleware when in demo mode.