### PR TITLE
Added a kustomization configuration and deployment guide for kubernetes users.

### DIFF
--- a/kubernetes/.gitignore
+++ b/kubernetes/.gitignore
@@ -1,0 +1,1 @@
+overlays/

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,158 @@
+# FDM Monster Kubernetes Guide
+
+This configuration template is provided for those wanting to deploy FDM Monster via kubernetes. This guide uses the [kustomize](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/) convention that employs [bases and overlays](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#bases-and-overlays) to keep things generalized.  Customization to a specific deployment is done through and overlay.
+
+## Requirements
+
+A kubernetes installation that has `ingress` functionality enabled. This configuration was tested with [microk8s](https://microk8s.io/).
+
+## Try/Test Base Configuration
+
+The base configuration uses `emptyDir` volumes, so you can try fdm-monster by simply applying the base configuration.
+
+```bash
+kubectl apply -k base
+```
+
+You can then navigate to `fdm-monster.local` and go through the setup process and explore the functionality. Note that there is no persistent storage configured due to the `emptyDir` configuration so continue to the section below to deploy and configure persistent storage.
+
+## Deploy
+
+First create an overlay:
+
+```bash
+mkdir -p kubernetes/overlays/local
+cd kubernetes/overlays/local
+```
+
+Next create patch files to alter the volumes, environment variables, or whatever else you'd like. Below is an example of changing the volumes from `emptyDir` to an `nfs` source. If using an nfs be sure to replace IP's below with your nfs IP address and appropriate export path.
+
+```bash
+cat > deployment-fdm-monster-patch.yaml << EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: fdm-monster
+  name: fdm-monster
+spec:
+  selector:
+    matchLabels:
+      app: fdm-monster
+  template:
+    spec:
+      volumes:
+        - name: fdm-monster-media
+          nfs:
+            server: 192.168.1.42
+            path: /opt/kube-nfs/fdm-monster/media
+            readOnly: false
+status: {}
+EOF
+```
+
+Do the same for the mongodb instance:
+
+```bash
+cat > deployment-mongodb-patch.yaml << EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: mongodb
+  name: mongodb
+spec:
+  selector:
+    matchLabels:
+      app: mongodb
+  template:
+    spec:
+      volumes:
+      - name: mongo-data
+        nfs:
+          server: 192.168.1.42
+          path: /opt/kube-nfs/fdm-monster/mongodb/db
+          readOnly: false
+      - name: mongo-config
+        nfs:
+          server: 192.168.1.42
+          path: /opt/kube-nfs/fdm-monster/mongodb/config
+          readOnly: false
+EOF
+```
+
+NOTE: For nfs, make sure the directory structure is created in advance and appropriate exports are configured.
+
+If you want to use an alternative ingress you can patch it by first creating a replacement ingress definition:
+
+```bash
+cat > ingress-patch.yaml << EOF
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: fdm-monster-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+spec:
+  rules:
+  - host: "fdm-monster.myhomedomain.local"
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: fdm-monster
+            port:
+              number: 4000
+EOF
+```
+
+At this point you can add/remove other patches per the kustomize [patch documentation](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#customizing). One may want to edit the namespace or add additional services, etc. After all your patches are finished you just need to create a `kustomization.yaml` file in the overlay that references the base.
+
+```bash
+cat > kustomization.yaml << EOF
+resources:
+  - ../../base
+patches:
+  - path: deployment-fdm-monster-patch.yaml
+  - path: deployment-mongodb-patch.yaml
+  - path: ingress-patch.yaml
+    target:
+      kind: Ingress
+      name: fdm-monster-ingress
+EOF
+```
+
+After this, test out your configuration:
+
+```bash
+# Assumes you're still in the overlay/local directory
+kubectl apply -k . 
+```
+
+You can then watch the deployment with `watch kubectl get all -n fdm-monster`. Output should look like the below once everything is up and running:
+
+```bash
+Every 2.0s: kubectl get all -n fdm-monster                                                                                                 ubuntu: Sat Dec 14 17:39:53 2024
+
+NAME                               READY   STATUS    RESTARTS   AGE
+pod/fdm-monster-66496c586c-rrzs6   1/1     Running   0          5m30s
+pod/mongodb-b489dd758-tvc7v        1/1     Running   0          5m30s
+
+NAME                  TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)     AGE
+service/fdm-monster   ClusterIP   10.152.183.71   <none>        4000/TCP    5m30s
+service/mongodb       ClusterIP   10.152.183.53   <none>        27017/TCP   5m30s
+
+NAME                          READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/fdm-monster   1/1     1            1           5m30s
+deployment.apps/mongodb       1/1     1            1           5m30s
+
+NAME                                     DESIRED   CURRENT   READY   AGE
+replicaset.apps/fdm-monster-66496c586c   1         1         1       5m30s
+replicaset.apps/mongodb-b489dd758        1         1         1       5m30s
+```
+
+You can then navigate to [fdm-monster.local](http://fdm-monster.local) or your modified hostname in the patch to setup fdm-monster.

--- a/kubernetes/base/deployment-fdm-monster.yaml
+++ b/kubernetes/base/deployment-fdm-monster.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: fdm-monster
+  name: fdm-monster
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fdm-monster
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: fdm-monster
+    spec:
+      initContainers:
+      - name: mongo-startup
+        image: busybox:latest
+        command:
+        - nc
+        - -zv
+        - mongodb
+        - "27017"
+      containers:
+      - image: fdmmonster/fdm-monster:latest
+        name: fdm-monster
+        resources: {}
+        volumeMounts:
+          - name: fdm-monster-media
+            mountPath: /app/media
+        env:
+          - name: MONGO
+            value: mongodb://admin:admin@mongodb:27017/fdm-monster?authSource=admin
+        livenessProbe:
+          tcpSocket:
+            port: 4000
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        readinessProbe:
+          tcpSocket:
+            port: 4000
+          initialDelaySeconds: 30
+          periodSeconds: 10
+      volumes:
+        - name: fdm-monster-media
+          emptyDir:
+status: {}

--- a/kubernetes/base/deployment-mongodb.yaml
+++ b/kubernetes/base/deployment-mongodb.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: mongodb
+  name: mongodb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mongodb
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: mongodb
+    spec:
+      containers:
+      - image: mongo:latest
+        name: mongo
+        resources: {}
+        livenessProbe:
+          tcpSocket:
+            port: 27017
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        readinessProbe:
+          tcpSocket:
+            port: 27017
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        env:
+          - name: MONGO_INITDB_ROOT_USERNAME
+            value: admin
+          - name: MONGO_INITDB_ROOT_PASSWORD
+            value: admin
+        volumeMounts:
+          - name: mongo-data
+            mountPath: /data/db
+          - name: mongo-config
+            mountPath: /data/configdb
+      volumes:
+      - name: mongo-data
+        emptyDir:
+      - name: mongo-config
+        emptyDir:
+status: {}

--- a/kubernetes/base/ingress.yaml
+++ b/kubernetes/base/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: fdm-monster-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+spec:
+  rules:
+  - host: "fdm-monster.local"
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: fdm-monster
+            port:
+              number: 4000

--- a/kubernetes/base/kustomization.yaml
+++ b/kubernetes/base/kustomization.yaml
@@ -1,0 +1,8 @@
+namespace: fdm-monster
+resources:
+  - deployment-fdm-monster.yaml
+  - deployment-mongodb.yaml
+  - ingress.yaml
+  - namespace.yaml
+  - service-fdm-monster.yaml
+  - service-mongodb.yaml

--- a/kubernetes/base/namespace.yaml
+++ b/kubernetes/base/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fdm-monster
+spec: {}
+status: {}

--- a/kubernetes/base/service-fdm-monster.yaml
+++ b/kubernetes/base/service-fdm-monster.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: fdm-monster
+  name: fdm-monster
+spec:
+  ports:
+  - name: "4000"
+    port: 4000
+    protocol: TCP
+    targetPort: 4000
+  selector:
+    app: fdm-monster
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/kubernetes/base/service-mongodb.yaml
+++ b/kubernetes/base/service-mongodb.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: mongodb
+  name: mongodb
+spec:
+  ports:
+  - name: "27017"
+    port: 27017
+    protocol: TCP
+    targetPort: 27017
+  selector:
+    app: mongodb
+  type: ClusterIP
+status:
+  loadBalancer: {}


### PR DESCRIPTION
# Description

Added a directory `kubernetes/` that includes a [kustomize configuration](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#customizing) that employs bases/overlays to keep the configuration generic. Also included a README guide to describe the testing and deployment process.

Fixes #3921 

## Type of change

- [X ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Deployed and tested on a [microk8s](https://microk8s.io/) instance running on Debian Bookworm with ingress functionality enabled. Was successfully able to add printers and configure admin/users which persisted after deleting and then re-deploying the application with an nfs persistent storage configuration.

A video of the testing I did is available below:

[https://youtu.be/W8vr8TPhEj4](https://youtu.be/W8vr8TPhEj4)

- [ ] Vue test
- [ ] Node test 

**Test Configuration**:
* Node version:
* OctoPrint version:
* Klipper version:
* Nodemon/PM2/docker:

# Checklist:

- [X ] I checked my changes
- [X ] I have commented my code concisely
- [X ] I have covered my changes with tests
