### PR TITLE
fix: incorrect UI state "No USB" shown, when OctoPrint USB is disconnected

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -3,6 +3,7 @@
 ## Fixes
 
 - Demo mode should never show first-time-setup. It would always return "first time setup completed: false". Now this will return true.
+- Incorrect UI state "No USB" shown, when OctoPrint USB is disconnected.
 
 ## Features
 

--- a/src/services/octoprint/octoprint-websocket.adapter.ts
+++ b/src/services/octoprint/octoprint-websocket.adapter.ts
@@ -227,7 +227,8 @@ export class OctoprintWebsocketAdapter extends WebsocketAdapter {
   private async updateCurrentStateSafely() {
     try {
       const current = await this.octoprintClient.getPrinterCurrent(this.login, true);
-      const job = await this.octoprintClient.getJob(this.login);
+      const isOperational = current.data?.state?.flags?.operational;
+      const job = isOperational ? await this.octoprintClient.getJob(this.login) : {};
       this.setApiState(API_STATE.responding);
       return await this.emitEvent("current", { ...current.data, progress: job?.progress, job: job?.job });
     } catch (e) {


### PR DESCRIPTION
This fixes #3795 