### PR TITLE
fix: new API keys are not accepted by outdated YAML validation

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -4,6 +4,7 @@
 
 - UserService: MongoDB had incorrect root user checks and SQLite user service missed the check altogether. Now root user checks are robust. 
 - Camera API: GUEST should not have access to change cameras
+- YAML import validation: new API keys are not accepted by outdated YAML validation
 
 # FDM Monster 23/11/2024 1.7.5
 

--- a/src/services/validators/yaml-service.validation.ts
+++ b/src/services/validators/yaml-service.validation.ts
@@ -37,7 +37,7 @@ export const importPrintersFloorsYamlRules = (
     "config.floorComparisonStrategiesByPriority": "required|string|in:name,floor,id",
     printers: `${!!importPrinters ? "array|minLength:0" : "not"}`,
     "printers.*.id": "required",
-    "printers.*.apiKey": `required|length:${apiKeyLengthMaxDefault},${apiKeyLengthMinDefault}|alphaNumeric`,
+    "printers.*.apiKey": `required|length:${apiKeyLengthMaxDefault},${apiKeyLengthMinDefault}|alphaDash`,
     "printers.*.printerURL": "required|httpurl",
     "printers.*.enabled": "boolean",
     "printers.*.printerType": `integer|in:${OctoprintType},${MoonrakerType}`,


### PR DESCRIPTION
# Description

This adapts the yaml validation to the latest OctoPrint API key format which might include dash and underscore