### PR TITLE
fix: filter folders on calling getLocalFiles for OctoPrint

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,5 +1,9 @@
 # Develop
 
+## Fixes
+
+- OctoPrint client: filter folders on calling getLocalFiles for OctoPrint
+
 # FDM Monster 13/12/2024 1.8.1
 
 ## Changes

--- a/src/services/octoprint/octoprint.client.ts
+++ b/src/services/octoprint/octoprint.client.ts
@@ -185,7 +185,7 @@ export class OctoprintClient extends OctoprintRoutes {
     return (
       // Filter out folders
       response?.data?.files
-        ?.filter((f) => f.date)
+        ?.filter((f) => f.date && f.type === "machinecode")
         .map((f) => {
           return normalizePrinterFile(f);
         }) || []


### PR DESCRIPTION
# Description

Regression or unintended behavior. Avoids folders in the file list of OctoPrint.