### PR TITLE
fix: role entity name column should be unique [ ON HOLD till 1.7.0 ] 

### DIFF
--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -19,6 +19,7 @@ import { PrinterGroup } from "@/entities/printer-group.entity";
 import { Group } from "@/entities/group.entity";
 import { PrinterGroup1707494762198 } from "@/migrations/1707494762198-PrinterGroup";
 import { ChangePrintCompletionDeletePrinterCascade1708465930665 } from "@/migrations/1708465930665-ChangePrintCompletionDeletePrinterCascade";
+import { ChangeRoleNameUnique1713300747465 } from "@/migrations/1713300747465-ChangeRoleNameUnique";
 
 dotenv.config({
   path: join(superRootPath(), ".env"),
@@ -53,6 +54,11 @@ export const AppDataSource = new DataSource({
     Group,
     PrinterGroup,
   ],
-  migrations: [InitSqlite1706829146617, PrinterGroup1707494762198, ChangePrintCompletionDeletePrinterCascade1708465930665],
+  migrations: [
+    InitSqlite1706829146617,
+    PrinterGroup1707494762198,
+    ChangePrintCompletionDeletePrinterCascade1708465930665,
+    ChangeRoleNameUnique1713300747465,
+  ],
   subscribers: [],
 });

--- a/src/entities/role.entity.ts
+++ b/src/entities/role.entity.ts
@@ -7,7 +7,9 @@ export class Role extends BaseEntity {
   @PrimaryGeneratedColumn()
   id!: number;
 
-  @Column()
+  @Column({
+    unique: true,
+  })
   name!: string;
 
   @OneToMany(() => UserRole, (ur) => ur.role, { eager: false })

--- a/src/migrations/1713300747465-ChangeRoleNameUnique.ts
+++ b/src/migrations/1713300747465-ChangeRoleNameUnique.ts
@@ -1,0 +1,96 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ChangeRoleNameUnique1713300747465 implements MigrationInterface {
+  name = "ChangeRoleNameUnique1713300747465";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DELETE FROM role
+      WHERE ID NOT IN (
+          SELECT MIN(ID)
+          FROM role
+          GROUP BY name
+      );
+    `);
+    await queryRunner.query(`
+            CREATE TABLE "temporary_role" (
+                "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+                "name" varchar NOT NULL
+            )
+        `);
+    await queryRunner.query(`
+            INSERT INTO "temporary_role"("id", "name")
+            SELECT "id",
+                "name"
+            FROM "role"
+        `);
+    await queryRunner.query(`
+            DROP TABLE "role"
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "temporary_role"
+                RENAME TO "role"
+        `);
+    await queryRunner.query(`
+            CREATE TABLE "temporary_role" (
+                "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+                "name" varchar NOT NULL,
+                CONSTRAINT "UQ_d430b72bf1eaebce7f87068a431" UNIQUE ("name")
+            )
+        `);
+    await queryRunner.query(`
+            INSERT INTO "temporary_role"("id", "name")
+            SELECT "id",
+                "name"
+            FROM "role"
+        `);
+    await queryRunner.query(`
+            DROP TABLE "role"
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "temporary_role"
+                RENAME TO "role"
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            ALTER TABLE "role"
+                RENAME TO "temporary_role"
+        `);
+    await queryRunner.query(`
+            CREATE TABLE "role" (
+                "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+                "name" varchar NOT NULL
+            )
+        `);
+    await queryRunner.query(`
+            INSERT INTO "role"("id", "name")
+            SELECT "id",
+                "name"
+            FROM "temporary_role"
+        `);
+    await queryRunner.query(`
+            DROP TABLE "temporary_role"
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "role"
+                RENAME TO "temporary_role"
+        `);
+    await queryRunner.query(`
+            CREATE TABLE "role" (
+                "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+                "name" varchar NOT NULL
+            )
+        `);
+    await queryRunner.query(`
+            INSERT INTO "role"("id", "name")
+            SELECT "id",
+                "name"
+            FROM "temporary_role"
+        `);
+    await queryRunner.query(`
+            DROP TABLE "temporary_role"
+        `);
+  }
+}


### PR DESCRIPTION
# Description

Tackles the item in #3080 by adding a migration.
This migration will remove all roles which are duplicate and then apply an uniqueness index to the name column of the role table.

Breaking change without direct benefit. Deferring till 1.7.0.