### PR TITLE
fix: adjust max length of apiKey property validation to 43 to allow new `secrets` based OctoPrint api keys

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,5 +1,9 @@
 # Develop
 
+## Fixes:
+
+- API & Service validators: adjust max length of apiKey property validation to 43 to allow new `secrets` based OctoPrint api keys
+
 # FDM Monster 04/11/2024 1.7.1
 
 ## Changes:

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
     "vue"
   ],
   "dependencies": {
-    "@fdm-monster/client": "1.6.7",
-    "@fdm-monster/client-next": "0.0.4",
+    "@fdm-monster/client": "1.6.8",
+    "@fdm-monster/client-next": "0.0.5",
     "@influxdata/influxdb-client": "1.35.0",
     "@octokit/plugin-throttling": "8.2.0",
     "@sentry/node": "8.37.1",

--- a/src/constants/service.constants.ts
+++ b/src/constants/service.constants.ts
@@ -1,4 +1,4 @@
-export const UUID_LENGTH = 32;
 export const minFloorNameLength = 3;
 
-export const apiKeyLengthMinimumDefault = 32;
+export const apiKeyLengthMinDefault = 32;
+export const apiKeyLengthMaxDefault = 43;

--- a/src/controllers/validation/printer-controller.validation.ts
+++ b/src/controllers/validation/printer-controller.validation.ts
@@ -1,4 +1,4 @@
-import { UUID_LENGTH } from "@/constants/service.constants";
+import { apiKeyLengthMaxDefault, apiKeyLengthMinDefault } from "@/constants/service.constants";
 import { MoonrakerType, OctoprintType } from "@/services/printer-api.interface";
 
 export const flowRateRules = {
@@ -11,7 +11,7 @@ export const feedRateRules = {
 
 export const testPrinterApiRules = {
   printerType: `required|integer|in:${OctoprintType},${MoonrakerType}`,
-  apiKey: `requiredIf:printerType,${OctoprintType}|length:${UUID_LENGTH},${UUID_LENGTH}|alphaNumeric`,
+  apiKey: `requiredIf:printerType,${OctoprintType}|length:${apiKeyLengthMaxDefault},${apiKeyLengthMinDefault}|alphaNumeric`,
   printerURL: "required|httpurl",
 };
 
@@ -26,7 +26,7 @@ export const updatePrinterEnabledRule = {
 export const updatePrinterConnectionSettingRules = {
   printerType: `required|integer|in:${OctoprintType},${MoonrakerType}`,
   printerURL: "required|httpurl",
-  apiKey: `requiredIf:printerType,${OctoprintType}|length:${UUID_LENGTH},${UUID_LENGTH}|alphaNumeric`,
+  apiKey: `requiredIf:printerType,${OctoprintType}|length:${apiKeyLengthMaxDefault},${apiKeyLengthMinDefault}|alphaNumeric`,
 };
 
 export const createOctoPrintBackupRules = {

--- a/src/controllers/validation/printer-controller.validation.ts
+++ b/src/controllers/validation/printer-controller.validation.ts
@@ -11,7 +11,7 @@ export const feedRateRules = {
 
 export const testPrinterApiRules = {
   printerType: `required|integer|in:${OctoprintType},${MoonrakerType}`,
-  apiKey: `requiredIf:printerType,${OctoprintType}|length:${apiKeyLengthMaxDefault},${apiKeyLengthMinDefault}|alphaNumeric`,
+  apiKey: `requiredIf:printerType,${OctoprintType}|length:${apiKeyLengthMaxDefault},${apiKeyLengthMinDefault}|alphaDash`,
   printerURL: "required|httpurl",
 };
 
@@ -26,7 +26,7 @@ export const updatePrinterEnabledRule = {
 export const updatePrinterConnectionSettingRules = {
   printerType: `required|integer|in:${OctoprintType},${MoonrakerType}`,
   printerURL: "required|httpurl",
-  apiKey: `requiredIf:printerType,${OctoprintType}|length:${apiKeyLengthMaxDefault},${apiKeyLengthMinDefault}|alphaNumeric`,
+  apiKey: `requiredIf:printerType,${OctoprintType}|length:${apiKeyLengthMaxDefault},${apiKeyLengthMinDefault}|alphaDash`,
 };
 
 export const createOctoPrintBackupRules = {

--- a/src/models/Printer.ts
+++ b/src/models/Printer.ts
@@ -1,5 +1,5 @@
 import { model, Schema } from "mongoose";
-import { MoonrakerType, OctoprintType } from "@/services/printer-api.interface";
+import { OctoprintType } from "@/services/printer-api.interface";
 
 export interface IPrinter {
   id: string;

--- a/src/server.constants.ts
+++ b/src/server.constants.ts
@@ -71,7 +71,7 @@ export const AppConstants = {
   orgName: "fdm-monster",
   // Wizard version changes will trigger a re-run of the wizard
   currentWizardVersion: 1,
-  defaultClientMinimum: "1.6.7",
+  defaultClientMinimum: "1.6.8",
 
   influxUrl: "INFLUX_URL",
   influxToken: "INFLUX_TOKEN",

--- a/src/services/validators/printer-service.validation.ts
+++ b/src/services/validators/printer-service.validation.ts
@@ -1,11 +1,11 @@
-import { UUID_LENGTH } from "@/constants/service.constants";
+import { apiKeyLengthMaxDefault, apiKeyLengthMinDefault } from "@/constants/service.constants";
 import { OctoprintType, MoonrakerType } from "@/services/printer-api.interface";
 
 export const createMongoPrinterRules = {
   _id: "not",
   printerURL: "required|httpurl",
   printerType: `required|integer|in:${OctoprintType},${MoonrakerType}`,
-  apiKey: `requiredIf:printerType,${OctoprintType}|length:${UUID_LENGTH},${UUID_LENGTH}|alphaNumeric`,
+  apiKey: `requiredIf:printerType,${OctoprintType}|length:${apiKeyLengthMaxDefault},${apiKeyLengthMinDefault}|alphaNumeric`,
   enabled: "boolean",
   name: "string",
 };
@@ -13,7 +13,7 @@ export const createMongoPrinterRules = {
 export const createPrinterRules = {
   printerURL: "required|httpurl",
   printerType: `required|integer|in:${OctoprintType},${MoonrakerType}`,
-  apiKey: `requiredIf:printerType,${OctoprintType}|length:${UUID_LENGTH},${UUID_LENGTH}|alphaNumeric`,
+  apiKey: `requiredIf:printerType,${OctoprintType}|length:${apiKeyLengthMaxDefault},${apiKeyLengthMinDefault}|alphaNumeric`,
   enabled: "boolean",
   name: "required|string",
 };

--- a/src/services/validators/printer-service.validation.ts
+++ b/src/services/validators/printer-service.validation.ts
@@ -5,7 +5,7 @@ export const createMongoPrinterRules = {
   _id: "not",
   printerURL: "required|httpurl",
   printerType: `required|integer|in:${OctoprintType},${MoonrakerType}`,
-  apiKey: `requiredIf:printerType,${OctoprintType}|length:${apiKeyLengthMaxDefault},${apiKeyLengthMinDefault}|alphaNumeric`,
+  apiKey: `requiredIf:printerType,${OctoprintType}|length:${apiKeyLengthMaxDefault},${apiKeyLengthMinDefault}|alphaDash`,
   enabled: "boolean",
   name: "string",
 };
@@ -13,7 +13,7 @@ export const createMongoPrinterRules = {
 export const createPrinterRules = {
   printerURL: "required|httpurl",
   printerType: `required|integer|in:${OctoprintType},${MoonrakerType}`,
-  apiKey: `requiredIf:printerType,${OctoprintType}|length:${apiKeyLengthMaxDefault},${apiKeyLengthMinDefault}|alphaNumeric`,
+  apiKey: `requiredIf:printerType,${OctoprintType}|length:${apiKeyLengthMaxDefault},${apiKeyLengthMinDefault}|alphaDash`,
   enabled: "boolean",
   name: "required|string",
 };

--- a/src/services/validators/yaml-service.validation.ts
+++ b/src/services/validators/yaml-service.validation.ts
@@ -1,4 +1,4 @@
-import { UUID_LENGTH } from "@/constants/service.constants";
+import { apiKeyLengthMaxDefault, apiKeyLengthMinDefault } from "@/constants/service.constants";
 import { OctoprintType, MoonrakerType } from "@/services/printer-api.interface";
 
 export const exportPrintersFloorsYamlRules = {
@@ -37,7 +37,7 @@ export const importPrintersFloorsYamlRules = (
     "config.floorComparisonStrategiesByPriority": "required|string|in:name,floor,id",
     printers: `${!!importPrinters ? "array|minLength:0" : "not"}`,
     "printers.*.id": "required",
-    "printers.*.apiKey": `required|length:${UUID_LENGTH},${UUID_LENGTH}|alphaNumeric`,
+    "printers.*.apiKey": `required|length:${apiKeyLengthMaxDefault},${apiKeyLengthMinDefault}|alphaNumeric`,
     "printers.*.printerURL": "required|httpurl",
     "printers.*.enabled": "boolean",
     "printers.*.printerType": `integer|in:${OctoprintType},${MoonrakerType}`,

--- a/src/state/validation/create-test-printer.validation.ts
+++ b/src/state/validation/create-test-printer.validation.ts
@@ -1,9 +1,9 @@
-import { UUID_LENGTH } from "@/constants/service.constants";
+import { apiKeyLengthMaxDefault, apiKeyLengthMinDefault } from "@/constants/service.constants";
 import { MoonrakerType, OctoprintType } from "@/services/printer-api.interface";
 
 export const createTestPrinterRules = {
   printerType: `required|integer|in:${OctoprintType},${MoonrakerType}`,
   correlationToken: "required|string",
-  apiKey: `requiredIf:printerType,${OctoprintType}|length:${UUID_LENGTH},${UUID_LENGTH}|alphaNumeric`,
+  apiKey: `requiredIf:printerType,${OctoprintType}|length:${apiKeyLengthMaxDefault},${apiKeyLengthMinDefault}|alphaNumeric`,
   printerURL: "required|httpurl",
 };

--- a/src/state/validation/create-test-printer.validation.ts
+++ b/src/state/validation/create-test-printer.validation.ts
@@ -4,6 +4,6 @@ import { MoonrakerType, OctoprintType } from "@/services/printer-api.interface";
 export const createTestPrinterRules = {
   printerType: `required|integer|in:${OctoprintType},${MoonrakerType}`,
   correlationToken: "required|string",
-  apiKey: `requiredIf:printerType,${OctoprintType}|length:${apiKeyLengthMaxDefault},${apiKeyLengthMinDefault}|alphaNumeric`,
+  apiKey: `requiredIf:printerType,${OctoprintType}|length:${apiKeyLengthMaxDefault},${apiKeyLengthMinDefault}|alphaDash`,
   printerURL: "required|httpurl",
 };

--- a/test/api/printer-controller.test.ts
+++ b/test/api/printer-controller.test.ts
@@ -74,6 +74,19 @@ describe(PrinterController.name, () => {
       name: "test123",
       printerType: OctoprintType,
     });
+
+    const response3 = await request.post(createRoute).query("forceSave=true").send({
+      printerURL: "http://url.com",
+      apiKey: "1234123412341234123412A4-234123412341234123",
+      name: "test123",
+      printerType: OctoprintType,
+    });
+    expectOkResponse(response3, {
+      printerURL: "http://url.com",
+      apiKey: "1234123412341234123412A4-234123412341234123",
+      name: "test123",
+      printerType: OctoprintType,
+    });
   });
 
   it(`should not be able to POST ${updateRoute} - missing printer field`, async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1056,17 +1056,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fdm-monster/client-next@npm:0.0.4":
-  version: 0.0.4
-  resolution: "@fdm-monster/client-next@npm:0.0.4"
-  checksum: 10c0/bf52b6fa2b1c45772e368c1404b8a99419f64df0e0a8a30ea8e2a0db6029c6f923c4caf3ccf8de207dd1963c1d2f4f59a459ce7be7ff9f069c94952f9a0a5110
+"@fdm-monster/client-next@npm:0.0.5":
+  version: 0.0.5
+  resolution: "@fdm-monster/client-next@npm:0.0.5"
+  checksum: 10c0/59706f6235293126b5abfa643cce0a29ab91d2a0fca18f39a5db8fc5630ee06e3d3816ed30a64db7effa17a749402a13c82ea60bb109b273dc0ea438daa812c8
   languageName: node
   linkType: hard
 
-"@fdm-monster/client@npm:1.6.7":
-  version: 1.6.7
-  resolution: "@fdm-monster/client@npm:1.6.7"
-  checksum: 10c0/be201d142f2fcef4e0b4576d339cd8016b3a22edc5456f28036fed89d5183b09a0211b163a2fbf06cd4183ea0905995d62b583638b186fd3cd455b7f611c2c9c
+"@fdm-monster/client@npm:1.6.8":
+  version: 1.6.8
+  resolution: "@fdm-monster/client@npm:1.6.8"
+  checksum: 10c0/b1b809e7f678ac5c7486b287b7cd74135ba3bfc250e054f96bd0830b5cbb72b1e82dbc1c3d2b09af740e1b682ef74cf879c17f93ad9882b0abbaac654a45a933
   languageName: node
   linkType: hard
 
@@ -1074,8 +1074,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fdm-monster/server@workspace:."
   dependencies:
-    "@fdm-monster/client": "npm:1.6.7"
-    "@fdm-monster/client-next": "npm:0.0.4"
+    "@fdm-monster/client": "npm:1.6.8"
+    "@fdm-monster/client-next": "npm:0.0.5"
     "@influxdata/influxdb-client": "npm:1.35.0"
     "@lcov-viewer/cli": "npm:1.3.0"
     "@lcov-viewer/istanbul-report": "npm:1.4.0"


### PR DESCRIPTION
This was an unexpected breaking change in OctoPrint 1.10.3. This PR fixes #3752 