### PR TITLE
Feat/2042 handle GitHub api limits in the software upgrade UI

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,11 +1,17 @@
 # FDM Monster 13/04/2024 1.6.1
 
-Changes:
+## Features:
+
+- Add GitHub Rate Limit API endpoint GET /api/server/github-rate-limit
+- Add feature flag for GitHub Rate Limit API endpoint
+
+## Changes:
 
 - Dropped the permission check on /api/features as it made no sense
-- Anonimized logging 
+- Anonimized logging
+- Handle OctoKit errors (ExternalServiceErrors) differently than OctoPrint errors (different HttpClient implementations). Refer to the new rate limit API and feature flag.
 
-Fixes:
+## Fixes:
 
 - YAML Import would fail updating properly an existing floor by floor level
 - YAML Import has issues updating a floor, printers positions are not consistently are updated.

--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -8,7 +8,7 @@
 ## Changes:
 
 - Dropped the permission check on /api/features as it made no sense
-- Anonimized logging
+- Anonymized logging
 - Handle OctoKit errors (ExternalServiceErrors) differently than OctoPrint errors (different HttpClient implementations). Refer to the new rate limit API and feature flag.
 
 ## Fixes:

--- a/src/controllers/server-private.controller.ts
+++ b/src/controllers/server-private.controller.ts
@@ -17,12 +17,14 @@ import { MulterService } from "@/services/core/multer.service";
 import { LogDumpService } from "@/services/core/logs-manager.service";
 import { Request, Response } from "express";
 import { demoUserNotAllowed } from "@/middleware/demo.middleware";
+import { GithubService } from "@/services/core/github.service";
 
 export class ServerPrivateController {
   clientBundleService: ClientBundleService;
   printerCache: PrinterCache;
   printerService: PrinterService;
   printerSocketStore: PrinterSocketStore;
+  githubService: GithubService;
   yamlService: YamlService;
   multerService: MulterService;
   logDumpService: LogDumpService;
@@ -36,6 +38,7 @@ export class ServerPrivateController {
     printerCache,
     printerService,
     clientBundleService,
+    githubService,
     logDumpService,
     printerSocketStore,
     yamlService,
@@ -46,6 +49,7 @@ export class ServerPrivateController {
     printerCache: PrinterCache;
     printerService: PrinterService;
     clientBundleService: ClientBundleService;
+    githubService: GithubService;
     logDumpService: LogDumpService;
     printerSocketStore: PrinterSocketStore;
     yamlService: YamlService;
@@ -54,6 +58,7 @@ export class ServerPrivateController {
     this.serverReleaseService = serverReleaseService;
     this.serverUpdateService = serverUpdateService;
     this.clientBundleService = clientBundleService;
+    this.githubService = githubService;
     this.logDumpService = logDumpService;
     this.printerSocketStore = printerSocketStore;
     this.printerCache = printerCache;
@@ -110,6 +115,11 @@ export class ServerPrivateController {
       targetVersion: willExecute.targetVersion,
       reason: willExecute?.reason,
     });
+  }
+
+  async getGithubRateLimit(req: Request, res: Response) {
+    const rateLimitResponse = await this.githubService.getRateLimit();
+    res.send(rateLimitResponse.data);
   }
 
   async getReleaseStateInfo(req: Request, res: Response) {
@@ -178,6 +188,7 @@ export default createController(ServerPrivateController)
   .before([authenticate(), authorizeRoles([ROLES.ADMIN]), demoUserNotAllowed])
   .get("/", "getReleaseStateInfo")
   .get("/client-releases", "getClientReleases")
+  .get("/github-rate-limit", "getGithubRateLimit")
   .post("/update-client-bundle-github", "updateClientBundleGithub")
   .post("/export-printers-floors-yaml", "exportPrintersAndFloorsYaml")
   .post("/import-printers-floors-yaml", "importPrintersAndFloorsYaml")

--- a/src/controllers/server-public.controller.ts
+++ b/src/controllers/server-public.controller.ts
@@ -119,6 +119,10 @@ export class ServerPublicController {
         available: true,
         version: 1,
       },
+      githubRateLimitApi: {
+        available: true,
+        version: 1,
+      },
     });
   }
 

--- a/src/exceptions/runtime.exceptions.ts
+++ b/src/exceptions/runtime.exceptions.ts
@@ -64,11 +64,13 @@ export class ValidationException extends Error {
 
 export class ExternalServiceError extends Error {
   error: any;
+  serviceType?: string;
 
-  constructor(responseObject: any) {
+  constructor(responseObject: any, serviceType?: string) {
     super(JSON.stringify(responseObject));
     this.name = ExternalServiceError.name;
     this.error = responseObject;
+    this.serviceType = serviceType;
   }
 }
 

--- a/src/services/core/client-bundle.service.ts
+++ b/src/services/core/client-bundle.service.ts
@@ -11,7 +11,8 @@ import { LoggerService } from "@/handlers/logger";
 import { ILoggerFactory } from "@/handlers/logger-factory";
 import { compare } from "semver";
 import { errorSummary } from "@/utils/error.utils";
-import { ExternalServiceError, NotFoundException } from "@/exceptions/runtime.exceptions";
+import { ExternalServiceError, InternalServerException, NotFoundException } from "@/exceptions/runtime.exceptions";
+import { RequestError } from "octokit";
 
 export class ClientBundleService {
   githubService: GithubService;
@@ -57,8 +58,11 @@ export class ClientBundleService {
         releases: result.data,
       };
     } catch (e) {
-      this.logger.error(`Github OctoKit error ${errorSummary(e)}`);
-      throw new ExternalServiceError(e, "GitHub");
+      if (e instanceof RequestError) {
+        this.logger.error(`Github OctoKit error ${errorSummary(e)}`);
+        throw new ExternalServiceError({ error: e.message }, "GitHub");
+      }
+      throw new InternalServerException("Something went wrong with the request to Github");
     }
   }
 

--- a/src/services/core/client-bundle.service.ts
+++ b/src/services/core/client-bundle.service.ts
@@ -60,7 +60,7 @@ export class ClientBundleService {
     } catch (e) {
       if (e instanceof RequestError) {
         this.logger.error(`Github OctoKit error ${errorSummary(e)}`);
-        throw new ExternalServiceError({ error: e.message }, "GitHub");
+        throw new ExternalServiceError({ error: "Github OctoKit error: " + e.message }, "GitHub");
       }
       throw new InternalServerException("Something went wrong with the request to Github");
     }

--- a/src/services/core/client-bundle.service.ts
+++ b/src/services/core/client-bundle.service.ts
@@ -58,7 +58,7 @@ export class ClientBundleService {
       };
     } catch (e) {
       this.logger.error(`Github OctoKit error ${errorSummary(e)}`);
-      throw new ExternalServiceError(e);
+      throw new ExternalServiceError(e, "GitHub");
     }
   }
 

--- a/src/services/core/github.service.ts
+++ b/src/services/core/github.service.ts
@@ -17,6 +17,10 @@ export class GithubService {
     return result?.type === "token";
   }
 
+  async getRateLimit() {
+    return this.octokitService.rest.rateLimit.get();
+  }
+
   async getLatestRelease(owner: string, repo: string) {
     try {
       return await this.octokitService.rest.repos.getLatestRelease({

--- a/src/services/octoprint/octoprint-api.service.ts
+++ b/src/services/octoprint/octoprint-api.service.ts
@@ -275,13 +275,16 @@ export class OctoPrintApiService extends OctoPrintRoutes {
       } catch {
         data = e.response?.body;
       }
-      throw new ExternalServiceError({
-        error: e.message,
-        statusCode: e.response?.statusCode,
-        data,
-        success: false,
-        stack: e.stack,
-      });
+      throw new ExternalServiceError(
+        {
+          error: e.message,
+          statusCode: e.response?.statusCode,
+          data,
+          success: false,
+          stack: e.stack,
+        },
+        "OctoPrint"
+      );
     }
   }
 
@@ -387,13 +390,16 @@ export class OctoPrintApiService extends OctoPrintRoutes {
       } catch {
         data = e.response?.body;
       }
-      throw new ExternalServiceError({
-        error: e.message,
-        statusCode: e.response?.statusCode,
-        data,
-        success: false,
-        stack: e.stack,
-      });
+      throw new ExternalServiceError(
+        {
+          error: e.message,
+          statusCode: e.response?.statusCode,
+          data,
+          success: false,
+          stack: e.stack,
+        },
+        "OctoPrint"
+      );
     }
   }
 
@@ -496,12 +502,15 @@ export class OctoPrintApiService extends OctoPrintRoutes {
         ...options,
       })
       .catch((e) => {
-        throw new ExternalServiceError({
-          error: e.message,
-          statusCode: e.response?.statusCode,
-          success: false,
-          stack: e.stack,
-        });
+        throw new ExternalServiceError(
+          {
+            error: e.message,
+            statusCode: e.response?.statusCode,
+            success: false,
+            stack: e.stack,
+          },
+          "OctoPrint"
+        );
       });
     return response.data;
   }
@@ -519,12 +528,15 @@ export class OctoPrintApiService extends OctoPrintRoutes {
         },
       })
       .catch((e) => {
-        throw new ExternalServiceError({
-          error: e.message,
-          statusCode: e.response?.statusCode,
-          success: false,
-          stack: e.stack,
-        });
+        throw new ExternalServiceError(
+          {
+            error: e.message,
+            statusCode: e.response?.statusCode,
+            success: false,
+            stack: e.stack,
+          },
+          "OctoPrint"
+        );
       });
     return response?.data;
   }

--- a/src/services/octoprint/octoprint-sockio.adapter.ts
+++ b/src/services/octoprint/octoprint-sockio.adapter.ts
@@ -168,13 +168,13 @@ export class OctoPrintSockIoAdapter extends WebsocketAdapter {
         if (r.name === "_api") {
           this.setApiState("globalKey");
           this.setSocketState("aborted");
-          throw new ExternalServiceError("Global API Key detected, aborting socket connection");
+          throw new ExternalServiceError("Global API Key detected, aborting socket connection", "OctoPrint");
         } else if (r.needs?.group[0] === "guests") {
           this.logger.warn("Detected group guests in OctoPrint login response, marking as unauthorized");
           // This doesn't occur often (instead a 400 with CSRF failed is returned)
           this.setApiState("authFail");
           this.setSocketState("aborted");
-          throw new ExternalServiceError("Guest group detected, authentication failed, aborting socket connection");
+          throw new ExternalServiceError("Guest group detected, authentication failed, aborting socket connection", "OctoPrint");
         }
         this.setApiState("responding");
         this.setSocketState("opening");
@@ -190,7 +190,7 @@ export class OctoPrintSockIoAdapter extends WebsocketAdapter {
           if (e?.response?.status === 403) {
             this.setApiState("authFail");
             this.setSocketState("aborted");
-            throw new ExternalServiceError(e);
+            throw new ExternalServiceError(e, "OctoPrint");
           }
           // We make an exception for such a problem concerning log anonymization
           this.logger.error(`Printer (${this.printerId}) network or transport error, marking it as unreachable; ${e}`);


### PR DESCRIPTION
Server PR accompanying https://github.com/fdm-monster/fdm-monster-client/pull/1192

# Description
See the UI changes here
![image](https://github.com/fdm-monster/fdm-monster/assets/6005355/8ab88a53-6b0e-467f-b1e9-d10967b4c681)

These are the UI change:
- [x] The GitHub API limit will be tested and shown in the software upgrade UI before attempting to load releases
- [x] The settings toolbars have been refactored: consistent icon, simpler titles and dark color
- [x] The settings navigation has been re-ordered and given separations
- [x] Use a feature flag to determine if server can provide github rate limit information

The server improvements:
- [x] Handle OctoKit errors (ExternalServiceErrors) differently than OctoPrint errors (different HttpClient implementations)
- [x] Add Github Rate Limit API endpoint GET /api/server/github-rate-limit
- [x] Add feature flag for Github Rate Limit API endpoint