### PR TITLE
fix: sometimes the moonraker services object can miss properties

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,5 +1,9 @@
 # Develop
 
+##
+
+- Moonraker 'notify_service_state_changed' event: sometimes the moonraker services object can miss properties
+
 ## Features
 
 - Settings: add grid setting to show cancel button instead of quick stop button

--- a/src/services/moonraker/moonraker-websocket.adapter.ts
+++ b/src/services/moonraker/moonraker-websocket.adapter.ts
@@ -280,9 +280,9 @@ export class MoonrakerWebsocketAdapter extends WebsocketRpcExtendedAdapter imple
     if (eventName === "notify_service_state_changed") {
       const serviceChanged = event.params[0] as NotifyServiceStateChangedParams;
       if (
-        serviceChanged.klipper.active_state ||
-        serviceChanged.klipper_mcu.active_state ||
-        serviceChanged.moonraker.active_state
+        serviceChanged.klipper?.active_state ||
+        serviceChanged.klipper_mcu?.active_state ||
+        serviceChanged.moonraker?.active_state
       ) {
         this.logger.log("Received notify_service_state_changed, reloading Moonraker printer objects");
         await this.setupSocketSession();


### PR DESCRIPTION
# Description

![image](https://github.com/user-attachments/assets/aa6d0a5f-0509-4060-bcda-b7b7570f0d33)
