### PR TITLE
fix: upload progress was not reported

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -4,6 +4,8 @@
 
 - Introduce HttpClientBuilder pattern for Octoprint client
 - Fix Sentry usage has updated
+- Fix upload progress was not updated properly
+- Fix failures and completions in file upload to OctoPrint/Moonraker were not consistently pushed over SocketIO
 
 # FDM Monster 03/01/2025 1.8.2
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "serve": "NODE_ENV=development node --enable-source-maps --watch dist/index.js",
     "start:dev": "ts-node src/index.ts",
     "start": "cross-env NODE_ENV=production node dist/index.js",
+    "console:http-file-receiver": "node ./dist/consoles/http-file-receiver.console.js",
     "console:github-releases": "yarn build && NODE_ENV=development node --watch --enable-source-maps ./dist/consoles/download-github-releases.js",
     "console:generate": "yarn build && NODE_ENV=development node --enable-source-maps ./dist/consoles/typeorm-generate.js",
     "console:torm": "yarn build && NODE_ENV=development node --watch --enable-source-maps ./dist/consoles/sqlite-torm.js",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   ],
   "dependencies": {
     "@fdm-monster/client": "1.9.0",
-    "@fdm-monster/client-next": "0.0.17",
+    "@fdm-monster/client-next": "0.0.18",
     "@octokit/plugin-throttling": "8.2.0",
     "@sentry/node": "9.5.0",
     "adm-zip": "0.5.16",

--- a/src/consoles/http-file-receiver.console.ts
+++ b/src/consoles/http-file-receiver.console.ts
@@ -1,0 +1,74 @@
+import express from "express";
+import multer from "multer";
+import { Request, Response } from "express";
+
+// Custom storage to introduce artificial delay
+const delayedMemoryStorage = (): multer.StorageEngine => {
+  return {
+    _handleFile(req, file, cb) {
+      let chunks: Buffer[] = [];
+      let processingComplete = Promise.resolve();
+
+      console.log(`Processing file upload name ${file.originalname} field ${file.fieldname} size ${file.size}`);
+
+      file.stream.on("data", (chunk) => {
+        chunks.push(chunk);
+        // processingComplete = processingComplete.then(
+        //   () => chunks.push(chunk)
+        //   // new Promise((resolve) => {
+        //   //   setTimeout(() => {
+        //   //     chunks.push(chunk);
+        //   //     resolve(null);
+        //   //   }, 1); // ~1ms delay per chunk
+        //   // })
+        // );
+      });
+
+      file.stream.on("end", () => {
+        cb(null, { buffer: Buffer.concat(chunks), size: Buffer.concat(chunks).length });
+        // processingComplete.then(() => {
+        // });
+      });
+
+      file.stream.on("error", (err) => {
+        cb(err);
+      });
+    },
+    _removeFile(req, file, cb) {
+      cb(null);
+    },
+  };
+};
+
+const upload = multer({ storage: delayedMemoryStorage() });
+
+const app = express();
+
+app.post("/api/files/local", upload.single("file"), (req: Request, res: Response) => {
+  const { select, print } = req.body;
+  const file = req.file;
+
+  if (!file) {
+    return res.status(400).json({ error: "Missing file" });
+  }
+  if (typeof select === "undefined" || typeof print === "undefined") {
+    return res.status(400).json({ error: "Missing required fields: select, print" });
+  }
+  if (Object.keys(req.body).length !== 2) {
+    return res.status(400).json({ error: "Only fields 'select' and 'print' are allowed" });
+  }
+  if (!["true", "false"].includes(select) || !["true", "false"].includes(print)) {
+    return res.status(400).json({ error: "Fields 'select' and 'print' must be boolean values (true/false)" });
+  }
+
+  console.log("Received file:", file.originalname);
+  console.log("File size:", file.size);
+  console.log("MIME type:", file.mimetype);
+  console.log("select:", select, "\nprint:", print, "\n-----");
+
+  res.json({ message: "File received successfully" });
+});
+
+app.listen(1234, () => {
+  console.log("Server is running on http://localhost:1234");
+});

--- a/src/constants/event.constants.ts
+++ b/src/constants/event.constants.ts
@@ -12,6 +12,8 @@ export const printerEvents = {
 export const octoPrintWebsocketEvent = (printerId: IdType) => `octoprint.${printerId}`;
 export const octoPrintWebsocketCurrentEvent = (printerId: IdType) => `octoprint.${printerId}.current`;
 export const uploadProgressEvent = (token: string) => `upload.progress.${token}`;
+export const uploadDoneEvent = (token: string) => `upload.done.${token}`;
+export const uploadFailedEvent = (token: string) => `upload.failed.${token}`;
 export const firmwareFlashUploadEvent = (printerId: IdType) => `firmware-upload.${printerId}`;
 
 export const prefix = "fdm-monster";

--- a/src/controllers/printer-files.controller.ts
+++ b/src/controllers/printer-files.controller.ts
@@ -65,14 +65,6 @@ export class PrinterFilesController {
     this.logger = loggerFactory(PrinterFilesController.name);
   }
 
-  @GET()
-  @route("/tracked-uploads")
-  @before(authorizePermission(PERMS.PrinterFiles.Upload))
-  getTrackedUploads(req: Request, res: Response) {
-    const sessions = this.multerService.getSessions();
-    res.send(sessions);
-  }
-
   @POST()
   @route("/purge")
   @before(authorizePermission(PERMS.PrinterFiles.Clear))
@@ -253,7 +245,7 @@ export class PrinterFilesController {
     }
 
     const uploadedFile = files[0];
-    const token = this.multerService.startTrackingSession(uploadedFile);
+    const token = this.multerService.startTrackingSession(uploadedFile, currentPrinterId);
     await this.printerApi.uploadFile(uploadedFile, token);
     await this.printerFilesStore.loadFiles(currentPrinterId);
 

--- a/src/server.constants.ts
+++ b/src/server.constants.ts
@@ -71,7 +71,7 @@ export const AppConstants = {
   orgName: "fdm-monster",
   // Wizard version changes will trigger a re-run of the wizard
   currentWizardVersion: 1,
-  defaultClientMinimum: "1.8.8",
+  defaultClientMinimum: "1.9.0",
 
   influxUrl: "INFLUX_URL",
   influxToken: "INFLUX_TOKEN",

--- a/src/services/core/multer.service.ts
+++ b/src/services/core/multer.service.ts
@@ -1,4 +1,4 @@
-import multer, { FileFilterCallback } from "multer";
+import multer, { diskStorage, FileFilterCallback, memoryStorage } from "multer";
 import { extname, join } from "path";
 import { createWriteStream, existsSync, lstatSync, mkdirSync, readdirSync, unlink } from "fs";
 import { superRootPath } from "@/utils/fs.utils";
@@ -6,7 +6,7 @@ import { AppConstants } from "@/server.constants";
 import { FileUploadTrackerCache } from "@/state/file-upload-tracker.cache";
 import { Request, Response } from "express";
 import { HttpClientFactory } from "@/services/core/http-client.factory";
-import { DefaultHttpClientBuilder } from "@/shared/default-http-client.builder";
+import { IdType } from "../../shared.constants";
 
 export class MulterService {
   fileUploadTrackerCache: FileUploadTrackerCache;
@@ -94,10 +94,10 @@ export class MulterService {
   getMulterFileFilter(fileExtensions: string[], storeAsFile = true) {
     return multer({
       storage: storeAsFile
-        ? multer.diskStorage({
+        ? diskStorage({
             destination: join(superRootPath(), AppConstants.defaultFileStorageFolder),
           })
-        : multer.memoryStorage(),
+        : memoryStorage(),
       fileFilter: this.multerFileFilter(fileExtensions),
     }).any();
   }
@@ -112,8 +112,8 @@ export class MulterService {
     };
   }
 
-  startTrackingSession(multerFile: Express.Multer.File) {
-    return this.fileUploadTrackerCache.addUploadTracker(multerFile);
+  startTrackingSession(multerFile: Express.Multer.File, printerId: IdType) {
+    return this.fileUploadTrackerCache.addUploadTracker(multerFile, printerId);
   }
 
   getSessions() {

--- a/src/services/interfaces/file-upload-tracker.interface.ts
+++ b/src/services/interfaces/file-upload-tracker.interface.ts
@@ -1,4 +1,4 @@
-import { IdType } from "../../shared.constants";
+import { IdType } from "@/shared.constants";
 
 export interface TrackedUpload {
   correlationToken: string;
@@ -8,12 +8,9 @@ export interface TrackedUpload {
     originalname: string;
     [k: string]: any;
   };
-  progress: {
-    percent: number;
-    [k: string]: number;
-  };
-  succeededAt?: number;
-  failedAt?: number;
+  progress: number;
+  completed: boolean;
+  completedAt?: number;
+  success?: boolean;
   reason?: string;
-  complete: boolean;
 }

--- a/src/services/interfaces/file-upload-tracker.interface.ts
+++ b/src/services/interfaces/file-upload-tracker.interface.ts
@@ -1,0 +1,19 @@
+import { IdType } from "../../shared.constants";
+
+export interface TrackedUpload {
+  correlationToken: string;
+  printerId: IdType;
+  startedAt: number;
+  multerFile: {
+    originalname: string;
+    [k: string]: any;
+  };
+  progress: {
+    percent: number;
+    [k: string]: number;
+  };
+  succeededAt?: number;
+  failedAt?: number;
+  reason?: string;
+  complete: boolean;
+}

--- a/src/services/octoprint/octoprint.client.ts
+++ b/src/services/octoprint/octoprint.client.ts
@@ -243,7 +243,7 @@ export class OctoprintClient extends OctoprintRoutes {
     let knownFileSize = (multerFileOrBuffer as Express.Multer.File).size;
     if (!fileBuffer) {
       const filePath = (multerFileOrBuffer as Express.Multer.File).path;
-      const fileStream = createReadStream(filePath, { highWaterMark: 16 * 1024 });
+      const fileStream = createReadStream(filePath, { highWaterMark: 512 });
       knownFileSize = fs.statSync(filePath).size;
 
       const delayedStream = new Readable({

--- a/src/services/octoprint/octoprint.client.ts
+++ b/src/services/octoprint/octoprint.client.ts
@@ -1,6 +1,5 @@
 import fs, { createReadStream, ReadStream } from "fs";
 import path from "path";
-import { Readable } from "stream";
 import FormData from "form-data";
 import { pluginRepositoryUrl } from "./constants/octoprint-service.constants";
 import { firmwareFlashUploadEvent, uploadDoneEvent, uploadFailedEvent, uploadProgressEvent } from "@/constants/event.constants";
@@ -30,11 +29,6 @@ import { OctoprintFileDto } from "@/services/octoprint/dto/files/octoprint-file.
 import { OP_PluginDto } from "@/services/octoprint/dto/plugin.dto";
 
 type TAxes = "x" | "y" | "z";
-
-const AB = new Int32Array(new SharedArrayBuffer(4));
-function sleep(t: number) {
-  Atomics.wait(AB, 0, 0, Math.max(1, t | 0));
-}
 
 /**
  * OctoPrint REST API
@@ -240,55 +234,14 @@ export class OctoprintClient extends OctoprintRoutes {
 
     let fileBuffer: ArrayBufferLike | ReadStream = (multerFileOrBuffer as Buffer).buffer;
     const filename = (multerFileOrBuffer as Express.Multer.File).originalname;
-    let knownFileSize = (multerFileOrBuffer as Express.Multer.File).size;
-    if (!fileBuffer) {
-      const filePath = (multerFileOrBuffer as Express.Multer.File).path;
-      const fileStream = createReadStream(filePath, { highWaterMark: 512 });
-      knownFileSize = fs.statSync(filePath).size;
-
-      const delayedStream = new Readable({
-        read() {}, // No need to override read, we'll push manually
-      });
-
-      let uploaded = 0;
-      let total = knownFileSize;
-      fileStream.on("data", (chunk) => {
-        fileStream.pause(); // Pause reading while we delay
-
-        uploaded += chunk.length;
-
-        // sleep(1);
-        delayedStream.push(chunk);
-        fileStream.resume(); // Resume after delay
-        const progress = uploaded / total;
-        console.log(`Upload file ${filename} - progress ${(100.0 * uploaded) / total}% `);
-        this.eventEmitter2.emit(`${uploadProgressEvent(token)}`, token, {
-          percent: progress,
-          progress: uploaded / total,
-        });
-        // setTimeout(() => {
-        //
-        // }, 1);
-      });
-
-      fileStream.on("end", () => delayedStream.push(null));
-
-      this.logger.log(`Attaching file from disk to formdata of size ${knownFileSize}`);
-      // const streamWithDelay = new Readable({
-      //   read() {
-      //     fileStream.on("data", (chunk) => {
-      //       this.push(chunk);
-      //       setTimeout(() => this.resume(), 1); // 100ms delay per chunk
-      //       this.pause();
-      //     });
-      //
-      //     fileStream.on("end", () => this.push(null));
-      //   },
-      // });
-      formData.append("file", delayedStream, { filename });
-    } else {
-      this.logger.log("Attaching file from memory buffer to formdata");
+    if (fileBuffer) {
+      this.logger.log("Attaching file from memory buffer to formdata for upload");
       formData.append("file", fileBuffer, { filename });
+    } else {
+      const filePath = (multerFileOrBuffer as Express.Multer.File).path;
+      const fileStream = createReadStream(filePath);
+      this.logger.log(`Attaching file from disk to formdata for upload`);
+      formData.append("file", fileStream, { filename });
     }
 
     // Calculate the header that axios uses to determine progress
@@ -302,17 +255,15 @@ export class OctoprintClient extends OctoprintRoutes {
     try {
       const response = await this.createClient(login, (builder) =>
         builder
-          .withBaseUrl("http://localhost:1234")
           .withMultiPartFormData()
           .withHeaders({
             ...formData.getHeaders(),
-            // "Content-Length": result?.toString() ?? knownFileSize.toString(),
+            "Content-Length": result.toString(),
           })
           .withOnUploadProgress((p) => {
-            // console.log(`Upload file ${filename} - progress ${p.progress} `);
-            // if (token) {
-            //   this.eventEmitter2.emit(`${uploadProgressEvent(token)}`, token, p);
-            // }
+            if (token) {
+              this.eventEmitter2.emit(`${uploadProgressEvent(token)}`, token, p);
+            }
           })
       ).post(urlPath, formData);
 

--- a/src/services/octoprint/octoprint.client.ts
+++ b/src/services/octoprint/octoprint.client.ts
@@ -2,10 +2,10 @@ import fs, { createReadStream, ReadStream } from "fs";
 import path from "path";
 import FormData from "form-data";
 import { pluginRepositoryUrl } from "./constants/octoprint-service.constants";
-import { firmwareFlashUploadEvent, uploadProgressEvent } from "@/constants/event.constants";
+import { firmwareFlashUploadEvent, uploadDoneEvent, uploadFailedEvent, uploadProgressEvent } from "@/constants/event.constants";
 import { ExternalServiceError } from "@/exceptions/runtime.exceptions";
 import { OctoprintRoutes } from "./octoprint-api.routes";
-import { AxiosPromise } from "axios";
+import { AxiosError, AxiosPromise } from "axios";
 import EventEmitter2 from "eventemitter2";
 import { LoggerService } from "@/handlers/logger";
 import { LoginDto } from "@/services/interfaces/login.dto";
@@ -267,9 +267,11 @@ export class OctoprintClient extends OctoprintRoutes {
       //   fs.unlinkSync((fileStreamOrBuffer as Express.Multer.File).path);
       // }
 
+      this.eventEmitter2.emit(`${uploadDoneEvent(token)}`, token);
+
       return response.data;
     } catch (e: any) {
-      this.eventEmitter2.emit(`${uploadProgressEvent(token)}`, token, { failed: true }, e);
+      this.eventEmitter2.emit(`${uploadFailedEvent(token)}`, token, (e as AxiosError)?.message);
       let data;
       try {
         data = JSON.parse(e.response?.body);

--- a/src/shared/default-http-client.builder.ts
+++ b/src/shared/default-http-client.builder.ts
@@ -32,6 +32,7 @@ export class DefaultHttpClientBuilder implements IHttpClientBuilder {
       maxBodyLength: this.axiosOptions.maxBodyLength ?? 1000 * 1000 * 1000, // 1GB,
       maxContentLength: this.axiosOptions.maxContentLength ?? 1000 * 1000 * 1000, // 1GB
       responseType: this.axiosOptions.responseType,
+      onUploadProgress: this.axiosOptions.onUploadProgress,
     };
 
     return axios.create(axiosConfig);

--- a/src/state/file-upload-tracker.cache.ts
+++ b/src/state/file-upload-tracker.cache.ts
@@ -69,6 +69,9 @@ export class FileUploadTrackerCache {
 
   handleUploadProgress(token: string, progress: AxiosProgressEvent) {
     const upload = this.getUpload(token);
+    if (!upload) {
+      return;
+    }
     upload.progress = progress;
   }
 

--- a/src/state/file-upload-tracker.cache.ts
+++ b/src/state/file-upload-tracker.cache.ts
@@ -4,23 +4,8 @@ import EventEmitter2 from "eventemitter2";
 import { LoggerService } from "@/handlers/logger";
 import { AxiosProgressEvent } from "axios";
 import { ILoggerFactory } from "@/handlers/logger-factory";
-
-interface TrackedUpload {
-  correlationToken: string;
-  startedAt: number;
-  multerFile: {
-    originalname: string;
-    [k: string]: any;
-  };
-  progress: {
-    percent: number;
-    [k: string]: number;
-  };
-  succeededAt?: number;
-  failedAt?: number;
-  reason?: string;
-  complete: boolean;
-}
+import { TrackedUpload } from "../services/interfaces/file-upload-tracker.interface";
+import { IdType } from "../shared.constants";
 
 /**
  * A generic cache for file upload progress
@@ -49,12 +34,13 @@ export class FileUploadTrackerCache {
     return this.currentUploads.find((cu) => cu.correlationToken === correlationToken);
   }
 
-  addUploadTracker(multerFile: Express.Multer.File) {
+  addUploadTracker(multerFile: Express.Multer.File, printerId: IdType) {
     const correlationToken = generateCorrelationToken();
     this.logger.log(`Starting upload session with token ${correlationToken}`);
 
     this.currentUploads.push({
       correlationToken,
+      printerId,
       startedAt: Date.now(),
       multerFile,
       progress: {

--- a/src/state/file-upload-tracker.cache.ts
+++ b/src/state/file-upload-tracker.cache.ts
@@ -4,12 +4,9 @@ import EventEmitter2 from "eventemitter2";
 import { LoggerService } from "@/handlers/logger";
 import { AxiosProgressEvent } from "axios";
 import { ILoggerFactory } from "@/handlers/logger-factory";
-import { TrackedUpload } from "../services/interfaces/file-upload-tracker.interface";
-import { IdType } from "../shared.constants";
+import { TrackedUpload } from "@/services/interfaces/file-upload-tracker.interface";
+import { IdType } from "@/shared.constants";
 
-/**
- * A generic cache for file upload progress
- */
 export class FileUploadTrackerCache {
   private currentUploads: TrackedUpload[] = [];
   private eventEmitter2: EventEmitter2;
@@ -43,22 +40,22 @@ export class FileUploadTrackerCache {
       printerId,
       startedAt: Date.now(),
       multerFile,
-      progress: {
-        percent: 0,
-        progress: 0,
-      },
-      complete: false,
+      progress: 0,
+      completed: false,
+      completedAt: null,
+      success: null,
+      reason: null,
     });
 
     return correlationToken;
   }
 
-  handleUploadProgress(token: string, progress: AxiosProgressEvent) {
+  handleUploadProgress(token: string, event: AxiosProgressEvent) {
     const upload = this.getUpload(token);
     if (!upload) {
       return;
     }
-    upload.progress = progress;
+    upload.progress = event.progress;
   }
 
   handleUploadFailed(token: string, reason?: string) {
@@ -80,13 +77,9 @@ export class FileUploadTrackerCache {
 
     const trackedUpload = this.currentUploads[trackedUploadIndex];
 
-    if (success) {
-      trackedUpload.succeededAt = Date.now();
-      trackedUpload.complete = true;
-    } else {
-      trackedUpload.failedAt = Date.now();
-      trackedUpload.reason = reason;
-      trackedUpload.complete = true;
-    }
+    trackedUpload.completed = true;
+    trackedUpload.success = success;
+    trackedUpload.completedAt = Date.now();
+    trackedUpload.reason = reason;
   }
 }

--- a/src/tasks/boot.task.ts
+++ b/src/tasks/boot.task.ts
@@ -170,8 +170,8 @@ export class BootTask {
     this.multerService.clearUploadsFolder();
     this.logger.log("Loading printer sockets");
     await this.printerSocketStore.loadPrinterSockets(); // New sockets
-    this.logger.log("Loading files store");
-    await this.printerFilesStore.loadFilesStore();
+    // this.logger.log("Loading files store");
+    // await this.printerFilesStore.loadFilesStore();
     this.logger.log("Loading floor store");
     await this.floorStore.loadStore();
     this.logger.log("Loading printer thumbnail cache");

--- a/src/tasks/boot.task.ts
+++ b/src/tasks/boot.task.ts
@@ -170,8 +170,8 @@ export class BootTask {
     this.multerService.clearUploadsFolder();
     this.logger.log("Loading printer sockets");
     await this.printerSocketStore.loadPrinterSockets(); // New sockets
-    // this.logger.log("Loading files store");
-    // await this.printerFilesStore.loadFilesStore();
+    this.logger.log("Loading files store");
+    await this.printerFilesStore.loadFilesStore();
     this.logger.log("Loading floor store");
     await this.floorStore.loadStore();
     this.logger.log("Loading printer thumbnail cache");

--- a/src/tasks/socketio.task.ts
+++ b/src/tasks/socketio.task.ts
@@ -95,7 +95,7 @@ export class SocketIoTask {
     const serializedData = JSON.stringify(socketIoData);
     const transportDataSize = sizeKB(serializedData);
     this.updateAggregator(transportDataSize);
-    this.socketIoGateway.send(IO_MESSAGES.LegacyUpdate, serializedData);
+    this.socketIoGateway.send(IO_MESSAGES.LegacyUpdate, socketIoData);
   }
 
   updateAggregator(transportDataLength: number) {

--- a/src/tasks/socketio.task.ts
+++ b/src/tasks/socketio.task.ts
@@ -72,7 +72,7 @@ export class SocketIoTask {
     const printers = await this.printerCache.listCachedPrinters(true);
     const socketStates = this.printerSocketStore.getSocketStatesById();
     const printerEvents = await this.printerEventsCache.getAllKeyValues();
-    const trackedUploads = this.fileUploadTrackerCache.getUploads(true);
+    const trackedUploads = this.fileUploadTrackerCache.getUploads();
 
     const socketIoData = {
       printers,

--- a/test/api/printer-files-controller.test.ts
+++ b/test/api/printer-files-controller.test.ts
@@ -11,7 +11,6 @@ import { IPrinterService } from "@/services/interfaces/printer.service.interface
 import TestAgent from "supertest/lib/agent";
 
 const defaultRoute = AppConstants.apiRoute + "/printer-files";
-const trackedUploadsRoute = `${defaultRoute}/tracked-uploads`;
 const purgeIndexedFilesRoute = `${defaultRoute}/purge`;
 const thumbnailsRoute = `${defaultRoute}/thumbnails`;
 type idType = Number;
@@ -101,16 +100,6 @@ describe(PrinterFilesController.name, () => {
     const response = await request.post(reloadThumbnailRoute(printer.id)).send({
       filePath: "123.gcode",
     });
-    expectOkResponse(response);
-  });
-
-  it("should allow GET on printer files - tracked uploads", async () => {
-    const response = await request.get(trackedUploadsRoute).send();
-    expectOkResponse(response);
-  });
-
-  it("should allow GET on printer files - tracked uploads", async () => {
-    const response = await request.get(trackedUploadsRoute).send();
     expectOkResponse(response);
   });
 

--- a/test/application/multer.service.test.ts
+++ b/test/application/multer.service.test.ts
@@ -29,12 +29,10 @@ describe("MulterService", () => {
   });
 
   it("should be able to start tracking upload", async () => {
-    multerService.startTrackingSession({});
+    multerService.startTrackingSession({}, 1);
 
     const trackedSessions = multerService.getSessions();
     expect(trackedSessions.current).not.toHaveLength(0);
-    expect(trackedSessions.done).toHaveLength(0);
-    expect(trackedSessions.failed).toHaveLength(0);
   });
 
   it("should provide multer filter middleware", async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1010,10 +1010,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fdm-monster/client-next@npm:0.0.17":
-  version: 0.0.17
-  resolution: "@fdm-monster/client-next@npm:0.0.17"
-  checksum: 10c0/a4dc9d744ec5199594480a56a4599749f659753c57e1f2b81cd9f1637c1341d006a489e7a35d67317a7ca1fb7ece15fba7f4ee337518f1d997f74cfac13e366c
+"@fdm-monster/client-next@npm:0.0.18":
+  version: 0.0.18
+  resolution: "@fdm-monster/client-next@npm:0.0.18"
+  checksum: 10c0/e8e31770a7ba7156a3bd002777e376912f15213c51b9f333659f9e340479d4d60ed109bf514255d7d1b99e5d63eaf00f0068a2aada725c27ba9f5af8d95f6b4d
   languageName: node
   linkType: hard
 
@@ -1029,7 +1029,7 @@ __metadata:
   resolution: "@fdm-monster/server@workspace:."
   dependencies:
     "@fdm-monster/client": "npm:1.9.0"
-    "@fdm-monster/client-next": "npm:0.0.17"
+    "@fdm-monster/client-next": "npm:0.0.18"
     "@lcov-viewer/cli": "npm:1.3.0"
     "@lcov-viewer/istanbul-report": "npm:1.4.0"
     "@octokit/plugin-throttling": "npm:8.2.0"


### PR DESCRIPTION
# Description

Fixes #4077.

## Items

- [x] Upload progress callback axios was missing in builder pattern `.build()` method
- [x] FileUploadTrackerCache more simplified EventEmitter2 handler implementation (`on("*")` instead of on/off with filter)
- [x] FileUploadTrackerCache fixed `markUploadDone` incorrect processing of successful upload
- [x] FileUploadTrackerCache simplified `getUploads`
- [x] OctoprintClient adjusted (done, failed events) for uploadFile and other usages
- [x] MoonrakerClient adjusted (done, failed events) for uploadFile and other usages
- [x] Other use cases adjusted (done, failed events) for uploadFile and other usages
- [x] UI does not show completed/failed uploads indefinitely anymore
- [ ] UI shows two sessions for an upload (local and server, there is no glued session)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Vue test
- [x] Node test 

**Test Configuration**:
* Node version:
* OctoPrint version:
* Klipper version:
* Nodemon/PM2/docker:

# Checklist:

- [x] I checked my changes
- [x] I have commented my code concisely
- [x] I have covered my changes with tests
