### PR TITLE
Fix/3856 bug regression 3778 printer state not reloaded

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,8 +1,10 @@
 # Develop
 
-##
+## Fixes
 
 - Moonraker 'notify_service_state_changed' event: sometimes the moonraker services object can miss properties
+- PrinterEventsCache: remove cache protection against deleted keys as this caused retry loops to stop updating printer state. Cache prevention on this level is too rough and needs to be moved to the place responsible for socket deletion.
+- WebsocketAdapters (OctoPrint, Moonraker): prevent a deleted socket from entering cache state again by silencing the event emits in the printer socket
 
 ## Features
 

--- a/src/controllers/printer.controller.ts
+++ b/src/controllers/printer.controller.ts
@@ -318,7 +318,7 @@ export class PrinterController {
         await printerApi.getVersion();
       }
     } catch (e) {
-      this.logger.log("OctoPrint /api/version test failed");
+      this.logger.log("Printer version test failed");
 
       if (e instanceof AxiosError) {
         this.logger.debug(e.message + " " + e.status + " " + e.response?.status);
@@ -333,7 +333,7 @@ export class PrinterController {
           case 0:
           case 502:
           case 503: {
-            throw new FailedDependencyException("OctoPrint unreachable", e.response?.status);
+            throw new FailedDependencyException("Printer service unreachable", e.response?.status);
           }
           default: {
             if (!e.response?.status) {
@@ -341,15 +341,18 @@ export class PrinterController {
               // ENOTFOUND: DNS problem
               // ECONNREFUSED: Port has no socket bound
               // ERR_BAD_REQUEST
-              throw new FailedDependencyException(`Reaching OctoPrint failed without status (code ${e.code})`);
+              throw new FailedDependencyException(`Reaching Printer service failed without status (code ${e.code})`);
             } else {
-              throw new FailedDependencyException(`Reaching OctoPrint failed with status (code ${e.code})`, e.response?.status);
+              throw new FailedDependencyException(
+                `Reaching Printer service failed with status (code ${e.code})`,
+                e.response?.status
+              );
             }
           }
         }
       }
 
-      throw new InternalServerException(`Could not call OctoPrint, internal problem`, (e as Error).stack);
+      throw new InternalServerException(`Could not call Printer service, internal problem`, (e as Error).stack);
     }
   }
 

--- a/src/services/moonraker/moonraker-websocket.adapter.ts
+++ b/src/services/moonraker/moonraker-websocket.adapter.ts
@@ -320,6 +320,10 @@ export class MoonrakerWebsocketAdapter extends WebsocketRpcExtendedAdapter imple
   }
 
   emitEventSync(event: string, payload: any) {
+    if (!this.eventEmittingAllowed) {
+      return;
+    }
+
     this.eventEmitter.emit(moonrakerEvent(event), {
       event,
       payload,
@@ -419,6 +423,10 @@ export class MoonrakerWebsocketAdapter extends WebsocketRpcExtendedAdapter imple
   }
 
   private async emitEvent(event: string, payload?: any) {
+    if (!this.eventEmittingAllowed) {
+      return;
+    }
+
     await this.eventEmitter.emitAsync(moonrakerEvent(event), {
       event,
       payload,

--- a/src/services/octoprint/octoprint-websocket.adapter.ts
+++ b/src/services/octoprint/octoprint-websocket.adapter.ts
@@ -22,6 +22,7 @@ import { Event as WsEvent } from "ws";
 import { CurrentMessageDto } from "@/services/octoprint/dto/websocket/current-message.dto";
 import { OctoprintErrorDto } from "@/services/octoprint/dto/rest/error.dto";
 import { OctoprintType } from "@/services/printer-api.interface";
+import { IWebsocketAdapter } from "@/services/websocket-adapter.interface";
 
 export const WsMessage = {
   // Custom events
@@ -45,7 +46,7 @@ export const OctoPrintMessage = {
 
 export const octoPrintEvent = (event: string) => `octoprint.${event}`;
 
-export class OctoprintWebsocketAdapter extends WebsocketAdapter {
+export class OctoprintWebsocketAdapter extends WebsocketAdapter implements IWebsocketAdapter {
   public readonly printerType = 0;
   octoprintClient: OctoprintClient;
   public printerId?: IdType;
@@ -59,7 +60,7 @@ export class OctoprintWebsocketAdapter extends WebsocketAdapter {
   reauthRequired = false;
   reauthRequiredTimestamp: null | number = null;
   login?: LoginDto;
-  protected logger: LoggerService;
+  protected declare logger: LoggerService;
   private eventEmitter: EventEmitter2;
   private configService: ConfigService;
   private socketURL?: URL;
@@ -273,6 +274,10 @@ export class OctoprintWebsocketAdapter extends WebsocketAdapter {
   }
 
   emitEventSync(event: string, payload: any) {
+    if (!this.eventEmittingAllowed) {
+      return;
+    }
+
     this.eventEmitter.emit(octoPrintEvent(event), {
       event,
       payload,
@@ -329,6 +334,10 @@ export class OctoprintWebsocketAdapter extends WebsocketAdapter {
   }
 
   private async emitEvent(event: string, payload?: any) {
+    if (!this.eventEmittingAllowed) {
+      return;
+    }
+
     await this.eventEmitter.emitAsync(octoPrintEvent(event), {
       event,
       payload,

--- a/src/services/websocket-adapter.interface.ts
+++ b/src/services/websocket-adapter.interface.ts
@@ -26,4 +26,8 @@ export interface IWebsocketAdapter<T = IdType> {
   setupSocketSession(): Promise<void>;
 
   resetSocketState(): void;
+
+  allowEmittingEvents(): void;
+
+  disallowEmittingEvents(): void;
 }

--- a/src/shared/websocket-rpc-extended.adapter.ts
+++ b/src/shared/websocket-rpc-extended.adapter.ts
@@ -7,7 +7,7 @@ import { LoggerService } from "@/handlers/logger";
 import { JsonRpcEventDto } from "@/services/moonraker/dto/websocket/json-rpc-event.dto";
 
 export abstract class WebsocketRpcExtendedAdapter extends WebsocketAdapter {
-  protected logger: LoggerService;
+  protected declare logger: LoggerService;
   protected constructor({ loggerFactory }: { loggerFactory: ILoggerFactory }) {
     super({ loggerFactory });
 
@@ -16,7 +16,6 @@ export abstract class WebsocketRpcExtendedAdapter extends WebsocketAdapter {
     this.requestMap = new Map();
   }
 
-  private nextRequestId = 0;
   private requestMap: Map<
     number,
     {

--- a/src/shared/websocket.adapter.ts
+++ b/src/shared/websocket.adapter.ts
@@ -8,6 +8,7 @@ export type WsProtocol = "ws" | "wss";
 export class WebsocketAdapter {
   socket?: WebSocket;
   protected logger: LoggerService;
+  eventEmittingAllowed: boolean = true;
 
   constructor({ loggerFactory }: { loggerFactory: ILoggerFactory }) {
     this.logger = loggerFactory(WebsocketAdapter.name);
@@ -20,6 +21,14 @@ export class WebsocketAdapter {
   public close() {
     this.socket?.close();
     delete this.socket;
+  }
+
+  public allowEmittingEvents() {
+    this.eventEmittingAllowed = true;
+  }
+
+  public disallowEmittingEvents() {
+    this.eventEmittingAllowed = false;
   }
 
   /**

--- a/src/state/printer-socket.store.ts
+++ b/src/state/printer-socket.store.ts
@@ -264,9 +264,12 @@ export class PrinterSocketStore {
 
   private deleteSocket(printerId: string) {
     const socket = this.printerSocketAdaptersById[printerId];
-    if (!!socket) {
-      socket.close();
-    }
+
+    // Ensure that the printer does not re-register itself after being purged
+    socket?.disallowEmittingEvents();
+
+    socket?.close();
+
     // TODO mark diff cache
     delete this.printerSocketAdaptersById[printerId];
   }

--- a/src/state/settings.store.ts
+++ b/src/state/settings.store.ts
@@ -23,7 +23,7 @@ import {
 import { ILoggerFactory } from "@/handlers/logger-factory";
 
 export class SettingsStore {
-  private isTypeOrmMode: boolean;
+  private readonly isTypeOrmMode: boolean;
   private settingsService: ISettingsService;
   private logger: LoggerService;
   private settings: ISettings | null = null;

--- a/src/state/test-printer-socket.store.ts
+++ b/src/state/test-printer-socket.store.ts
@@ -119,6 +119,9 @@ export class TestPrinterSocketStore {
       this.logger.error(`Test harness error ${errorSummary(e)}`);
       captureException(e);
     } finally {
+      // Ensure that the printer does not re-register itself after being purged
+      this.testSocket.disallowEmittingEvents();
+
       if (this.testSocket) {
         this.testSocket.close();
       }

--- a/src/utils/cache/key-diff.cache.ts
+++ b/src/utils/cache/key-diff.cache.ts
@@ -75,11 +75,6 @@ export class KeyDiffCache<T> {
       throw new Error("Key must be a non-empty serializable string");
     }
 
-    // We dont accept deleted key updates
-    if (this.deletedKeys.includes(keyString)) {
-      return;
-    }
-
     this.keyValueStore[keyString] = value;
     if (markUpdated) {
       this.markUpdated(keyString);


### PR DESCRIPTION
# Description

- fix: remove cache protection against deleted keys as this caused retry loops to stop updating printer state. Cache prevention on this level is too rough and needs to be moved to the place responsible for socket deletion.
- fix: prevent a deleted socket from entering cache state again by silencing the event emits in the printer socket