### PR TITLE
fix: when printers and test printers are deleted, the printer events cache should not be allowed to be filled by late update events

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -3,7 +3,11 @@
 ## Features:
 
 - User API: new endpoint which registers user directly with roles and without verification step
- 
+
+## Fixes: 
+
+- PrinterEventsCache: when printers and test printers are deleted, the printer events cache should not be allowed to be filled by late update events
+
 # FDM Monster 11/11/2024 1.7.3
 
 ## Fixes:

--- a/src/state/printer-events.cache.ts
+++ b/src/state/printer-events.cache.ts
@@ -93,7 +93,7 @@ export class PrinterEventsCache extends KeyDiffCache<PrinterEventsCacheDto> {
     await this.setKeyValue(printerId, ref);
   }
 
-  async handlePrintersDeleted({ printerIds }: { printerIds: IdType[] }) {
+  private async handlePrintersDeleted({ printerIds }: { printerIds: IdType[] }) {
     await this.deleteKeysBatch(printerIds);
   }
 

--- a/src/state/printer.cache.ts
+++ b/src/state/printer.cache.ts
@@ -102,18 +102,18 @@ export class PrinterCache extends KeyDiffCache<CachedPrinter> {
     };
   }
 
-  async handleBatchPrinterCreated({ printers }) {
+  private async handleBatchPrinterCreated({ printers }) {
     const mappedPrinters = this.mapArray(printers);
     const keyValues = mappedPrinters.map((p) => ({ key: this.getId(p), value: p }));
     await this.setKeyValuesBatch(keyValues, true);
   }
 
-  async handlePrinterCreatedOrUpdated({ printer }) {
+  private async handlePrinterCreatedOrUpdated({ printer }) {
     const printerDto = this.map(printer);
     await this.setKeyValue(printerDto.id, printerDto, true);
   }
 
-  async handlePrintersDeleted({ printerIds }: { printerIds: keyType[] }) {
+  private async handlePrintersDeleted({ printerIds }: { printerIds: keyType[] }) {
     await this.deleteKeysBatch(printerIds, true);
   }
 

--- a/src/state/test-printer-socket.store.ts
+++ b/src/state/test-printer-socket.store.ts
@@ -15,6 +15,7 @@ import { PrinterUnsafeDto } from "@/services/interfaces/printer.dto";
 import { IdType } from "@/shared.constants";
 import { IWebsocketAdapter } from "@/services/websocket-adapter.interface";
 import { moonrakerEvent } from "@/services/moonraker/constants/websocket.constants";
+import { printerEvents } from "@/constants/event.constants";
 
 export class TestPrinterSocketStore {
   testSocket: IWebsocketAdapter;
@@ -22,6 +23,7 @@ export class TestPrinterSocketStore {
   socketFactory: SocketFactory;
   eventEmitter2: EventEmitter2;
   logger: LoggerService;
+
   constructor({
     socketFactory,
     socketIoGateway,
@@ -120,6 +122,9 @@ export class TestPrinterSocketStore {
       if (this.testSocket) {
         this.testSocket.close();
       }
+      this.eventEmitter2.emit(printerEvents.printersDeleted, {
+        printerIds: [correlationToken],
+      });
       delete this.testSocket;
       testEvents.forEach((te) => {
         this.eventEmitter2.off(te, listener);

--- a/src/utils/cache/key-diff.cache.ts
+++ b/src/utils/cache/key-diff.cache.ts
@@ -75,6 +75,11 @@ export class KeyDiffCache<T> {
       throw new Error("Key must be a non-empty serializable string");
     }
 
+    // We dont accept deleted key updates
+    if (this.deletedKeys.includes(keyString)) {
+      return;
+    }
+
     this.keyValueStore[keyString] = value;
     if (markUpdated) {
       this.markUpdated(keyString);


### PR DESCRIPTION
This is a regression and bug that has existed for a while now.

If a printer is deleted, events should not be kept. They should be purged and any update should be rejected.