### PR TITLE
fix: add .yarn folder to release zip asset on github

### DIFF
--- a/.github/workflows/nodejs_release.yml
+++ b/.github/workflows/nodejs_release.yml
@@ -75,7 +75,7 @@ jobs:
         uses: montudor/action-zip@v1.0.0
         with:
           args: | 
-            zip -qq -r dist-server-${{ env.RELEASE_TAG }}.zip dist .env.template package.json yarn.lock .yarnrc.yml migrate-mongo-config.js tsconfig.json README.md LICENSE CODE_OF_CONDUCT.md CONTRIBUTING.md SECURITY.md .swcrc .dockerignore            
+            zip -qq -r dist-server-${{ env.RELEASE_TAG }}.zip dist .env.template package.json .yarn yarn.lock .yarnrc.yml migrate-mongo-config.js tsconfig.json README.md LICENSE CODE_OF_CONDUCT.md CONTRIBUTING.md SECURITY.md .swcrc .dockerignore            
 
       - name: Upload server bundle zip
         uses: actions/upload-release-asset@v1

--- a/.npmignore
+++ b/.npmignore
@@ -54,4 +54,5 @@ test
 !migrate-mongo-config.js
 !package.json
 !yarn.lock
+!.yarn
 !tsconfig.json

--- a/package.json
+++ b/package.json
@@ -154,11 +154,12 @@
     "verbose": false,
     "ignore": [
       ".github/*",
+      "database/*",
       "docs/*",
+      "docker/*",
+      "installations/*",
       "media",
-      "test/*",
-      "views/*",
-      "docker/*"
+      "test/*"
     ],
     "delay": 100
   },


### PR DESCRIPTION
# Description

The folder `.yarn` was missing which is crucial in combination with `.yarnrc.yml`. Either the rc file has to not specify `yarnPath` or the yarnPath needs to be valid.