### PR TITLE
Feat/2196 validate printer url before update

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -10,6 +10,7 @@
 - Dropped the permission check on /api/features as it made no sense
 - Anonymized logging
 - Handle OctoKit errors (ExternalServiceErrors) differently than OctoPrint errors (different HttpClient implementations). Refer to the new rate limit API and feature flag.
+- Set default API call timeout to 10000 milliseconds (to call OctoPrint APIs)
 
 ## Fixes:
 
@@ -20,3 +21,4 @@
 - Setting demo mode will not set wizard to be completed: first time setup will be required after setting demo mode to false.
 - Settings: incorrect file clean shape would not throw any validation errors (SQLite only). Validation has been added for file clean on API level.
 - Settings: make all settings API endpoints stricter by adding validation on API level. Patching is not possible anymore.
+- Printer: add OctoPrint URL validation which parses the error with user friendly errors as result

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "vue"
   ],
   "dependencies": {
-    "@fdm-monster/client": "1.5.12",
+    "@fdm-monster/client": "1.5.13",
     "@influxdata/influxdb-client": "1.33.2",
     "@octokit/plugin-throttling": "8.2.0",
     "@sentry/node": "7.111.0",

--- a/src/constants/server-settings.constants.ts
+++ b/src/constants/server-settings.constants.ts
@@ -56,7 +56,7 @@ export const getDefaultFrontendSettings = (): FrontendSettingsDto => ({
 
 export const timeoutSettingKey = "timeout";
 export const getDefaultTimeout = (): TimeoutSettingsDto => ({
-  apiTimeout: 1000,
+  apiTimeout: 10000,
 });
 
 export const fileCleanSettingKey = "printerFileClean";

--- a/src/controllers/printer.controller.ts
+++ b/src/controllers/printer.controller.ts
@@ -180,7 +180,7 @@ export class PrinterController {
   async create(req: Request, res: Response) {
     const newPrinter = req.body;
 
-    if (!req.query.skipTest) {
+    if (req.query.forceSave !== "true") {
       await this.testOctoPrintConnection(newPrinter);
     }
 
@@ -197,7 +197,7 @@ export class PrinterController {
     const { currentPrinterId } = getScopedPrinter(req);
     const updatedPrinter = req.body;
 
-    if (!req.query.skipTest) {
+    if (req.query.forceSave !== "true") {
       await this.testOctoPrintConnection(updatedPrinter);
     }
     await this.printerService.update(currentPrinterId, updatedPrinter);
@@ -213,7 +213,7 @@ export class PrinterController {
     const { currentPrinterId } = getScopedPrinter(req);
     const inputData = await validateMiddleware(req, updatePrinterConnectionSettingRules);
 
-    if (!req.query.skipTest) {
+    if (req.query.forceSave !== "true") {
       await this.testOctoPrintConnection(inputData);
     }
 

--- a/src/exceptions/failed-dependency.exception.ts
+++ b/src/exceptions/failed-dependency.exception.ts
@@ -1,0 +1,8 @@
+export class FailedDependencyException extends Error {
+  serviceCode?: number;
+  constructor(message: string, serviceCode?: number) {
+    super(message);
+    this.name = FailedDependencyException.name;
+    this.serviceCode = serviceCode;
+  }
+}

--- a/src/middleware/exception.filter.ts
+++ b/src/middleware/exception.filter.ts
@@ -13,6 +13,7 @@ import { NextFunction, Request, Response } from "express";
 import { HttpStatusCode } from "@/constants/http-status-codes.constants";
 import { AxiosError } from "axios";
 import { EntityNotFoundError } from "typeorm";
+import { FailedDependencyException } from "@/exceptions/failed-dependency.exception";
 
 export function exceptionFilter(err: any | AxiosError, req: Request, res: Response, next: NextFunction) {
   const isTest = process.env.NODE_ENV === AppConstants.defaultTestEnv;
@@ -57,6 +58,14 @@ export function exceptionFilter(err: any | AxiosError, req: Request, res: Respon
       error: "API could not accept this input",
       type: err.name,
       errors: err.errors,
+    });
+  }
+  if (err instanceof FailedDependencyException) {
+    const code = 424;
+    return res.status(code).send({
+      error: err.message,
+      serviceCode: err.serviceCode,
+      type: err.name,
     });
   }
   if (err instanceof InternalServerException) {

--- a/src/server.constants.ts
+++ b/src/server.constants.ts
@@ -68,7 +68,7 @@ export const AppConstants = {
   orgName: "fdm-monster",
   // Wizard version changes will trigger a re-run of the wizard
   currentWizardVersion: 1,
-  defaultClientMinimum: "1.5.12",
+  defaultClientMinimum: "1.5.13",
 
   influxUrl: "INFLUX_URL",
   influxToken: "INFLUX_TOKEN",

--- a/src/services/octoprint/octoprint-api.routes.ts
+++ b/src/services/octoprint/octoprint-api.routes.ts
@@ -9,6 +9,8 @@ import { ITimeoutSettings } from "@/models/Settings";
 export class OctoPrintRoutes {
   octoPrintBase = "/";
   apiBase = `${this.octoPrintBase}api`;
+  apiVersion = `${this.apiBase}/version`;
+  apiServer = `${this.apiBase}/server`;
   apiSettingsPart = `${this.apiBase}/settings`;
   apiFiles = `${this.apiBase}/files`;
   apiFilesLocation = `${this.apiFiles}/local`;

--- a/src/services/octoprint/octoprint-api.service.ts
+++ b/src/services/octoprint/octoprint-api.service.ts
@@ -14,7 +14,6 @@ import { SettingsStore } from "@/state/settings.store";
 import { ILoggerFactory } from "@/handlers/logger-factory";
 import { OctoprintRawFilesResponseDto } from "@/services/octoprint/models/octoprint-file.dto";
 import { normalizePrinterFile } from "@/services/octoprint/utils/file.utils";
-import { errorSummary } from "@/utils/error.utils";
 import { CurrentStateDto } from "@/services/octoprint/dto/websocket-output/current-message.dto";
 import { ConnectionDto } from "@/services/octoprint/dto/connection.dto";
 import { captureException } from "@sentry/node";
@@ -41,6 +40,18 @@ export class OctoPrintApiService extends OctoPrintRoutes {
     this.axiosClient = httpClient;
     this.eventEmitter2 = eventEmitter2;
     this.logger = loggerFactory(OctoPrintApiService.name);
+  }
+
+  async getVersion(login: LoginDto, timeout?: number) {
+    const { url, options } = this.prepareRequest(login, this.apiVersion, timeout);
+    const response = await this.axiosClient.get(url, options);
+    return response?.data;
+  }
+
+  async getServer(login: LoginDto) {
+    const { url, options } = this.prepareRequest(login, this.apiServer);
+    const response = await this.axiosClient.get(url, options);
+    return response?.data;
   }
 
   async login(login: LoginDto) {

--- a/src/state/test-printer-socket.store.ts
+++ b/src/state/test-printer-socket.store.ts
@@ -34,12 +34,7 @@ export class TestPrinterSocketStore {
     this.logger = loggerFactory(TestPrinterSocketStore.name);
   }
 
-  /**
-   * Sets up/recreates a printer to be tested quickly by running the standard checks
-   * @param printer
-   * @returns {Promise<*>}
-   */
-  async setupTestPrinter(printer) {
+  async setupTestPrinter(printer): Promise<void> {
     if (this.testSocket) {
       this.testSocket.close();
       this.testSocket = null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1054,10 +1054,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fdm-monster/client@npm:1.5.12":
-  version: 1.5.12
-  resolution: "@fdm-monster/client@npm:1.5.12"
-  checksum: 10c0/5b02450825f8c68804aec3d66590a8db7234a6b2efb9bbbcfdae268777a7841ac51b22558a7ef6b91a8dc941e7688789fa69d81d8e803776ed118bee5a066631
+"@fdm-monster/client@npm:1.5.13":
+  version: 1.5.13
+  resolution: "@fdm-monster/client@npm:1.5.13"
+  checksum: 10c0/06cd7b0a5d09d9ca71fcda12065f5992e98b7d0a819269f0be15f6d77f3953a8e896eab9a38310e9848ce3bbd64098f7372f2d69377a71e946da1cbc2734a857
   languageName: node
   linkType: hard
 
@@ -1065,7 +1065,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fdm-monster/server@workspace:."
   dependencies:
-    "@fdm-monster/client": "npm:1.5.12"
+    "@fdm-monster/client": "npm:1.5.13"
     "@influxdata/influxdb-client": "npm:1.33.2"
     "@lcov-viewer/cli": "npm:1.3.0"
     "@lcov-viewer/istanbul-report": "npm:1.4.0"


### PR DESCRIPTION
# Description

The printer create and update API will test the printer, except when `forceSave` is provided as a query argument.
The API can now return these error codes: 200/204, 400, 424, 500. The 424 code is a new code for representing OctoPrint failures.

Also, the API timeout has been set to 10000 msec by default.

- [x] Force new client update
- [x] Release notes

