### PR TITLE
4086 [Bug]: failed upload still ends up in changed thumbnail

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -6,10 +6,14 @@
 - Fix Sentry usage has updated
 - Fix upload progress was not updated properly
 - Fix failures and completions in file upload to OctoPrint/Moonraker were not consistently pushed over SocketIO
+- Fix Moonraker file upload did not track upload, failure or completion
+- Fix Moonraker file upload did not try-catch failures
+- Fix thumbnail is now parsed after file upload instead of before, preventing premature thumbnail switch in case of upload failure.
+- Fix file uploads were never unlinked, except for server startup.
 
 # FDM Monster 03/01/2025 1.8.2
 
-## Changes 
+## Changes
 
 - Update client to 1.8.8
 
@@ -31,7 +35,7 @@
 
 - Update to client 1.8.4
 
-## Fixes 
+## Fixes
 
 - YAML import: regression caused all imports to fail validation
 - YAML import: a bug caused all import with printers without api key to fail validation
@@ -59,7 +63,7 @@
 
 ## Fixes
 
-- UserService: MongoDB had incorrect root user checks and SQLite user service missed the check altogether. Now root user checks are robust. 
+- UserService: MongoDB had incorrect root user checks and SQLite user service missed the check altogether. Now root user checks are robust.
 - Camera API: GUEST should not have access to change cameras
 - YAML import validation: new API keys are not accepted by outdated YAML validation
 
@@ -80,7 +84,7 @@
 
 - User API: new endpoint which registers user directly with roles and without verification step
 
-## Fixes: 
+## Fixes:
 
 - PrinterEventsCache: when printers and test printers are deleted, the printer events cache should not be allowed to be filled by late update events
 
@@ -97,7 +101,7 @@
 ## Fixes:
 
 - API & Service validators: adjust max length of apiKey property validation to 43 to allow new `secrets` based OctoPrint api keys
- 
+
 # FDM Monster 04/11/2024 1.7.1
 
 ## Changes:

--- a/src/controllers/printer-files.controller.ts
+++ b/src/controllers/printer-files.controller.ts
@@ -238,7 +238,14 @@ export class PrinterFilesController {
     const uploadedFile = files[0];
     const token = this.multerService.startTrackingSession(uploadedFile, currentPrinterId);
 
-    await this.printerApi.uploadFile(uploadedFile, token);
+    await this.printerApi.uploadFile(uploadedFile, token).catch((e) => {
+      try {
+        this.multerService.clearUploadedFile(uploadedFile);
+      } catch (e) {
+        this.logger.error(`Could not remove uploaded file from temporary storage ${errorSummary(e)}`);
+      }
+      throw e;
+    });
     await this.printerFilesStore.loadFiles(currentPrinterId);
 
     try {
@@ -255,6 +262,7 @@ export class PrinterFilesController {
     } catch (e) {
       this.logger.error(`Could not remove uploaded file from temporary storage ${errorSummary(e)}`);
     }
+
     res.send();
   }
 }

--- a/src/services/core/logs-manager.service.ts
+++ b/src/services/core/logs-manager.service.ts
@@ -1,11 +1,12 @@
 import AdmZip from "adm-zip";
 import { join } from "path";
-import { readdirSync, unlinkSync } from "fs";
+import { readdirSync } from "fs";
 import { superRootPath } from "@/utils/fs.utils";
 import { AppConstants } from "@/server.constants";
 import { isValidDate } from "@/utils/time.utils";
 import { LoggerService } from "@/handlers/logger";
 import { ILoggerFactory } from "@/handlers/logger-factory";
+import { rmSync } from "node:fs";
 
 export class LogDumpService {
   logger: LoggerService;
@@ -47,7 +48,7 @@ export class LogDumpService {
     let removedWrongFormatFilesCount = 0;
     for (const file of removedFilesNotInFormat) {
       try {
-        unlinkSync(join(path, file));
+        rmSync(join(path, file));
         removedWrongFormatFilesCount++;
       } catch (err) {
         this.logger.warn(`Failed to delete log file`);
@@ -57,7 +58,7 @@ export class LogDumpService {
     let removedOutdatedFilesCount = 0;
     for (const file of removedFilesOutdated) {
       try {
-        unlinkSync(join(path, file));
+        rmSync(join(path, file));
         removedOutdatedFilesCount++;
       } catch (err) {
         this.logger.warn(`Failed to delete log file`);

--- a/src/services/core/multer.service.ts
+++ b/src/services/core/multer.service.ts
@@ -6,31 +6,35 @@ import { AppConstants } from "@/server.constants";
 import { FileUploadTrackerCache } from "@/state/file-upload-tracker.cache";
 import { Request, Response } from "express";
 import { HttpClientFactory } from "@/services/core/http-client.factory";
-import { IdType } from "../../shared.constants";
+import { IdType } from "@/shared.constants";
+import { rmSync } from "node:fs";
+import { errorSummary } from "@/utils/error.utils";
+import { LoggerService } from "@/handlers/logger";
+import { ILoggerFactory } from "@/handlers/logger-factory";
 
 export class MulterService {
   fileUploadTrackerCache: FileUploadTrackerCache;
   httpClientFactory: HttpClientFactory;
-
+  logger: LoggerService;
   constructor({
     fileUploadTrackerCache,
     httpClientFactory,
+    loggerFactory,
   }: {
     fileUploadTrackerCache: FileUploadTrackerCache;
     httpClientFactory: HttpClientFactory;
+    loggerFactory: ILoggerFactory;
   }) {
     this.fileUploadTrackerCache = fileUploadTrackerCache;
     this.httpClientFactory = httpClientFactory;
+    this.logger = loggerFactory(MulterService.name);
   }
 
-  getNewestFile(collection: string) {
-    const dirPath = this.collectionPath(collection);
-    const files = this.orderRecentFiles(dirPath);
-    const latestFile = files.length ? files[0] : undefined;
-    return latestFile ? join(dirPath, latestFile.file) : undefined;
+  public startTrackingSession(multerFile: Express.Multer.File, printerId: IdType) {
+    return this.fileUploadTrackerCache.addUploadTracker(multerFile, printerId);
   }
 
-  clearUploadsFolder() {
+  public clearUploadsFolder() {
     const fileStoragePath = join(superRootPath(), AppConstants.defaultFileStorageFolder);
     if (!existsSync(fileStoragePath)) return;
 
@@ -39,16 +43,27 @@ export class MulterService {
       .map((item) => item.name);
 
     for (const file of files) {
-      unlink(join(fileStoragePath, file), (err) => {
-        if (err) throw err;
-      });
+      try {
+        rmSync(join(fileStoragePath, file));
+      } catch (error) {
+        this.logger.error(`Could not clear upload file in temporary folder ${errorSummary(error)}`);
+      }
     }
   }
 
-  clearUploadedFile(multerFile: Express.Multer.File) {
+  public clearUploadedFile(multerFile: Express.Multer.File) {
     if (existsSync(multerFile.path)) {
-      unlinkSync(multerFile.path);
+      rmSync(multerFile.path);
+    } else {
+      console.log("Cannot unlink temporarily uploaded file as it was not found");
     }
+  }
+
+  getNewestFile(collection: string) {
+    const dirPath = this.collectionPath(collection);
+    const files = this.orderRecentFiles(dirPath);
+    const latestFile = files.length ? files[0] : undefined;
+    return latestFile ? join(dirPath, latestFile.file) : undefined;
   }
 
   fileExists(downloadFilename: string, collection: string) {
@@ -109,17 +124,13 @@ export class MulterService {
   }
 
   multerFileFilter(extensions: string[]) {
-    return (req: Request, file: Express.Multer.File, callback: FileFilterCallback) => {
+    return (_: Request, file: Express.Multer.File, callback: FileFilterCallback) => {
       const ext = extname(file.originalname);
       if (extensions?.length && !extensions.includes(ext?.toLowerCase())) {
         return callback(new Error(`Only files with extensions ${extensions} are allowed`));
       }
       return callback(null, true);
     };
-  }
-
-  startTrackingSession(multerFile: Express.Multer.File, printerId: IdType) {
-    return this.fileUploadTrackerCache.addUploadTracker(multerFile, printerId);
   }
 
   getSessions() {

--- a/src/services/core/multer.service.ts
+++ b/src/services/core/multer.service.ts
@@ -55,7 +55,7 @@ export class MulterService {
     if (existsSync(multerFile.path)) {
       rmSync(multerFile.path);
     } else {
-      console.log("Cannot unlink temporarily uploaded file as it was not found");
+      this.logger.warn("Cannot unlink temporarily uploaded file as it was not found");
     }
   }
 

--- a/src/services/core/multer.service.ts
+++ b/src/services/core/multer.service.ts
@@ -1,6 +1,6 @@
 import multer, { diskStorage, FileFilterCallback, memoryStorage } from "multer";
 import { extname, join } from "path";
-import { createWriteStream, existsSync, lstatSync, mkdirSync, readdirSync, unlink } from "fs";
+import { createWriteStream, existsSync, lstatSync, mkdirSync, readdirSync, unlink, unlinkSync } from "fs";
 import { superRootPath } from "@/utils/fs.utils";
 import { AppConstants } from "@/server.constants";
 import { FileUploadTrackerCache } from "@/state/file-upload-tracker.cache";
@@ -42,6 +42,12 @@ export class MulterService {
       unlink(join(fileStoragePath, file), (err) => {
         if (err) throw err;
       });
+    }
+  }
+
+  clearUploadedFile(multerFile: Express.Multer.File) {
+    if (existsSync(multerFile.path)) {
+      unlinkSync(multerFile.path);
     }
   }
 

--- a/src/utils/pretty-print.utils.ts
+++ b/src/utils/pretty-print.utils.ts
@@ -3,5 +3,5 @@ export function PP(input: any) {
 }
 
 export function PL(input: any) {
-  return console.log(PP(input));
+  console.log(PP(input));
 }


### PR DESCRIPTION
- Fix Moonraker file upload did not track upload, failure or completion
- Fix Moonraker file upload did not try-catch failures
- Fix thumbnail is now parsed after file upload instead of before, preventing premature thumbnail switch in case of upload failure.
- Fix file uploads were never unlinked, except for server startup.
