### PR TITLE
Support Moonraker and therefore Klipper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ installations/ansible/inventory.cfg
 !.yarn/versions
 
 requests/http-client.private.env.json
+
+*.sqlite-journal

--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,5 +1,7 @@
 # Develop
 
+# FDM Monster 01/11/2024 1.6.4
+
 ## Chore:
 
 - Workflows: upgrade github actions to node 20
@@ -8,7 +10,9 @@
 ## Features:
 
 - Setting: add experimental moonraker support setting to model, validation and API endpoints
-- Setting: expose typeorm setting and adjust test
+- Setting: expose experimental typeorm setting and adjust test
+- Apply moonraker setting to middleware, and disable moonraker printers on disabling feature
+- Enable moonraker printerType support
 
 ## Fixes:
 
@@ -16,7 +20,7 @@
 - Printer file clean could contain extra data, skim those props off
 - Batch reprint selection: wrong status is concluded when reprint preparation is called (OctoPrint is not available, instead of no job is selected)
 
-# FDM Monster 14/06/2024 1.6.4
+# FDM Monster 12/26/2024 1.6.4
 
 ## Changes:
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "author": "David Zwart",
   "license": "AGPL-3.0-or-later",
-  "version": "1.6.4",
+  "version": "1.7.0",
   "bin": {
     "fdm-monster": "dist/index.js",
     "fdmm": "dist/index.js"
@@ -53,7 +53,7 @@
     "vue"
   ],
   "dependencies": {
-    "@fdm-monster/client": "1.6.4",
+    "@fdm-monster/client": "1.6.5",
     "@fdm-monster/client-next": "0.0.3",
     "@influxdata/influxdb-client": "1.35.0",
     "@octokit/plugin-throttling": "8.2.0",

--- a/src/controllers/server-public.controller.ts
+++ b/src/controllers/server-public.controller.ts
@@ -127,7 +127,7 @@ export class ServerPublicController {
         available: true,
         version: 1,
         subFeatures: {
-          types: ["octoprint"],
+          types: ["octoprint", "klipper"],
         },
       },
     });

--- a/src/controllers/server-public.controller.ts
+++ b/src/controllers/server-public.controller.ts
@@ -66,6 +66,8 @@ export class ServerPublicController {
   }
 
   getFeatures(req: Request, res: Response) {
+    const serverSettings = this.settingsStore.getServerSettings();
+    const moonrakerEnabled = serverSettings.experimentalMoonrakerSupport;
     res.send({
       batchReprintCalls: {
         available: true,
@@ -127,7 +129,7 @@ export class ServerPublicController {
         available: true,
         version: 1,
         subFeatures: {
-          types: ["octoprint", "klipper"],
+          types: moonrakerEnabled ? ["octoprint", "klipper"] : ["octoprint"],
         },
       },
     });

--- a/src/controllers/validation/printer-controller.validation.ts
+++ b/src/controllers/validation/printer-controller.validation.ts
@@ -10,7 +10,7 @@ export const feedRateRules = {
 };
 
 export const testPrinterApiRules = {
-  printerType: `required|integer|in:${OctoprintType}`,
+  printerType: `required|integer|in:${OctoprintType},${MoonrakerType}`,
   apiKey: `required|length:${UUID_LENGTH},${UUID_LENGTH}|alphaNumeric`,
   printerURL: "required|httpurl",
 };
@@ -24,7 +24,7 @@ export const updatePrinterEnabledRule = {
 };
 
 export const updatePrinterConnectionSettingRules = {
-  printerType: `required|integer|in:${OctoprintType}`,
+  printerType: `required|integer|in:${OctoprintType},${MoonrakerType}`,
   printerURL: "required|httpurl",
   apiKey: `required|minLength:${UUID_LENGTH}|maxLength:${UUID_LENGTH}`,
 };

--- a/src/controllers/validation/printer-controller.validation.ts
+++ b/src/controllers/validation/printer-controller.validation.ts
@@ -1,5 +1,5 @@
 import { UUID_LENGTH } from "@/constants/service.constants";
-import { OctoprintType } from "@/services/printer-api.interface";
+import { MoonrakerType, OctoprintType } from "@/services/printer-api.interface";
 
 export const flowRateRules = {
   flowRate: "required|between:75,125|integer",

--- a/src/middleware/printer.ts
+++ b/src/middleware/printer.ts
@@ -5,7 +5,6 @@ import { PrinterCache } from "@/state/printer.cache";
 import { OctoprintApi } from "@/services/octoprint.api";
 import { MoonrakerType, OctoprintType } from "@/services/printer-api.interface";
 import { MoonrakerApi } from "@/services/moonraker.api";
-import { NotImplementedException } from "@/exceptions/runtime.exceptions";
 
 export const printerIdToken = "currentPrinterId";
 export const printerApiToken = "printerApi";
@@ -38,13 +37,9 @@ export const printerResolveMiddleware = (key = "id") => {
           });
           break;
         case MoonrakerType:
-          // throw new NotImplementedException("Moonraker has not been implemented as a supported printer service type");
-          //   const moonrakerInstance = req.container.resolve<MoonrakerApi>(DITokens.moonrakerApi);
-          //   req.container.register({
-          //     [printerApiToken]: asValue(moonrakerInstance),
-          //   });
+          const moonrakerInstance = req.container.resolve<MoonrakerApi>(DITokens.moonrakerApi);
           req.container.register({
-            [printerApiToken]: asValue(octoprintApiInstance),
+            [printerApiToken]: asValue(moonrakerInstance),
           });
           break;
       }

--- a/src/middleware/printer.ts
+++ b/src/middleware/printer.ts
@@ -5,6 +5,7 @@ import { PrinterCache } from "@/state/printer.cache";
 import { OctoprintApi } from "@/services/octoprint.api";
 import { MoonrakerType, OctoprintType } from "@/services/printer-api.interface";
 import { MoonrakerApi } from "@/services/moonraker.api";
+import { SettingsStore } from "@/state/settings.store";
 
 export const printerIdToken = "currentPrinterId";
 export const printerApiToken = "printerApi";
@@ -14,6 +15,8 @@ export const printerLoginToken = "printerLogin";
 export const printerResolveMiddleware = (key = "id") => {
   return (req: Request, res: Response, next: NextFunction) => {
     const printerCache = req.container.resolve<PrinterCache>(DITokens.printerCache);
+    const settingsService = req.container.resolve<any>(DITokens.settingsStore) as SettingsStore;
+    const moonrakerEnabled = settingsService.getServerSettings().experimentalMoonrakerSupport;
 
     let scopedPrinter = undefined;
     let loginDto = undefined;
@@ -39,7 +42,7 @@ export const printerResolveMiddleware = (key = "id") => {
         case MoonrakerType:
           const moonrakerInstance = req.container.resolve<MoonrakerApi>(DITokens.moonrakerApi);
           req.container.register({
-            [printerApiToken]: asValue(moonrakerInstance),
+            [printerApiToken]: moonrakerEnabled ? asValue(moonrakerInstance) : asValue(undefined),
           });
           break;
       }

--- a/src/server.constants.ts
+++ b/src/server.constants.ts
@@ -71,7 +71,7 @@ export const AppConstants = {
   orgName: "fdm-monster",
   // Wizard version changes will trigger a re-run of the wizard
   currentWizardVersion: 1,
-  defaultClientMinimum: "1.6.4",
+  defaultClientMinimum: "1.6.5",
 
   influxUrl: "INFLUX_URL",
   influxToken: "INFLUX_TOKEN",

--- a/src/services/core/yaml.service.ts
+++ b/src/services/core/yaml.service.ts
@@ -77,7 +77,7 @@ export class YamlService {
 
       // 1.7 backwards compatibility
       // if (![OctoprintType, MoonrakerType].includes[printer.printerType]) {
-      if (![OctoprintType].includes[printer.printerType]) {
+      if (![OctoprintType, MoonrakerType].includes[printer.printerType]) {
         printer.printerType = OctoprintType;
       }
     }

--- a/src/services/moonraker.api.ts
+++ b/src/services/moonraker.api.ts
@@ -91,7 +91,7 @@ export class MoonrakerApi implements IPrinterApi {
     await this.client.postGcodeScript(this.login, script);
   }
 
-  async quickStop(): Promise<void> {
+  async emergencyStop(): Promise<void> {
     await this.client.postEmergencyStop(this.login);
   }
 

--- a/src/services/moonraker.api.ts
+++ b/src/services/moonraker.api.ts
@@ -91,8 +91,8 @@ export class MoonrakerApi implements IPrinterApi {
     await this.client.postGcodeScript(this.login, script);
   }
 
-  async emergencyStop(): Promise<void> {
-    await this.client.postEmergencyStop(this.login);
+  async quickStop(): Promise<void> {
+    await this.client.postQuickStop(this.login);
   }
 
   async movePrintHead(amounts: { x?: number; y?: number; z?: number; speed?: number }) {

--- a/src/services/moonraker/moonraker-websocket.adapter.ts
+++ b/src/services/moonraker/moonraker-websocket.adapter.ts
@@ -17,6 +17,7 @@ import { LoginDto } from "@/services/interfaces/login.dto";
 import { ConnectionIdentifyDto } from "@/services/moonraker/dto/websocket/connection-identify.dto";
 import { WebsocketRpcExtendedAdapter } from "@/shared/websocket-rpc-extended.adapter";
 import { JsonRpcEventDto } from "@/services/moonraker/dto/websocket/json-rpc-event.dto";
+import { errorSummary } from "@/utils/error.utils";
 import { KnownPrinterObject } from "@/services/moonraker/dto/objects/printer-objects-list.dto";
 import { NotifyStatusUpdate } from "@/services/moonraker/dto/websocket/message.types";
 import {

--- a/src/services/moonraker/moonraker-websocket.adapter.ts
+++ b/src/services/moonraker/moonraker-websocket.adapter.ts
@@ -17,7 +17,6 @@ import { LoginDto } from "@/services/interfaces/login.dto";
 import { ConnectionIdentifyDto } from "@/services/moonraker/dto/websocket/connection-identify.dto";
 import { WebsocketRpcExtendedAdapter } from "@/shared/websocket-rpc-extended.adapter";
 import { JsonRpcEventDto } from "@/services/moonraker/dto/websocket/json-rpc-event.dto";
-import { errorSummary } from "@/utils/error.utils";
 import { KnownPrinterObject } from "@/services/moonraker/dto/objects/printer-objects-list.dto";
 import { NotifyStatusUpdate } from "@/services/moonraker/dto/websocket/message.types";
 import {

--- a/src/services/moonraker/moonraker.client.ts
+++ b/src/services/moonraker/moonraker.client.ts
@@ -127,7 +127,7 @@ export class MoonrakerClient {
     return this.httpClient.post<ResultDto<PrinterInfoDto>>(`${login.printerURL}/printer/info`);
   }
 
-  async postEmergencyStop(login: LoginDto) {
+  async postQuickStop(login: LoginDto) {
     return this.httpClient.post<ResultDto<ActionResultDto>>(`${login.printerURL}/printer/emergency_stop`);
   }
 

--- a/src/services/octoprint/dto/octoprint-event.dto.ts
+++ b/src/services/octoprint/dto/octoprint-event.dto.ts
@@ -18,7 +18,7 @@ export const messages = {
   ...octoprintWsMessages,
 
   // Nice klipper subscription state
-  // notify_status_update: "notify_status_update",
+  notify_status_update: "notify_status_update",
 
   // Custom events
   WS_OPENED: "WS_OPENED",

--- a/src/services/octoprint/utils/file.utils.ts
+++ b/src/services/octoprint/utils/file.utils.ts
@@ -1,3 +1,4 @@
+import { CreateOrUpdatePrinterFileDto } from "@/services/interfaces/printer-file.dto";
 import { OctoPrintCustomDto, OctoprintFileDto } from "@/services/octoprint/dto/files/octoprint-file.dto";
 import { FileDto } from "@/services/printer-api.interface";
 
@@ -18,7 +19,7 @@ export function normalizePrinterFile(file: OctoprintFileDto): FileDto {
     // "display",
     // "gcodeAnalysis",
     // "origin",
-    "name",
+    // "name",
     // "prints",
     // "refs",
     "size",

--- a/src/services/printer-api.factory.ts
+++ b/src/services/printer-api.factory.ts
@@ -20,12 +20,10 @@ export class PrinterApiFactory {
     let printerApi;
     if (login.printerType === OctoprintType) {
       printerApi = this.cradle[DITokens.octoprintApi] as IPrinterApi;
-    }
-    // else if (login.printerType === MoonrakerType) {
-    //   printerApi = this.cradle[DITokens.moonrakerApi] as IPrinterApi;
-    // }
-    else {
-      throw new Error("PrinterType is unsupported, cant pick the right api client");
+    } else if (login.printerType === MoonrakerType) {
+      printerApi = this.cradle[DITokens.moonrakerApi] as IPrinterApi;
+    } else {
+      throw new Error("PrinterType is unknown, cant pick the right socket adapter");
     }
 
     printerApi.login = login;

--- a/src/services/printer-api.interface.ts
+++ b/src/services/printer-api.interface.ts
@@ -40,7 +40,7 @@ export interface IPrinterApi {
   pausePrint(): Promise<void>;
   resumePrint(): Promise<void>;
   cancelPrint(): Promise<void>;
-  emergencyStop(): Promise<void>;
+  quickStop(): Promise<void>;
 
   // Subsetting of OctoPrint
   // getName(): string;

--- a/src/services/printer-api.interface.ts
+++ b/src/services/printer-api.interface.ts
@@ -13,12 +13,7 @@ export interface StatusFlags {
   error: boolean;
   finished: boolean;
 }
-
 export interface FileDto {
-  /**
-   * @deprecated name will be removed soon, use path instead
-   */
-  name: string;
   path: string;
   size: number;
   date: number;
@@ -45,7 +40,7 @@ export interface IPrinterApi {
   pausePrint(): Promise<void>;
   resumePrint(): Promise<void>;
   cancelPrint(): Promise<void>;
-  quickStop(): Promise<void>;
+  emergencyStop(): Promise<void>;
 
   // Subsetting of OctoPrint
   // getName(): string;

--- a/src/services/socket.factory.ts
+++ b/src/services/socket.factory.ts
@@ -2,6 +2,7 @@ import { DITokens } from "@/container.tokens";
 import { OctoprintWebsocketAdapter } from "@/services/octoprint/octoprint-websocket.adapter";
 import { MoonrakerWebsocketAdapter } from "@/services/moonraker/moonraker-websocket.adapter";
 import { MoonrakerType, OctoprintType } from "@/services/printer-api.interface";
+import { SettingsStore } from "@/state/settings.store";
 
 export class SocketFactory {
   cradle: any;
@@ -11,9 +12,13 @@ export class SocketFactory {
   }
 
   createInstance(printerType: number): OctoprintWebsocketAdapter | MoonrakerWebsocketAdapter {
+    const settingsStore = this.cradle[DITokens.settingsStore] as SettingsStore;
+    const serverSettings = settingsStore.getServerSettings();
+    const moonrakerSupport = serverSettings.experimentalMoonrakerSupport;
+
     if (printerType === OctoprintType) {
       return this.cradle[DITokens.octoPrintSockIoAdapter];
-    } else if (printerType === MoonrakerType) {
+    } else if (moonrakerSupport && printerType === MoonrakerType) {
       return this.cradle[DITokens.moonrakerWebsocketAdapter];
     } else {
       throw new Error("PrinterType is unknown, cant pick the right socket adapter");

--- a/src/services/socket.factory.ts
+++ b/src/services/socket.factory.ts
@@ -13,12 +13,10 @@ export class SocketFactory {
   createInstance(printerType: number): OctoprintWebsocketAdapter | MoonrakerWebsocketAdapter {
     if (printerType === OctoprintType) {
       return this.cradle[DITokens.octoPrintSockIoAdapter];
-    }
-    // else if (printerType === MoonrakerType) {
-    //   return this.cradle[DITokens.moonrakerWebsocketAdapter];
-    // }
-    else {
-      throw new Error("PrinterType is unsupported, cant pick the right socket adapter");
+    } else if (printerType === MoonrakerType) {
+      return this.cradle[DITokens.moonrakerWebsocketAdapter];
+    } else {
+      throw new Error("PrinterType is unknown, cant pick the right socket adapter");
     }
   }
 }

--- a/src/services/validators/printer-service.validation.ts
+++ b/src/services/validators/printer-service.validation.ts
@@ -1,11 +1,11 @@
 import { UUID_LENGTH } from "@/constants/service.constants";
-import { OctoprintType } from "@/services/printer-api.interface";
+import { OctoprintType, MoonrakerType } from "@/services/printer-api.interface";
 
 export const createMongoPrinterRules = {
   _id: "not",
   apiKey: `required|length:${UUID_LENGTH},${UUID_LENGTH}|alphaNumeric`,
   printerURL: "required|httpurl",
-  printerType: `required|integer|in:${OctoprintType}`,
+  printerType: `required|integer|in:${OctoprintType},${MoonrakerType}`,
   enabled: "boolean",
   name: "string",
 };
@@ -13,7 +13,7 @@ export const createMongoPrinterRules = {
 export const createPrinterRules = {
   apiKey: `required|length:${UUID_LENGTH},${UUID_LENGTH}|alphaNumeric`,
   printerURL: "required|httpurl",
-  printerType: `required|integer|in:${OctoprintType}`,
+  printerType: `required|integer|in:${OctoprintType},${MoonrakerType}`,
   enabled: "boolean",
   name: "required|string",
 };

--- a/src/services/validators/yaml-service.validation.ts
+++ b/src/services/validators/yaml-service.validation.ts
@@ -1,5 +1,5 @@
 import { UUID_LENGTH } from "@/constants/service.constants";
-import { OctoprintType } from "@/services/printer-api.interface";
+import { OctoprintType, MoonrakerType } from "@/services/printer-api.interface";
 
 export const exportPrintersFloorsYamlRules = {
   // Used to export
@@ -40,7 +40,7 @@ export const importPrintersFloorsYamlRules = (
     "printers.*.apiKey": `required|length:${UUID_LENGTH},${UUID_LENGTH}|alphaNumeric`,
     "printers.*.printerURL": "required|httpurl",
     "printers.*.enabled": "boolean",
-    "printers.*.printerType": `integer|in:${OctoprintType}`,
+    "printers.*.printerType": `integer|in:${OctoprintType},${MoonrakerType}`,
     "printers.*.name": "required|string",
     floors: `${!!importFloors ? "array|minLength:0" : "not"}`,
     "floors.*.id": "required",

--- a/src/state/printer-events.cache.ts
+++ b/src/state/printer-events.cache.ts
@@ -52,7 +52,7 @@ export class PrinterEventsCache extends KeyDiffCache<PrinterEventsCacheDto> {
         connected: null,
         reauthRequired: null,
         // slicingProgress: null,
-        // notify_status_update: null,
+        notify_status_update: null,
         current: null,
         history: null,
         // timelapse: null,
@@ -96,7 +96,7 @@ export class PrinterEventsCache extends KeyDiffCache<PrinterEventsCacheDto> {
 
   private subscribeToEvents() {
     this.eventEmitter2.on("octoprint.*", (e) => this.onOctoPrintSocketMessage(e));
-    // this.eventEmitter2.on("moonraker.*", (e) => this.onMoonrakerSocketMessage(e));
+    this.eventEmitter2.on("moonraker.*", (e) => this.onMoonrakerSocketMessage(e));
     this.eventEmitter2.on(printerEvents.printersDeleted, this.handlePrintersDeleted.bind(this));
   }
 
@@ -111,17 +111,17 @@ export class PrinterEventsCache extends KeyDiffCache<PrinterEventsCacheDto> {
     }
   }
 
-  // private async onMoonrakerSocketMessage(
-  //   e: MoonrakerEventDto<MR_WsMessage, PrinterObjectsQueryDto<SubscriptionType | null>, IdType>
-  // ) {
-  //   const printerId = e.printerId;
-  //   const eventType = e.event;
-  //
-  //   // https://github.com/mainsail-crew/mainsail/blob/fa61d4ef92 97426a404dd845a1a4d5e4525c43dc/src/components/panels/StatusPanel.vue#L199
-  //   if (["notify_status_update", "current"].includes(eventType)) {
-  //     await this.setEvent(printerId, eventType as "notify_status_update" | "current", e.payload);
-  //   }
-  // }
+  private async onMoonrakerSocketMessage(
+    e: MoonrakerEventDto<MR_WsMessage, PrinterObjectsQueryDto<SubscriptionType | null>, IdType>
+  ) {
+    const printerId = e.printerId;
+    const eventType = e.event;
+
+    // https://github.com/mainsail-crew/mainsail/blob/fa61d4ef92 97426a404dd845a1a4d5e4525c43dc/src/components/panels/StatusPanel.vue#L199
+    if (["notify_status_update", "current"].includes(eventType)) {
+      await this.setEvent(printerId, eventType as "notify_status_update" | "current", e.payload);
+    }
+  }
 
   private pruneHistoryPayload(payload: HistoryMessageDto) {
     delete payload.logs;

--- a/src/state/printer-files.store.ts
+++ b/src/state/printer-files.store.ts
@@ -44,7 +44,7 @@ export class PrinterFilesStore {
         this.fileCache.cachePrinterFiles(printer.id, printerFiles);
       } catch (e) {
         captureException(e);
-        this.logger.error("Files store failed to load file list for printer");
+        this.logger.error("Files store failed to reconstruct files from database");
       }
     }
   }

--- a/src/state/printer-files.store.ts
+++ b/src/state/printer-files.store.ts
@@ -44,7 +44,7 @@ export class PrinterFilesStore {
         this.fileCache.cachePrinterFiles(printer.id, printerFiles);
       } catch (e) {
         captureException(e);
-        this.logger.error("Files store failed to reconstruct files from database");
+        this.logger.error("Files store failed to load file list for printer");
       }
     }
   }

--- a/src/state/printer.cache.ts
+++ b/src/state/printer.cache.ts
@@ -4,7 +4,7 @@ import { NotFoundException } from "@/exceptions/runtime.exceptions";
 import EventEmitter2 from "eventemitter2";
 import { IdType } from "@/shared.constants";
 import { IPrinterService } from "@/services/interfaces/printer.service.interface";
-import { PrinterDto, PrinterUnsafeDto } from "@/services/interfaces/printer.dto";
+import { PrinterUnsafeDto } from "@/services/interfaces/printer.dto";
 import { Printer } from "@/entities";
 import { IPrinter } from "@/models/Printer";
 import { PrinterType } from "@/services/printer-api.interface";

--- a/test/api/printer-controller.test.ts
+++ b/test/api/printer-controller.test.ts
@@ -5,9 +5,9 @@ import { createTestPrinter, testApiKey } from "./test-data/create-printer";
 import { Test } from "supertest";
 import { PrinterController } from "@/controllers/printer.controller";
 import { IdType } from "@/shared.constants";
-import { OctoprintType } from "@/services/printer-api.interface";
 import TestAgent from "supertest/lib/agent";
 import nock from "nock";
+import { OctoprintType, MoonrakerType } from "@/services/printer-api.interface";
 
 const defaultRoute = AppConstants.apiRoute + "/printer";
 const createRoute = defaultRoute;
@@ -54,13 +54,13 @@ describe(PrinterController.name, () => {
       printerURL: "http://url.com",
       apiKey: testApiKey,
       name: "test123",
-      printerType: OctoprintType,
+      printerType: MoonrakerType,
     });
     expectOkResponse(response, {
       printerURL: "http://url.com",
       apiKey: testApiKey,
       name: "test123",
-      printerType: OctoprintType,
+      printerType: MoonrakerType,
     });
   });
 
@@ -118,7 +118,7 @@ describe(PrinterController.name, () => {
         printerURL: "http://localhost/",
         apiKey,
         name,
-        printerType: OctoprintType,
+        printerType: MoonrakerType,
       },
     ]);
     expectOkResponse(response);
@@ -158,14 +158,14 @@ describe(PrinterController.name, () => {
       apiKey,
       enabled: false,
       name: "asd124",
-      printerType: OctoprintType,
+      printerType: MoonrakerType,
     };
     const updatePatch = await request.patch(updateRoute(printer.id)).send(patch);
     expectOkResponse(updatePatch, {
       printerURL: "https://test.com",
       enabled: false,
       name: "asd124",
-      printerType: OctoprintType,
+      printerType: MoonrakerType,
     });
   });
 
@@ -178,12 +178,12 @@ describe(PrinterController.name, () => {
       printerURL: "https://test.com/",
       apiKey,
       name,
-      printerType: OctoprintType,
+      printerType: MoonrakerType,
     });
     expectOkResponse(updatePatch, {
       printerURL: "https://test.com",
       apiKey,
-      printerType: OctoprintType,
+      printerType: MoonrakerType,
     });
   });
 
@@ -197,7 +197,7 @@ describe(PrinterController.name, () => {
       apiKey,
       printerURL: "https://test.com/",
       name,
-      printerType: OctoprintType,
+      printerType: MoonrakerType,
     });
     expectOkResponse(res);
   });

--- a/test/api/settings-controller.test.ts
+++ b/test/api/settings-controller.test.ts
@@ -39,6 +39,7 @@ describe(SettingsController.name, () => {
     const defaultSettings = getDefaultSettings();
     defaultSettings[serverSettingsKey].loginRequired = false; // Test override
     defaultSettings[serverSettingsKey].experimentalTypeormSupport = isSqliteModeTest();
+    defaultSettings[serverSettingsKey].experimentalMoonrakerSupport = true;
     delete defaultSettings[serverSettingsKey].whitelistEnabled;
     delete defaultSettings[serverSettingsKey].whitelistedIpAddresses;
     delete defaultSettings[serverSettingsKey].debugSettings;

--- a/test/application/store/files-store.test.ts
+++ b/test/application/store/files-store.test.ts
@@ -4,7 +4,7 @@ import { PrinterFilesStore } from "@/state/printer-files.store";
 import { setupTestApp } from "../../test-server";
 import { SqliteIdType } from "@/shared.constants";
 import { IPrinterService } from "@/services/interfaces/printer.service.interface";
-import { OctoprintType } from "@/services/printer-api.interface";
+import { OctoprintType, MoonrakerType } from "@/services/printer-api.interface";
 
 let printerFilesStore: PrinterFilesStore;
 let printerService: IPrinterService<SqliteIdType>;
@@ -22,7 +22,7 @@ describe(PrinterFilesStore.name, () => {
     apiKey: "asdasasdasdasdasdasdasdasdasdasd",
     printerURL: "https://asd.com:81",
     name: "TestPrinter",
-    printerType: OctoprintType,
+    printerType: MoonrakerType,
   };
 
   it("old files - should deal with empty files cache correctly", async () => {

--- a/test/test-server.ts
+++ b/test/test-server.ts
@@ -2,8 +2,6 @@ import { asClass, asValue, AwilixContainer } from "awilix";
 import { DITokens } from "@/container.tokens";
 import { setupServer } from "@/server.core";
 import { setupEnvConfig } from "@/server.env";
-import { AxiosMock } from "./mocks/axios.mock";
-import { OctoPrintApiMock } from "./mocks/octoprint-api.mock";
 import { ROLES } from "@/constants/authorization.constants";
 import supertest, { Test } from "supertest";
 import { Express } from "express";
@@ -12,6 +10,7 @@ import { TypeormService } from "@/services/typeorm/typeorm.service";
 import { TaskManagerService } from "@/services/core/task-manager.service";
 import { AxiosInstance } from "axios";
 import TestAgent from "supertest/lib/agent";
+import { SettingsStore } from "@/state/settings.store";
 
 jest.mock("../src/utils/env.utils", () => ({
   ...jest.requireActual("../src/utils/env.utils"),
@@ -50,8 +49,9 @@ export async function setupTestApp(
   }
 
   // Setup
-  const settingsStore = container.resolve(DITokens.settingsStore);
+  const settingsStore = container.resolve(DITokens.settingsStore) as SettingsStore;
   await settingsStore.loadSettings();
+  await settingsStore.setExperimentalMoonrakerSupport(true);
 
   const serverHost = container.resolve(DITokens.serverHost);
   await serverHost.boot(httpServer, quick_boot, false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1063,10 +1063,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fdm-monster/client@npm:1.6.4":
-  version: 1.6.4
-  resolution: "@fdm-monster/client@npm:1.6.4"
-  checksum: 10c0/5d948aae5e586e480e5f1c3003ba7adaf750ce7824b91048939e23408bc56aad8723b8f1f8ad5f5473360d0fd3ad57062a98768baac9857aa188c2956bd6403b
+"@fdm-monster/client@npm:1.6.5":
+  version: 1.6.5
+  resolution: "@fdm-monster/client@npm:1.6.5"
+  checksum: 10c0/1ac9eee64685737523f1a72bb3db162b7e36672ae5265ebfa397bd16b76d982627594600832bc806489ac1c44b18463d87c6d88ff0a25b15470d36043d5cd22e
   languageName: node
   linkType: hard
 
@@ -1074,7 +1074,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fdm-monster/server@workspace:."
   dependencies:
-    "@fdm-monster/client": "npm:1.6.4"
+    "@fdm-monster/client": "npm:1.6.5"
     "@fdm-monster/client-next": "npm:0.0.3"
     "@influxdata/influxdb-client": "npm:1.35.0"
     "@lcov-viewer/cli": "npm:1.3.0"


### PR DESCRIPTION
### Implementation

- [x] Build Moonraker API client
- [x] Build Moonraker Websocket client
- [x] Introduce PrinterType + SQLite migration
- [x] Decouple PrinterFile database from cache: this database will not be used in the next release (kept for backwards compatibility)
- [x] Adjust LoginDto to carry PrinterType around
- [x] Build client updates for new Printer Type
- [x] Introduce Printer API for printer control, file actions and gcode commands
  - [x] Implement basic OctoprintApi
  - [x] Implement basic MoonrakerApi
- [x] Build PrinterApiFactory for scoped and non-scoped printer api resolution with Awilix (overridable service registration by providing asValue(null) for `printerApi` dependency)
- [x] Adjust `printerResolveMiddleware` to use new `printerApi:IPrinterApi` scoped dependency
- [x] Adjust `PrinterFilesStore` to use PrinterApiFactory for non-scoped PrinterApi
- [x] Receive, extract and transform specific socket events for MR+OP in such a way that the UI has 1 truth for PrinterStateStore
  - [x] Implement websocket RPC request-response with timeout
  - [x] Socket setup now involves object subscription or event subscription
  - [x] Pick roughly which "objects" and "events" are needed instead of sending everything (print_stats, pause_resume, idle_timeout, heaters, heater_bed)
  - [x] Transform the objects to a standardized format
  - [x] Also transform OctoPrint `current` to a similar format
  - [x] Plan ahead: pick exactly which "objects" and "events" are needed instead of sending everything
- [x] Abstract the UI PrinterStateStore so it can handle Moonraker "objects" similar to Octoprint events
- [x] Fix: add printerType to YAML export
- [x] Fix: API tests
- [x] Fix: cant download file 
- [x] Fix: cant delete file
- [x] Fix: printing file is not presented in sidenav
- [x] Add a interval to socket which queries server info state as a fallback mechanism for webhooks object
- [x] Moonraker emergency stop results in paused mode?
![image](https://github.com/fdm-monster/fdm-monster/assets/6005355/e3df13ac-da64-46ab-b3ab-d18e694be886)
- [x] Rectify any tile state, printer list row state, job menu state, toolbar summary state or sidenav state
- [ ] Fix: Moonraker does not require API Key
- [x] Move printer `current` conversion into socket adapter
- [x] Query webook object to determine operational state
- [x] Fix: klipper service stoppage should at least result in disconnected state, with connect resulting in klipper restart
- [x] Fix: klippy non-responsive or 503 error should lead to disconnected or offline
- [ ] Fix axios upload tracker mechanism (or investigate UI bug)
- [ ] Restore the PrinterStateUpdatePollTask to at least report the states, it has no responsibility anymore
- [ ] Speed up reconnect action from UI, its so slow right now
- [x] When no printer current state is known, weird state is show in UI. Instead "loading" should be presented.

### Minimum happy flow tests (acceptance criteria):
- [x] Showing the file list should work and files should be sorted by upload date (newest at the top)
- [x] After an update in the file list, the sidenav should show this update after reopening
- [x] Uploading a file should upload it to Moonraker
- [ ] Uploading a file should lead to printing UI tile state
- [x] Downloading a file should work
- [x] Deleting a file in sidenav should lead to file being removed for OctoPrint/Moonraker and list being cleared
- [x] Start/pause/cancel actions should lead to appropriate tile and sidenav states
- [ ] Printer control should lead to appropriate home/move response (GCode should be comparable to OctoPrint control)
- [x] Emergency stop should work
- [ ] Reconnecting the socket should lead to a refreshed backend socket connection
- [x] Disabling the printer should lead to stopped socket, and a disabled print state interval
- [ ] Test printer should show simple and consistent messages (not the technical ones)
  - [ ] DNS check
  - [ ] Auth check (if enabled)
  - [ ] API version check 
  - [ ] Connection check or MCU+host state check
  - [ ] Printer state available check
  - [ ] Socket state check
  - [ ] Disk/CPU check?

### Unhappy flow tests:
- [ ] Batch import should not break on missing printer type
- [ ] Printer import should select what printer type to default to (OctoPrint by default)
- [ ] Disconnecting from the moonraker API should lead to disconnect state/color on tile
- [ ] Restarting the klippy host or power toggling it, should lead to exclamation mark on the tile accordingly
- [ ] Any MCU firmware crash, should lead to exclamation mark on the tile accordingly

### Beta release actions:
- [x] Add release notes
- [ ] General code cleanup
  - [x] Remove PrinterConnectionCache backend store
  - [ ] Remove PluginFirmwareUpdateController and push to git branch
  - [x] Cleanup unused backend and frontend DTOs 
  - [x] Model OctoPrint client DTOs better
- [ ] Write integration tests to cover file store, printer api's, printer file controller and printer controller
- [x] UI update pushed + new minor minimum requirement in API
- [ ] Decide about CustomGcodeController dupe sendEmergencyM112 vs PrinterApi command (printer API is better, but backwards compat fallback + deprecation note + github issue is best, just in case)
- [x] Decide to use Octoprint compatible /api/job and /api/printer APIs or Moonraker object subscriptions/polling
- [ ] Tweak moonraker object subscription, add debug mode which exposes more objects
- [ ] Plan ahead to see if Octoprint subscriptions are comparable to Moonraker object subscription
- [ ] Figure out disconnect/connect difference between Klippy and OctoPrint (or disable the capability for (dis)connect in case of Klipper)