### PR TITLE
Feat/3721 replace node input validator legacy dependency

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -22,6 +22,12 @@
 - Enforce floor id on Mongoose schema for consistency with TypeORM floor entity
 - Set floor id in Mongoose floor service for consistency with typeorm service
 - Remove PrinterFile entity (unused)
+- Remove printer/connection PATCH endpoint (unused)
+- Make yaml import fill in defaults
+- Make printerId camera nullish
+- Merge create and update schema floor
+- Make printCompletionSchema context type any,
+- printerPositionsSchema simplified
 
 ## Fixes
 

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "migrate-mongo": "11.0.0",
     "mongoose": "6.13.8",
     "multer": "1.4.5-lts.2",
-    "node-input-validator": "4.5.1",
     "octokit": "3.2.1",
     "passport": "0.7.0",
     "passport-anonymous": "1.0.1",
@@ -95,7 +94,8 @@
     "typeorm": "0.3.21",
     "uuid": "11.1.0",
     "winston": "3.17.0",
-    "ws": "8.18.1"
+    "ws": "8.18.1",
+    "zod": "3.24.2"
   },
   "devDependencies": {
     "@lcov-viewer/cli": "1.3.0",

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -13,6 +13,7 @@ import { IRoleService } from "@/services/interfaces/role-service.interface";
 import { demoUserNotAllowed } from "@/middleware/demo.middleware";
 import { IConfigService } from "@/services/core/config.service";
 import { registerUserSchema } from "@/controllers/validation/user-controller.validation";
+import { validateMiddleware } from "@/handlers/validators";
 
 @route(AppConstants.apiRoute + "/auth")
 export class AuthController {

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -1,9 +1,7 @@
 import { before, GET, POST, route } from "awilix-express";
 import { BadRequestException } from "@/exceptions/runtime.exceptions";
 import { AppConstants } from "@/server.constants";
-import { validateMiddleware } from "@/handlers/validators";
-import { registerUserRules } from "./validation/user-controller.validation";
-import { refreshTokenRules } from "./validation/auth-controller.validation";
+import { refreshTokenSchema } from "./validation/auth-controller.validation";
 import { authenticate } from "@/middleware/authenticate";
 import { SettingsStore } from "@/state/settings.store";
 import { ILoggerFactory } from "@/handlers/logger-factory";
@@ -14,6 +12,7 @@ import { IAuthService } from "@/services/interfaces/auth.service.interface";
 import { IRoleService } from "@/services/interfaces/role-service.interface";
 import { demoUserNotAllowed } from "@/middleware/demo.middleware";
 import { IConfigService } from "@/services/core/config.service";
+import { registerUserSchema } from "@/controllers/validation/user-controller.validation";
 
 @route(AppConstants.apiRoute + "/auth")
 export class AuthController {
@@ -92,7 +91,7 @@ export class AuthController {
   @POST()
   @route("/refresh")
   async refreshLogin(req: Request, res: Response) {
-    const { refreshToken } = await validateMiddleware(req, refreshTokenRules);
+    const { refreshToken } = await validateMiddleware(req, refreshTokenSchema);
     // TODO sensitivity filter
     this.logger.debug(`Refresh login attempt from IP ${req.ip} and user-agent ${req.headers["user-agent"]}`);
     const idToken = await this.authService.renewLoginByRefreshToken(refreshToken);
@@ -123,7 +122,7 @@ export class AuthController {
     if (!registrationEnabled) {
       throw new BadRequestException("Registration is disabled. Cant register user");
     }
-    const { username, password } = await validateMiddleware(req, registerUserRules);
+    const { username, password } = await validateMiddleware(req, registerUserSchema);
     if (
       username.toLowerCase().includes("admin") ||
       username.toLowerCase().includes("root") ||

--- a/src/controllers/batch-call.controller.ts
+++ b/src/controllers/batch-call.controller.ts
@@ -1,9 +1,9 @@
 import { before, POST, route } from "awilix-express";
 import { validateInput } from "@/handlers/validators";
 import {
-  batchPrinterRules,
-  batchPrintersEnabledRules,
-  executeBatchRePrinterRule,
+  batchPrinterSchema,
+  batchPrintersEnabledSchema,
+  executeBatchRePrinterSchema,
 } from "./validation/batch-controller.validation";
 import { AppConstants } from "@/server.constants";
 import { authenticate, authorizeRoles } from "@/middleware/authenticate";
@@ -19,7 +19,7 @@ export class BatchCallController {
   @POST()
   @route("/settings/get")
   async batchSettingsGet(req: Request, res: Response) {
-    const { printerIds } = await validateInput(req.body, batchPrinterRules(this.isTypeormMode));
+    const { printerIds } = await validateInput(req.body, batchPrinterSchema(this.isTypeormMode));
     const results = await this.batchCallService.batchSettingsGet(printerIds);
     res.send(results);
   }
@@ -27,7 +27,7 @@ export class BatchCallController {
   @POST()
   @route("/connect/usb")
   async batchConnectUsb(req: Request, res: Response) {
-    const { printerIds } = await validateInput(req.body, batchPrinterRules(this.isTypeormMode));
+    const { printerIds } = await validateInput(req.body, batchPrinterSchema(this.isTypeormMode));
     const results = await this.batchCallService.batchConnectUsb(printerIds);
     res.send(results);
   }
@@ -35,7 +35,7 @@ export class BatchCallController {
   @POST()
   @route("/connect/socket")
   async batchConnectSocket(req: Request, res: Response) {
-    const { printerIds } = await validateInput(req.body, batchPrinterRules(this.isTypeormMode));
+    const { printerIds } = await validateInput(req.body, batchPrinterSchema(this.isTypeormMode));
     this.batchCallService.batchConnectSocket(printerIds);
     res.send({});
   }
@@ -43,7 +43,7 @@ export class BatchCallController {
   @POST()
   @route("/reprint/list")
   async getLastPrintedFiles(req: Request, res: Response) {
-    const { printerIds } = await validateInput(req.body, batchPrinterRules(this.isTypeormMode));
+    const { printerIds } = await validateInput(req.body, batchPrinterSchema(this.isTypeormMode));
     const files = await this.batchCallService.getBatchPrinterReprintFile(printerIds);
     res.send(files);
   }
@@ -51,7 +51,7 @@ export class BatchCallController {
   @POST()
   @route("/reprint/execute")
   async batchReprintFiles(req: Request, res: Response) {
-    const { prints } = await validateInput(req.body, executeBatchRePrinterRule(this.isTypeormMode));
+    const { prints } = await validateInput(req.body, executeBatchRePrinterSchema(this.isTypeormMode));
     const files = await this.batchCallService.batchReprintCalls(prints);
     res.send(files);
   }
@@ -59,7 +59,7 @@ export class BatchCallController {
   @POST()
   @route("/toggle-enabled")
   async batchTogglePrintersEnabled(req: Request, res: Response) {
-    const { printerIds, enabled } = await validateInput(req.body, batchPrintersEnabledRules(this.isTypeormMode));
+    const { printerIds, enabled } = await validateInput(req.body, batchPrintersEnabledSchema(this.isTypeormMode));
     const results = await this.batchCallService.batchTogglePrintersEnabled(printerIds, enabled);
     res.send(results);
   }

--- a/src/controllers/dto/update-client-dist.dto.ts
+++ b/src/controllers/dto/update-client-dist.dto.ts
@@ -1,13 +1,7 @@
-import { IsBoolean, IsOptional, IsSemVer, IsString } from "class-validator";
 import { AppConstants } from "@/server.constants";
 
 export class UpdateClientDistDto {
-  @IsOptional()
-  @IsString()
-  @IsSemVer()
   downloadRelease?: string = AppConstants.defaultClientMinimum;
 
-  @IsOptional()
-  @IsBoolean()
   allowDowngrade?: boolean = false;
 }

--- a/src/controllers/first-time-setup.controller.ts
+++ b/src/controllers/first-time-setup.controller.ts
@@ -1,7 +1,7 @@
 import { POST, route } from "awilix-express";
 import { AppConstants } from "@/server.constants";
 import { validateMiddleware } from "@/handlers/validators";
-import { wizardSettingsRules } from "./validation/setting.validation";
+import { wizardSettingsSchema } from "./validation/setting.validation";
 import { BadRequestException, ForbiddenError } from "@/exceptions/runtime.exceptions";
 import { ROLES } from "@/constants/authorization.constants";
 import { SettingsStore } from "@/state/settings.store";
@@ -20,7 +20,7 @@ export class FirstTimeSetupController {
   @POST()
   @route("/validate")
   async validateWizard(req: Request, res: Response) {
-    const { rootUsername } = await validateMiddleware(req, wizardSettingsRules);
+    const { rootUsername } = await validateMiddleware(req, wizardSettingsSchema);
     await this.roleService.getSynchronizedRoleByName(ROLES.ADMIN);
 
     if (this.settingsStore.isWizardCompleted()) {
@@ -38,7 +38,7 @@ export class FirstTimeSetupController {
   @POST()
   @route("/complete")
   async completeWizard(req: Request, res: Response) {
-    const { loginRequired, registration, rootUsername, rootPassword } = await validateMiddleware(req, wizardSettingsRules);
+    const { loginRequired, registration, rootUsername, rootPassword } = await validateMiddleware(req, wizardSettingsSchema);
 
     if (this.settingsStore.isWizardCompleted()) {
       throw new ForbiddenError("Wizard already completed");

--- a/src/controllers/print-completion.controller.ts
+++ b/src/controllers/print-completion.controller.ts
@@ -6,6 +6,7 @@ import { validateInput } from "@/handlers/validators";
 import { PrintCompletionSocketIoTask } from "@/tasks/print-completion.socketio.task";
 import { Request, Response } from "express";
 import { IPrintCompletionService } from "@/services/interfaces/print-completion.interface";
+import { findPrinterCompletionSchema } from "@/controllers/validation/printer-completion-controller.validation";
 
 @route(AppConstants.apiRoute + "/print-completion")
 @before([authenticate()])
@@ -38,7 +39,7 @@ export class PrintCompletionController {
   @route("/:correlationId")
   @before([permission(PERMS.PrintCompletion.Default)])
   async findCorrelatedEntries(req: Request, res: Response) {
-    const { correlationId } = await validateInput(req.params, { correlationId: "required|string" });
+    const { correlationId } = await validateInput(req.params, findPrinterCompletionSchema);
     const result = await this.printCompletionService.findPrintCompletion(correlationId);
     res.send(result);
   }

--- a/src/controllers/printer-files.controller.ts
+++ b/src/controllers/printer-files.controller.ts
@@ -2,7 +2,7 @@ import { before, DELETE, GET, POST, route } from "awilix-express";
 import { authenticate, permission, authorizeRoles } from "@/middleware/authenticate";
 import { validateInput } from "@/handlers/validators";
 import { AppConstants } from "@/server.constants";
-import { downloadFileRules, getFileRules, startPrintFileRules } from "./validation/printer-files-controller.validation";
+import { downloadFileSchema, getFileSchema, startPrintFileSchema } from "./validation/printer-files-controller.validation";
 import { ValidationException } from "@/exceptions/runtime.exceptions";
 import { printerResolveMiddleware } from "@/middleware/printer";
 import { PERMS, ROLES } from "@/constants/authorization.constants";
@@ -68,7 +68,7 @@ export class PrinterFilesController {
   @route("/:id/reload-thumbnail")
   @before(permission(PERMS.PrinterFiles.Actions))
   async reloadThumbnail(req: Request, res: Response) {
-    const { filePath } = await validateInput(req.body, startPrintFileRules);
+    const { filePath } = await validateInput(req.body, startPrintFileSchema);
 
     try {
       if (this.settingsStore.isThumbnailSupportEnabled()) {
@@ -90,7 +90,7 @@ export class PrinterFilesController {
   @route("/:id/print")
   @before(permission(PERMS.PrinterFiles.Actions))
   async startPrintFile(req: Request, res: Response) {
-    const { filePath } = await validateInput(req.body, startPrintFileRules);
+    const { filePath } = await validateInput(req.body, startPrintFileSchema);
     const encodedFilePath = encodeURIComponent(filePath);
     await this.printerApi.startPrint(encodedFilePath);
 
@@ -119,7 +119,7 @@ export class PrinterFilesController {
   @before(permission(PERMS.PrinterFiles.Get))
   async downloadFile(req: Request, res: Response) {
     this.logger.log(`Downloading file ${req.params.path}`);
-    const { path } = await validateInput(req.params, downloadFileRules);
+    const { path } = await validateInput(req.params, downloadFileSchema);
     const encodedFilePath = encodeURIComponent(path);
 
     const response = await this.printerApi.downloadFile(encodedFilePath);
@@ -137,7 +137,7 @@ export class PrinterFilesController {
   @before(permission(PERMS.PrinterFiles.Delete))
   async deleteFileOrFolder(req: Request, res: Response) {
     const { currentPrinterId } = getScopedPrinter(req);
-    const { path } = await validateInput(req.query, getFileRules);
+    const { path } = await validateInput(req.query, getFileSchema);
     const encodedFilePath = encodeURIComponent(path);
 
     const result = await this.printerApi.deleteFile(encodedFilePath);

--- a/src/controllers/printer-settings.controller.ts
+++ b/src/controllers/printer-settings.controller.ts
@@ -2,12 +2,12 @@ import { before, GET, POST, route } from "awilix-express";
 import { authenticate, permission } from "@/middleware/authenticate";
 import { validateMiddleware } from "@/handlers/validators";
 import { AppConstants } from "@/server.constants";
+import { setGcodeAnalysisSchema } from "./validation/printer-settings-controller.validation";
 import { PERMS } from "@/constants/authorization.constants";
 import { OctoprintClient } from "@/services/octoprint/octoprint.client";
 import { PrinterCache } from "@/state/printer.cache";
 import { Request, Response } from "express";
 import { ParamId } from "@/middleware/param-converter.middleware";
-import { setGcodeAnalysisRules } from "@/controllers/validation/printer-settings-controller.validation";
 
 @route(AppConstants.apiRoute + "/printer-settings")
 @before([authenticate()])
@@ -27,7 +27,7 @@ export class PrinterSettingsController {
   @route("/:id/gcode-analysis")
   @before([ParamId("id")])
   async setGCodeAnalysis(req: Request, res: Response) {
-    const { enabled } = await validateMiddleware(req, setGcodeAnalysisRules);
+    const { enabled } = await validateMiddleware(req, setGcodeAnalysisSchema);
 
     const printerLogin = await this.printerCache.getLoginDtoAsync(req.local.id);
     const settings = await this.octoprintClient.setGCodeAnalysis(printerLogin, enabled);

--- a/src/controllers/printer.controller.ts
+++ b/src/controllers/printer.controller.ts
@@ -2,12 +2,12 @@ import { before, DELETE, GET, PATCH, POST, route } from "awilix-express";
 import { authenticate, authorizeRoles } from "@/middleware/authenticate";
 import { validateInput, validateMiddleware } from "@/handlers/validators";
 import {
-  feedRateRules,
-  flowRateRules,
-  testPrinterApiRules,
-  updatePrinterConnectionSettingRules,
-  updatePrinterDisabledReasonRules,
-  updatePrinterEnabledRule,
+  feedRateSchema,
+  flowRateSchema,
+  testPrinterApiSchema,
+  updatePrinterConnectionSettingSchema,
+  updatePrinterDisabledReasonSchema,
+  updatePrinterEnabledSchema,
 } from "./validation/printer-controller.validation";
 import { AppConstants } from "@/server.constants";
 import { printerResolveMiddleware } from "@/middleware/printer";
@@ -120,7 +120,7 @@ export class PrinterController {
   @route("/:id/enabled")
   async updateEnabled(req: Request, res: Response) {
     const { currentPrinterId } = getScopedPrinter(req);
-    const data = await validateMiddleware(req, updatePrinterEnabledRule);
+    const data = await validateMiddleware(req, updatePrinterEnabledSchema);
     await this.printerService.updateEnabled(currentPrinterId, data.enabled);
     res.send({});
   }
@@ -129,7 +129,7 @@ export class PrinterController {
   @route("/:id/disabled-reason")
   async updatePrinterDisabledReason(req: Request, res: Response) {
     const { currentPrinterId } = getScopedPrinter(req);
-    const data = await validateMiddleware(req, updatePrinterDisabledReasonRules);
+    const data = await validateMiddleware(req, updatePrinterDisabledReasonSchema);
     await this.printerService.updateDisabledReason(currentPrinterId, data.disabledReason);
     res.send({});
   }
@@ -138,7 +138,7 @@ export class PrinterController {
   @route("/:id/connection")
   async updateConnectionSettings(req: Request, res: Response) {
     const { currentPrinterId } = getScopedPrinter(req);
-    const inputData = await validateMiddleware(req, updatePrinterConnectionSettingRules);
+    const inputData = await validateMiddleware(req, updatePrinterConnectionSettingSchema);
 
     if (req.query.forceSave !== "true") {
       await this.testPrintApiConnection(inputData);
@@ -167,7 +167,7 @@ export class PrinterController {
     if (req.body.printerURL?.length) {
       req.body.printerURL = normalizeUrl(req.body.printerURL, { defaultProtocol: defaultHttpProtocol });
     }
-    const newPrinter = await validateMiddleware(req, testPrinterApiRules);
+    const newPrinter = await validateMiddleware(req, testPrinterApiSchema);
     newPrinter.correlationToken = generateCorrelationToken();
     this.logger.log(`Testing printer with correlation token ${newPrinter.correlationToken}`);
 
@@ -248,7 +248,7 @@ export class PrinterController {
   }
 
   private async testPrintApiConnection(inputLoginDto: LoginDto) {
-    await validateInput(inputLoginDto, updatePrinterConnectionSettingRules);
+    await validateInput(inputLoginDto, updatePrinterConnectionSettingSchema);
     try {
       if (this.printerApi) {
         await this.printerApi.getVersion();
@@ -299,7 +299,7 @@ export class PrinterController {
   @route("/:id/feed-rate")
   async setFeedRate(req: Request, res: Response) {
     const { currentPrinterId } = getScopedPrinter(req);
-    const data = await validateMiddleware(req, feedRateRules);
+    const data = await validateMiddleware(req, feedRateSchema);
 
     await this.printerService.updateFeedRate(currentPrinterId, data.feedRate);
     res.send({});
@@ -309,7 +309,7 @@ export class PrinterController {
   @route("/:id/flow-rate")
   async setFlowRate(req: Request, res: Response) {
     const { currentPrinterId } = getScopedPrinter(req);
-    const data = await validateMiddleware(req, flowRateRules);
+    const data = await validateMiddleware(req, flowRateSchema);
     await this.printerService.updateFlowRate(currentPrinterId, data.flowRate);
     res.send({});
   }

--- a/src/controllers/printer.controller.ts
+++ b/src/controllers/printer.controller.ts
@@ -134,24 +134,6 @@ export class PrinterController {
     res.send({});
   }
 
-  @PATCH()
-  @route("/:id/connection")
-  async updateConnectionSettings(req: Request, res: Response) {
-    const { currentPrinterId } = getScopedPrinter(req);
-    const inputData = await validateMiddleware(req, updatePrinterConnectionSettingSchema);
-
-    if (req.query.forceSave !== "true") {
-      await this.testPrintApiConnection(inputData);
-    }
-
-    const newEntity = await this.printerService.updateConnectionSettings(currentPrinterId, inputData);
-    res.send({
-      printerURL: newEntity.printerURL,
-      apiKey: newEntity.apiKey,
-      printerType: newEntity.printerType,
-    });
-  }
-
   @POST()
   @route("/:id/refresh-socket")
   async refreshPrinterSocket(req: Request, res: Response) {

--- a/src/controllers/server-private.controller.ts
+++ b/src/controllers/server-private.controller.ts
@@ -14,6 +14,7 @@ import { Request, Response } from "express";
 import { demoUserNotAllowed } from "@/middleware/demo.middleware";
 import { GithubService } from "@/services/core/github.service";
 import { IPrinterService } from "@/services/interfaces/printer.service.interface";
+import { updateClientBundleSchema } from "@/controllers/validation/server-private.validation";
 import { ILoggerFactory } from "@/handlers/logger-factory";
 
 @route(AppConstants.apiRoute + "/server")
@@ -57,11 +58,7 @@ export class ServerPrivateController {
   @POST()
   @route("/update-client-bundle-github")
   async updateClientBundleGithub(req: Request, res: Response) {
-    const inputRules = {
-      downloadRelease: "string",
-      allowDowngrade: "boolean",
-    };
-    const updateDto = await validateMiddleware(req, inputRules);
+    const updateDto = await validateMiddleware(req, updateClientBundleSchema);
 
     const willExecute = await this.clientBundleService.shouldUpdateWithReason(
       true,

--- a/src/controllers/settings.controller.ts
+++ b/src/controllers/settings.controller.ts
@@ -4,15 +4,15 @@ import { AppConstants } from "@/server.constants";
 import { ROLES } from "@/constants/authorization.constants";
 import { validateInput } from "@/handlers/validators";
 import {
-  clientNextRules,
-  credentialSettingPatchRules,
-  fileCleanSettingsUpdateRules,
-  frontendSettingsUpdateRules,
-  moonrakerSupportRules,
-  sentryDiagnosticsEnabledRules,
-  serverSettingsUpdateRules,
-  thumbnailSupportRules,
-  timeoutSettingsUpdateRules,
+  clientNextSchema,
+  credentialSettingPatchSchema,
+  fileCleanSettingsUpdateSchema,
+  frontendSettingsUpdateSchema,
+  moonrakerSupportSchema,
+  sentryDiagnosticsEnabledSchema,
+  serverSettingsUpdateSchema,
+  thumbnailSupportSchema,
+  timeoutSettingsUpdateSchema,
 } from "@/services/validators/settings-service.validation";
 import { SettingsStore } from "@/state/settings.store";
 import { Request, Response } from "express";
@@ -23,6 +23,7 @@ import { PrinterCache } from "@/state/printer.cache";
 import { MoonrakerType } from "@/services/printer-api.interface";
 import { IPrinterService } from "@/services/interfaces/printer.service.interface";
 import { PrinterThumbnailCache } from "@/state/printer-thumbnail.cache";
+import { loginRequiredSchema, registrationEnabledSchema } from "@/controllers/validation/setting.validation";
 
 @route(AppConstants.apiRoute + "/settings")
 @before([authenticate()])
@@ -68,7 +69,7 @@ export class SettingsController {
   @route("/sentry-diagnostics")
   @before([demoUserNotAllowed])
   async updateSentryDiagnosticsEnabled(req: Request, res: Response) {
-    const { enabled } = await validateInput(req.body, sentryDiagnosticsEnabledRules);
+    const { enabled } = await validateInput(req.body, sentryDiagnosticsEnabledSchema);
     const result = this.settingsStore.setSentryDiagnosticsEnabled(enabled);
     res.send(result);
   }
@@ -77,7 +78,7 @@ export class SettingsController {
   @route("/experimental-moonraker-support")
   @before([authorizeRoles([ROLES.ADMIN]), demoUserNotAllowed])
   async updateMoonrakerSupport(req: Request, res: Response) {
-    const { enabled } = await validateInput(req.body, moonrakerSupportRules);
+    const { enabled } = await validateInput(req.body, moonrakerSupportSchema);
     const result = await this.settingsStore.setExperimentalMoonrakerSupport(enabled);
 
     if (!enabled) {
@@ -94,7 +95,7 @@ export class SettingsController {
   @route("/experimental-thumbnail-support")
   @before([authorizeRoles([ROLES.ADMIN]), demoUserNotAllowed])
   async updateThumbnailSupport(req: Request, res: Response) {
-    const { enabled } = await validateInput(req.body, thumbnailSupportRules);
+    const { enabled } = await validateInput(req.body, thumbnailSupportSchema);
     const result = await this.settingsStore.setExperimentalThumbnailSupport(enabled);
 
     if (enabled) {
@@ -109,7 +110,7 @@ export class SettingsController {
   @route("/experimental-client-support")
   @before([authorizeRoles([ROLES.ADMIN]), demoUserNotAllowed])
   async updateClientSupport(req: Request, res: Response) {
-    const { enabled } = await validateInput(req.body, clientNextRules);
+    const { enabled } = await validateInput(req.body, clientNextSchema);
     const result = await this.settingsStore.setExperimentalClientSupport(enabled);
     res.send(result);
   }
@@ -118,7 +119,7 @@ export class SettingsController {
   @route("/frontend")
   @before([authorizeRoles([ROLES.ADMIN])])
   async updateFrontendSettings(req: Request, res: Response) {
-    const validatedInput = await validateInput(req.body, frontendSettingsUpdateRules);
+    const validatedInput = await validateInput(req.body, frontendSettingsUpdateSchema);
     const result = await this.settingsStore.updateFrontendSettings(validatedInput);
     res.send(result);
   }
@@ -127,7 +128,7 @@ export class SettingsController {
   @route("/server")
   @before([authorizeRoles([ROLES.ADMIN]), demoUserNotAllowed])
   async updateServerSettings(req: Request, res: Response) {
-    const validatedInput = await validateInput(req.body, serverSettingsUpdateRules);
+    const validatedInput = await validateInput(req.body, serverSettingsUpdateSchema);
     const result = await this.settingsStore.updateServerSettings(validatedInput);
     res.send(result);
   }
@@ -136,7 +137,7 @@ export class SettingsController {
   @route("/login-required")
   @before([authorizeRoles([ROLES.ADMIN]), demoUserNotAllowed])
   async updateLoginRequiredSettings(req: Request, res: Response) {
-    const { loginRequired } = await validateInput(req.body, { loginRequired: "required|boolean" });
+    const { loginRequired } = await validateInput(req.body, loginRequiredSchema);
     const result = await this.settingsStore.setLoginRequired(loginRequired);
     res.send(result);
   }
@@ -145,7 +146,7 @@ export class SettingsController {
   @route("/registration-enabled")
   @before([authorizeRoles([ROLES.ADMIN]), demoUserNotAllowed])
   async updateRegistrationEnabledSettings(req: Request, res: Response) {
-    const { registrationEnabled } = await validateInput(req.body, { registrationEnabled: "required|boolean" });
+    const { registrationEnabled } = await validateInput(req.body, registrationEnabledSchema);
     const result = await this.settingsStore.setRegistrationEnabled(registrationEnabled);
     res.send(result);
   }
@@ -154,7 +155,7 @@ export class SettingsController {
   @route("/credential")
   @before([authorizeRoles([ROLES.ADMIN]), demoUserNotAllowed])
   async updateCredentialSettings(req: Request, res: Response) {
-    const validatedInput = await validateInput(req.body, credentialSettingPatchRules);
+    const validatedInput = await validateInput(req.body, credentialSettingPatchSchema);
     await this.settingsStore.updateCredentialSettings(validatedInput);
     res.send();
   }
@@ -163,7 +164,7 @@ export class SettingsController {
   @route("/file-clean")
   @before([authorizeRoles([ROLES.ADMIN]), demoUserNotAllowed])
   async updateFileCleanSettings(req: Request, res: Response) {
-    const validatedInput = await validateInput(req.body, fileCleanSettingsUpdateRules);
+    const validatedInput = await validateInput(req.body, fileCleanSettingsUpdateSchema);
     const result = await this.settingsStore.patchFileCleanSettings(validatedInput);
     res.send(result);
   }
@@ -172,7 +173,7 @@ export class SettingsController {
   @route("/timeout")
   @before([authorizeRoles([ROLES.ADMIN]), demoUserNotAllowed])
   async updateTimeoutSettings(req: Request, res: Response) {
-    const validatedInput = await validateInput(req.body, timeoutSettingsUpdateRules);
+    const validatedInput = await validateInput(req.body, timeoutSettingsUpdateSchema);
     const result = await this.settingsStore.updateTimeoutSettings(validatedInput);
     res.send(result);
   }

--- a/src/controllers/validation/auth-controller.validation.ts
+++ b/src/controllers/validation/auth-controller.validation.ts
@@ -1,3 +1,5 @@
-export const refreshTokenRules = {
-  refreshToken: "required|string",
-};
+import { z } from "zod";
+
+export const refreshTokenSchema = z.object({
+  refreshToken: z.string().min(1),
+});

--- a/src/controllers/validation/batch-controller.validation.ts
+++ b/src/controllers/validation/batch-controller.validation.ts
@@ -1,19 +1,23 @@
+import { z } from "zod";
 import { idRuleV2 } from "@/controllers/validation/generic.validation";
 
-export const batchPrinterRules = (isSqlite: boolean) => ({
-  printerIds: "required|array",
-  "printerIds.*": idRuleV2(isSqlite),
-});
+export const batchPrinterSchema = (isSqlite: boolean) =>
+  z.object({
+    printerIds: z.array(idRuleV2(isSqlite)),
+  });
 
-export const executeBatchRePrinterRule = (isSqlite: boolean) => ({
-  prints: "required|array",
-  "prints.*": "required",
-  "prints.*.printerId": idRuleV2(isSqlite),
-  "prints.*.path": "required|string",
-});
+export const executeBatchRePrinterSchema = (isSqlite: boolean) =>
+  z.object({
+    prints: z.array(
+      z.object({
+        printerId: idRuleV2(isSqlite),
+        path: z.string(),
+      })
+    ),
+  });
 
-export const batchPrintersEnabledRules = (isSqlite: boolean) => ({
-  printerIds: "required|array",
-  "printerIds.*": idRuleV2(isSqlite),
-  enabled: "required|boolean",
-});
+export const batchPrintersEnabledSchema = (isSqlite: boolean) =>
+  z.object({
+    printerIds: z.array(idRuleV2(isSqlite)),
+    enabled: z.boolean(),
+  });

--- a/src/controllers/validation/generic.validation.ts
+++ b/src/controllers/validation/generic.validation.ts
@@ -1,5 +1,19 @@
-export const idRuleV2 = (isSqlite: boolean) => `required|${isSqlite ? "integer|min:1" : "mongoId"}`;
+import { z } from "zod";
 
-export const idRulesV2 = (isSqlite: boolean) => ({
-  id: idRuleV2(isSqlite),
-});
+const isHexadecimal = (str: string) => /^[a-fA-F0-9]+$/.test(str);
+
+const isMongoId = (str: string) => isHexadecimal(str) && str.length === 24;
+
+export const idRuleV2 = (isSqlite: boolean) =>
+  isSqlite
+    ? z.number().min(1)
+    : z.string().refine(isMongoId, {
+        message: "Invalid MongoDB ObjectId",
+      });
+
+export const idRulesV2 = (isSqlite: boolean) =>
+  z
+    .object({
+      id: idRuleV2(isSqlite),
+    })
+    .strict();

--- a/src/controllers/validation/printer-completion-controller.validation.ts
+++ b/src/controllers/validation/printer-completion-controller.validation.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const findPrinterCompletionSchema = z.object({
+  correlationId: z.string().min(1),
+});

--- a/src/controllers/validation/printer-controller.validation.ts
+++ b/src/controllers/validation/printer-controller.validation.ts
@@ -1,30 +1,52 @@
-import { apiKeyLengthMaxDefault, apiKeyLengthMinDefault } from "@/constants/service.constants";
-import { MoonrakerType, OctoprintType } from "@/services/printer-api.interface";
+import { z } from "zod";
+import { OctoprintType, PrinterTypes } from "@/services/printer-api.interface";
+import { numberEnum } from "@/handlers/validators";
+import { validateApiKey } from "@/services/validators/printer-service.validation";
 
-export const flowRateRules = {
-  flowRate: "required|between:75,125|integer",
-};
+export const flowRateSchema = z.object({
+  flowRate: z.number().int().min(75).max(125).nonnegative(),
+});
 
-export const feedRateRules = {
-  feedRate: "required|between:10,200|integer",
-};
+export const feedRateSchema = z.object({
+  feedRate: z.number().int().min(10).max(200).nonnegative(),
+});
 
-export const testPrinterApiRules = {
-  printerType: `required|integer|in:${OctoprintType},${MoonrakerType}`,
-  apiKey: `requiredIf:printerType,${OctoprintType}|length:${apiKeyLengthMaxDefault},${apiKeyLengthMinDefault}|alphaDash`,
-  printerURL: "required|httpurl",
-};
+export const testPrinterApiSchema = z
+  .object({
+    printerURL: z.string().url(),
+    printerType: z.number().superRefine(numberEnum(PrinterTypes)),
+    apiKey: validateApiKey,
+  })
+  .superRefine((data, ctx) => {
+    if (data.printerType === OctoprintType && !data.apiKey?.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "apiKey is required when printerType is OctoprintType",
+        path: ["apiKey"],
+      });
+      return ctx;
+    }
 
-export const updatePrinterDisabledReasonRules = {
-  disabledReason: "string",
-};
+    // Validate that apiKey length is either 32 or 43 characters if it exists
+    if (data.apiKey && data.apiKey.length !== 32 && data.apiKey.length !== 43) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "apiKey must be either 32 or 43 characters long",
+        path: ["apiKey"],
+      });
+    }
+  });
 
-export const updatePrinterEnabledRule = {
-  enabled: "required|boolean",
-};
+export const updatePrinterDisabledReasonSchema = z.object({
+  disabledReason: z.string().optional(),
+});
 
-export const updatePrinterConnectionSettingRules = {
-  printerType: `required|integer|in:${OctoprintType},${MoonrakerType}`,
-  printerURL: "required|httpurl",
-  apiKey: `requiredIf:printerType,${OctoprintType}|length:${apiKeyLengthMaxDefault},${apiKeyLengthMinDefault}|alphaDash`,
-};
+export const updatePrinterEnabledSchema = z.object({
+  enabled: z.boolean(),
+});
+
+export const updatePrinterConnectionSettingSchema = z.object({
+  printerType: z.number().superRefine(numberEnum(PrinterTypes)),
+  printerURL: z.string().url(),
+  apiKey: validateApiKey,
+});

--- a/src/controllers/validation/printer-controller.validation.ts
+++ b/src/controllers/validation/printer-controller.validation.ts
@@ -1,7 +1,12 @@
 import { z } from "zod";
-import { OctoprintType, PrinterTypes } from "@/services/printer-api.interface";
-import { numberEnum } from "@/handlers/validators";
-import { validateApiKey } from "@/services/validators/printer-service.validation";
+import {
+  printerTypeValidator,
+  printerUrlValidator,
+  printerApiKeyValidator,
+  printerEnabledValidator,
+  printerDisabledReasonValidator,
+  refineApiKeyValidator,
+} from "@/services/validators/printer-service.validation";
 
 export const flowRateSchema = z.object({
   flowRate: z.number().int().min(75).max(125).nonnegative(),
@@ -13,40 +18,22 @@ export const feedRateSchema = z.object({
 
 export const testPrinterApiSchema = z
   .object({
-    printerURL: z.string().url(),
-    printerType: z.number().superRefine(numberEnum(PrinterTypes)),
-    apiKey: validateApiKey,
+    printerURL: printerUrlValidator,
+    printerType: printerTypeValidator,
+    apiKey: printerApiKeyValidator,
   })
-  .superRefine((data, ctx) => {
-    if (data.printerType === OctoprintType && !data.apiKey?.length) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "apiKey is required when printerType is OctoprintType",
-        path: ["apiKey"],
-      });
-      return ctx;
-    }
-
-    // Validate that apiKey length is either 32 or 43 characters if it exists
-    if (data.apiKey && data.apiKey.length !== 32 && data.apiKey.length !== 43) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "apiKey must be either 32 or 43 characters long",
-        path: ["apiKey"],
-      });
-    }
-  });
+  .superRefine(refineApiKeyValidator);
 
 export const updatePrinterDisabledReasonSchema = z.object({
-  disabledReason: z.string().optional(),
+  disabledReason: printerDisabledReasonValidator,
 });
 
 export const updatePrinterEnabledSchema = z.object({
-  enabled: z.boolean(),
+  enabled: printerEnabledValidator,
 });
 
 export const updatePrinterConnectionSettingSchema = z.object({
-  printerType: z.number().superRefine(numberEnum(PrinterTypes)),
-  printerURL: z.string().url(),
-  apiKey: validateApiKey,
+  printerType: printerTypeValidator,
+  printerURL: printerUrlValidator,
+  apiKey: printerApiKeyValidator,
 });

--- a/src/controllers/validation/printer-files-controller.validation.ts
+++ b/src/controllers/validation/printer-files-controller.validation.ts
@@ -1,11 +1,13 @@
-export const getFileRules = {
-  path: "required|string",
-};
+import { z } from "zod";
 
-export const downloadFileRules = {
-  path: "required|string",
-};
+export const startPrintFileSchema = z.object({
+  filePath: z.string().min(1),
+});
 
-export const startPrintFileRules = {
-  filePath: "required|string",
-};
+export const downloadFileSchema = z.object({
+  path: z.string().min(1),
+});
+
+export const getFileSchema = z.object({
+  path: z.string().min(1),
+});

--- a/src/controllers/validation/printer-settings-controller.validation.ts
+++ b/src/controllers/validation/printer-settings-controller.validation.ts
@@ -1,3 +1,5 @@
-export const setGcodeAnalysisRules = {
-  enabled: "required|boolean",
-};
+import { z } from "zod";
+
+export const setGcodeAnalysisSchema = z.object({
+  enabled: z.boolean(),
+});

--- a/src/controllers/validation/server-private.validation.ts
+++ b/src/controllers/validation/server-private.validation.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const updateClientBundleSchema = z.object({
+  downloadRelease: z.string().optional(),
+  allowDowngrade: z.boolean().optional(),
+});

--- a/src/controllers/validation/setting.validation.ts
+++ b/src/controllers/validation/setting.validation.ts
@@ -1,7 +1,16 @@
-// Wizard version 1
-export const wizardSettingsRules = {
-  loginRequired: "required|boolean",
-  registration: "required|boolean",
-  rootUsername: "required|string",
-  rootPassword: "required|string|minLength:8",
-};
+import { z } from "zod";
+
+export const wizardSettingsSchema = z.object({
+  loginRequired: z.boolean(),
+  registration: z.boolean(),
+  rootUsername: z.string().nonempty("rootUsername is required"),
+  rootPassword: z.string().min(8, "rootPassword must be at least 8 characters long").nonempty("rootPassword is required"),
+});
+
+export const loginRequiredSchema = z.object({
+  loginRequired: z.boolean(),
+});
+
+export const registrationEnabledSchema = z.object({
+  registrationEnabled: z.boolean(),
+});

--- a/src/controllers/validation/user-controller.validation.ts
+++ b/src/controllers/validation/user-controller.validation.ts
@@ -1,14 +1,37 @@
+import { z } from "zod";
 import { AppConstants } from "@/server.constants";
 import { idRuleV2 } from "./generic.validation";
 
-export const registerUserRules = {
-  username: `required|string|minLength:${AppConstants.DEFAULT_USERNAME_MINLEN}`,
-  password: `required|string|minLength:${AppConstants.DEFAULT_PASSWORD_MINLEN}`,
-};
+export const registerUserSchema = z.object({
+  username: z.string().min(AppConstants.DEFAULT_USERNAME_MINLEN).nonempty(),
+  password: z.string().min(AppConstants.DEFAULT_PASSWORD_MINLEN).nonempty(),
+});
 
-export const registerUserWithRolesRules = (isSqlite: boolean) => ({
-  username: `required|string|minLength:${AppConstants.DEFAULT_USERNAME_MINLEN}`,
-  password: `required|string|minLength:${AppConstants.DEFAULT_PASSWORD_MINLEN}`,
-  roleIds: "array",
-  "roleIds.*": idRuleV2(isSqlite),
+export const changePasswordSchema = z.object({
+  oldPassword: z.string().nonempty(),
+  newPassword: z.string().min(AppConstants.DEFAULT_PASSWORD_MINLEN).nonempty(),
+});
+
+export const registerUserWithRolesSchema = (isSqlite: boolean) =>
+  z.object({
+    username: z.string().min(AppConstants.DEFAULT_USERNAME_MINLEN).nonempty(),
+    password: z.string().min(AppConstants.DEFAULT_PASSWORD_MINLEN).nonempty(),
+    roleIds: z.array(idRuleV2(isSqlite)),
+  });
+
+export const setUserRolesSchema = (isSqlite: boolean) =>
+  z.object({
+    roleIds: z.array(idRuleV2(isSqlite)),
+  });
+
+export const usernameSchema = z.object({
+  username: z.string().min(AppConstants.DEFAULT_USERNAME_MINLEN).nonempty(),
+});
+
+export const isVerifiedSchema = z.object({
+  isVerified: z.boolean(),
+});
+
+export const isRootUserSchema = z.object({
+  isRootUser: z.boolean(),
 });

--- a/src/entities/printer.entity.ts
+++ b/src/entities/printer.entity.ts
@@ -26,7 +26,7 @@ export class Printer {
     nullable: false,
     default: true,
   })
-  enabled: boolean = true;
+  enabled: boolean;
 
   @Column({
     nullable: true,

--- a/src/models/Auth/Permission.ts
+++ b/src/models/Auth/Permission.ts
@@ -1,7 +1,8 @@
 import { model, Schema } from "mongoose";
+import { MongoIdType } from "@/shared.constants";
 
-export interface IPermission {
-  id: string;
+export interface IPermission<KeyType = MongoIdType> {
+  id: KeyType;
   name: string;
 }
 

--- a/src/models/Auth/RefreshToken.ts
+++ b/src/models/Auth/RefreshToken.ts
@@ -1,6 +1,7 @@
 import { model, Schema, Types } from "mongoose";
+import { MongoIdType } from "@/shared.constants";
 
-export interface IRefreshToken<KeyType = string> {
+export interface IRefreshToken<KeyType = MongoIdType> {
   id: KeyType;
   userId: Types.ObjectId;
   createdAt: Date;

--- a/src/models/Auth/RefreshToken.ts
+++ b/src/models/Auth/RefreshToken.ts
@@ -1,7 +1,7 @@
 import { model, Schema, Types } from "mongoose";
 
-export interface IRefreshToken {
-  id: string;
+export interface IRefreshToken<KeyType = string> {
+  id: KeyType;
   userId: Types.ObjectId;
   createdAt: Date;
   expiresAt: number;

--- a/src/models/Auth/Role.ts
+++ b/src/models/Auth/Role.ts
@@ -1,7 +1,8 @@
 import { model, Schema } from "mongoose";
+import { MongoIdType } from "@/shared.constants";
 
-export interface IRole {
-  id: string;
+export interface IRole<KeyType = MongoIdType> {
+  id: KeyType;
   name: string;
 }
 

--- a/src/models/Auth/User.ts
+++ b/src/models/Auth/User.ts
@@ -1,6 +1,7 @@
 import { AnyArray, model, Schema } from "mongoose";
+import { MongoIdType } from "@/shared.constants";
 
-export interface IUser<KeyType = string> {
+export interface IUser<KeyType = MongoIdType> {
   id: KeyType;
   username: string;
   isDemoUser: boolean;

--- a/src/models/Auth/User.ts
+++ b/src/models/Auth/User.ts
@@ -1,7 +1,7 @@
 import { AnyArray, model, Schema } from "mongoose";
 
-export interface IUser {
-  id: string;
+export interface IUser<KeyType = string> {
+  id: KeyType;
   username: string;
   isDemoUser: boolean;
   isRootUser: boolean;

--- a/src/models/CameraStream.ts
+++ b/src/models/CameraStream.ts
@@ -1,7 +1,8 @@
 import { model, Schema, Types } from "mongoose";
+import { MongoIdType } from "@/shared.constants";
 
-export interface ICameraStream {
-  id: string;
+export interface ICameraStream<KeyType = MongoIdType> {
+  id: KeyType;
   name?: string;
   streamURL: string;
   printerId?: Types.ObjectId;

--- a/src/models/CustomGcode.ts
+++ b/src/models/CustomGcode.ts
@@ -1,7 +1,8 @@
 import { AnyArray, model, Schema } from "mongoose";
+import { MongoIdType } from "@/shared.constants";
 
-export interface ICustomGcode {
-  id: string;
+export interface ICustomGcode<KeyType = MongoIdType> {
+  id: KeyType;
   name: string;
   description?: string;
   gcode: AnyArray<string>;

--- a/src/models/Floor.ts
+++ b/src/models/Floor.ts
@@ -3,10 +3,10 @@ import { IPosition, PrinterInFloorSchema } from "./FloorPrinter";
 import { MongoIdType } from "@/shared.constants";
 
 export interface IFloor<KeyType = MongoIdType> {
-  id: string;
+  id: KeyType;
   name: string;
   floor: number;
-  printers: IPosition<KeyType>[];
+  printers: IPosition[];
 }
 
 const FloorSchema = new Schema<IFloor>({

--- a/src/models/Floor.ts
+++ b/src/models/Floor.ts
@@ -1,11 +1,12 @@
 import { model, Schema } from "mongoose";
 import { IPosition, PrinterInFloorSchema } from "./FloorPrinter";
+import { MongoIdType } from "@/shared.constants";
 
-export interface IFloor {
+export interface IFloor<KeyType = MongoIdType> {
   id: string;
   name: string;
   floor: number;
-  printers: IPosition[];
+  printers: IPosition<KeyType>[];
 }
 
 const FloorSchema = new Schema<IFloor>({

--- a/src/models/PrintCompletion.ts
+++ b/src/models/PrintCompletion.ts
@@ -1,8 +1,9 @@
 import { model, Schema } from "mongoose";
 import { PrintCompletionContextDto } from "@/services/interfaces/print-completion-context.dto";
+import { MongoIdType } from "@/shared.constants";
 
-export interface IPrintCompletion {
-  id: string;
+export interface IPrintCompletion<KeyType = MongoIdType> {
+  id: KeyType;
   fileName: string;
   createdAt: number;
   status: string;

--- a/src/models/Printer.ts
+++ b/src/models/Printer.ts
@@ -1,8 +1,9 @@
 import { model, Schema } from "mongoose";
 import { OctoprintType } from "@/services/printer-api.interface";
+import { MongoIdType } from "@/shared.constants";
 
-export interface IPrinter {
-  id: string;
+export interface IPrinter<KeyType = MongoIdType> {
+  id: KeyType;
   apiKey: string;
   printerURL: string;
   printerType: number;

--- a/src/services/core/yaml.service.ts
+++ b/src/services/core/yaml.service.ts
@@ -1,8 +1,8 @@
 import { validateInput } from "@/handlers/validators";
 import {
-  exportPrintersFloorsYamlRules,
-  importPrinterPositionsRules,
-  importPrintersFloorsYamlRules,
+  exportPrintersFloorsYamlSchema,
+  importPrinterPositionsSchema,
+  importPrintersFloorsYamlSchema,
 } from "../validators/yaml-service.validation";
 import { dump, load } from "js-yaml";
 import { LoggerService } from "@/handlers/logger";
@@ -75,13 +75,13 @@ export class YamlService {
 
     const importData = await validateInput(
       importSpec,
-      importPrintersFloorsYamlRules(exportPrinters, exportFloorGrid, exportFloors, exportGroups)
+      importPrintersFloorsYamlSchema(exportPrinters, exportFloorGrid, exportFloors, exportGroups)
     );
 
     // Nested validation is manual (for now)
     if (!!exportFloorGrid) {
       for (const floor of importData.floors) {
-        await validateInput(floor, importPrinterPositionsRules(this.isTypeormMode));
+        await validateInput(floor, importPrinterPositionsSchema(this.isTypeormMode));
       }
     }
 
@@ -412,18 +412,8 @@ export class YamlService {
   }
 
   async exportPrintersAndFloors(options) {
-    const input = await validateInput(options, exportPrintersFloorsYamlRules);
-    const {
-      exportFloors,
-      exportPrinters,
-      exportFloorGrid,
-      exportGroups,
-      // dropPrinterIds, // optional idea for future
-      // dropFloorIds, // optional idea for future
-      // printerComparisonStrategiesByPriority, // not used for export
-      // floorComparisonStrategiesByPriority, // not used for export
-      // notes, // passed on to config immediately
-    } = input;
+    const input = await validateInput(options, exportPrintersFloorsYamlSchema);
+    const { exportFloors, exportPrinters, exportFloorGrid, exportGroups } = input;
 
     if (!this.isTypeormMode) {
       input.exportGroups = false;

--- a/src/services/core/yaml.service.ts
+++ b/src/services/core/yaml.service.ts
@@ -35,7 +35,7 @@ export class YamlService {
   async importPrintersAndFloors(yamlBuffer: string) {
     const importSpec = (await load(yamlBuffer)) as YamlExportSchema;
     const databaseTypeSqlite = importSpec.databaseType === "sqlite";
-    const { exportPrinters, exportFloorGrid } = importSpec?.config;
+    const { exportPrinters, exportFloorGrid } = importSpec.config;
 
     for (const printer of importSpec.printers) {
       // old export bug

--- a/src/services/core/yaml.service.ts
+++ b/src/services/core/yaml.service.ts
@@ -3,6 +3,7 @@ import {
   exportPrintersFloorsYamlSchema,
   importPrinterPositionsSchema,
   importPrintersFloorsYamlSchema,
+  YamlExportSchema,
 } from "../validators/yaml-service.validation";
 import { dump, load } from "js-yaml";
 import { LoggerService } from "@/handlers/logger";
@@ -14,6 +15,7 @@ import { IFloorService } from "@/services/interfaces/floor.service.interface";
 import { SqliteIdType } from "@/shared.constants";
 import { IPrinterGroupService } from "@/services/interfaces/printer-group.service.interface";
 import { MoonrakerType, OctoprintType } from "@/services/printer-api.interface";
+import { z } from "zod";
 
 export class YamlService {
   private readonly logger: LoggerService;
@@ -31,7 +33,7 @@ export class YamlService {
   }
 
   async importPrintersAndFloors(yamlBuffer: string) {
-    const importSpec = await load(yamlBuffer);
+    const importSpec = (await load(yamlBuffer)) as YamlExportSchema;
     const databaseTypeSqlite = importSpec.databaseType === "sqlite";
     const { exportPrinters, exportFloorGrid, exportFloors, exportGroups } = importSpec?.config;
 
@@ -73,15 +75,12 @@ export class YamlService {
       }
     }
 
-    const importData = await validateInput(
-      importSpec,
-      importPrintersFloorsYamlSchema(exportPrinters, exportFloorGrid, exportFloors, exportGroups)
-    );
+    const importData = await validateInput(importSpec, importPrintersFloorsYamlSchema);
 
     // Nested validation is manual (for now)
     if (!!exportFloorGrid) {
       for (const floor of importData.floors) {
-        await validateInput(floor, importPrinterPositionsSchema(this.isTypeormMode));
+        await validateInput(floor, importPrinterPositionsSchema);
       }
     }
 
@@ -411,13 +410,13 @@ export class YamlService {
     };
   }
 
-  async exportPrintersAndFloors(options) {
+  async exportPrintersAndFloors(options: z.infer<typeof exportPrintersFloorsYamlSchema>) {
     const input = await validateInput(options, exportPrintersFloorsYamlSchema);
-    const { exportFloors, exportPrinters, exportFloorGrid, exportGroups } = input;
 
     if (!this.isTypeormMode) {
       input.exportGroups = false;
     }
+    const { exportFloors, exportPrinters, exportFloorGrid, exportGroups } = input;
 
     const dumpedObject = {
       version: process.env.npm_package_version,

--- a/src/services/core/yaml.service.ts
+++ b/src/services/core/yaml.service.ts
@@ -35,7 +35,7 @@ export class YamlService {
   async importPrintersAndFloors(yamlBuffer: string) {
     const importSpec = (await load(yamlBuffer)) as YamlExportSchema;
     const databaseTypeSqlite = importSpec.databaseType === "sqlite";
-    const { exportPrinters, exportFloorGrid, exportFloors, exportGroups } = importSpec?.config;
+    const { exportPrinters, exportFloorGrid } = importSpec?.config;
 
     for (const printer of importSpec.printers) {
       // old export bug

--- a/src/services/interfaces/camera-stream.dto.ts
+++ b/src/services/interfaces/camera-stream.dto.ts
@@ -1,5 +1,4 @@
 import { IdDto } from "@/shared.constants";
-import { IsDefined, IsIn, IsNotEmpty, IsOptional } from "class-validator";
 
 export class CameraStreamDto<KeyType> extends IdDto<KeyType> {
   name?: string;
@@ -12,19 +11,13 @@ export class CameraStreamDto<KeyType> extends IdDto<KeyType> {
 }
 
 export class CreateCameraStreamDto<KeyType> {
-  @IsNotEmpty()
   streamURL: string;
-  @IsNotEmpty()
   name: string;
-  @IsOptional()
   printerId?: KeyType;
 }
 
 export class UpdateCameraStreamDto<KeyType> {
-  @IsNotEmpty()
   streamURL: string;
-  @IsNotEmpty()
   name: string;
-  @IsOptional()
   printerId: KeyType;
 }

--- a/src/services/interfaces/floor.dto.ts
+++ b/src/services/interfaces/floor.dto.ts
@@ -7,6 +7,13 @@ export class PositionDto<KeyType = IdType> {
   floorId: KeyType;
 }
 
+export class CreatePositionDto<KeyType> {
+  x: number;
+  y: number;
+  printerId: KeyType;
+  floorId?: KeyType;
+}
+
 export class FloorDto<KeyType = IdType> {
   id: KeyType;
   name: string;
@@ -15,7 +22,7 @@ export class FloorDto<KeyType = IdType> {
 }
 
 export class CreateFloorDto<KeyType> {
-  printers?: PositionDto<KeyType>[];
+  printers?: CreatePositionDto<KeyType>[];
   name: string;
   floor: number;
 }

--- a/src/services/interfaces/printer-group.dto.ts
+++ b/src/services/interfaces/printer-group.dto.ts
@@ -1,11 +1,8 @@
-import { IsNotEmpty } from "class-validator";
-
 export class PrinterGroupDto<KeyType = number> {
   printerId: KeyType;
   groupId: KeyType;
 }
 
 export class CreateGroupDto {
-  @IsNotEmpty()
   name: string;
 }

--- a/src/services/interfaces/printer.dto.ts
+++ b/src/services/interfaces/printer.dto.ts
@@ -3,7 +3,7 @@ import { IdDto } from "@/shared.constants";
 export class PrinterDto<KeyType> extends IdDto<KeyType> {
   name: string;
   enabled: boolean;
-  disabledReason: string;
+  disabledReason?: string;
   dateAdded: number;
 }
 

--- a/src/services/interfaces/printer.service.interface.ts
+++ b/src/services/interfaces/printer.service.interface.ts
@@ -22,8 +22,6 @@ export interface IPrinterService<KeyType = IdType, Entity = IPrinter | Printer> 
 
   batchImport(printers: Partial<Entity>[]): Promise<Entity[]>;
 
-  updateConnectionSettings(printerId: KeyType, partial: { printerUrl: string; apiKey: string }): Promise<Entity>;
-
   updateEnabled(printerId: KeyType, enabled: boolean): Promise<Entity>;
 
   updateFeedRate(printerId: KeyType, feedRate: number): Promise<Entity>;

--- a/src/services/mongoose/camera-stream.service.ts
+++ b/src/services/mongoose/camera-stream.service.ts
@@ -6,13 +6,7 @@ import { MongoIdType } from "@/shared.constants";
 import { ICameraStreamService } from "@/services/interfaces/camera-stream.service.interface";
 import { ICameraStream } from "@/models/CameraStream";
 import { CameraStreamDto, CreateCameraStreamDto, UpdateCameraStreamDto } from "@/services/interfaces/camera-stream.dto";
-
-// TODO switch to class-validator DTO validation
-const createCameraStreamRules = {
-  printerId: "mongoId",
-  streamURL: "required|httpurl",
-  name: "required|string",
-};
+import { createCameraStreamSchema } from "../validators/camera-service.validation";
 
 export class CameraStreamService implements ICameraStreamService<MongoIdType> {
   model = CameraStream;
@@ -33,7 +27,7 @@ export class CameraStreamService implements ICameraStreamService<MongoIdType> {
   }
 
   async create(data: CreateCameraStreamDto<MongoIdType>) {
-    const input = await validateInput(data, createCameraStreamRules);
+    const input = await validateInput(data, createCameraStreamSchema(false));
     if (input.printerId) {
       this.printerCache.getCachedPrinterOrThrow(input.printerId);
     }
@@ -47,7 +41,8 @@ export class CameraStreamService implements ICameraStreamService<MongoIdType> {
 
   async update(id: MongoIdType, input: UpdateCameraStreamDto<MongoIdType>) {
     await this.get(id);
-    const updateInput = await validateInput(input, createCameraStreamRules);
+
+    const updateInput = await validateInput(input, createCameraStreamSchema(false));
     if (input.printerId) {
       this.printerCache.getCachedPrinterOrThrow(input.printerId);
     }

--- a/src/services/mongoose/custom-gcode.service.ts
+++ b/src/services/mongoose/custom-gcode.service.ts
@@ -6,7 +6,7 @@ import { ICustomGcodeService } from "@/services/interfaces/custom-gcode.service.
 import { ICustomGcode } from "@/models/CustomGcode";
 
 export class CustomGcodeService implements ICustomGcodeService<MongoIdType> {
-  toDto(document: ICustomGcode): CustomGcodeDto {
+  toDto(document: ICustomGcode): CustomGcodeDto<MongoIdType> {
     return {
       id: document.id,
       name: document.name,

--- a/src/services/mongoose/floor.service.ts
+++ b/src/services/mongoose/floor.service.ts
@@ -14,7 +14,6 @@ import { MongoIdType } from "@/shared.constants";
 import { IFloorService } from "@/services/interfaces/floor.service.interface";
 import { CreateFloorDto, FloorDto, PositionDto, UpdateFloorDto } from "@/services/interfaces/floor.dto";
 import { IPosition } from "@/models/FloorPrinter";
-import { ILoggerFactory } from "@/handlers/logger-factory";
 
 export class FloorService implements IFloorService<MongoIdType> {
   constructor(private readonly printerCache: PrinterCache) {}
@@ -116,7 +115,7 @@ export class FloorService implements IFloorService<MongoIdType> {
 
   async addOrUpdatePrinter(floorId: MongoIdType, updatedPosition: PositionDto<MongoIdType>) {
     const floor = await this.get(floorId, true);
-    
+
     updatedPosition.floorId = floor.id;
     const validInput = await validateInput(updatedPosition, printerInFloorSchema(false));
 

--- a/src/services/mongoose/floor.service.ts
+++ b/src/services/mongoose/floor.service.ts
@@ -12,7 +12,6 @@ import { PrinterCache } from "@/state/printer.cache";
 import { MongoIdType } from "@/shared.constants";
 import { IFloorService } from "@/services/interfaces/floor.service.interface";
 import { CreateFloorDto, FloorDto, PositionDto, UpdateFloorDto } from "@/services/interfaces/floor.dto";
-import { IPosition } from "@/models/FloorPrinter";
 
 export class FloorService implements IFloorService<MongoIdType> {
   constructor(private readonly printerCache: PrinterCache) {}

--- a/src/services/mongoose/floor.service.ts
+++ b/src/services/mongoose/floor.service.ts
@@ -62,8 +62,8 @@ export class FloorService implements IFloorService<MongoIdType> {
   async update(floorId: MongoIdType, update: UpdateFloorDto<MongoIdType>) {
     const existingFloor = await this.get(floorId);
 
-    if (input.printers) {
-      for (const position of input.printers) {
+    if (update.printers) {
+      for (const position of update.printers) {
         position.floorId = existingFloor.id;
       }
     }

--- a/src/services/mongoose/floor.service.ts
+++ b/src/services/mongoose/floor.service.ts
@@ -2,12 +2,11 @@ import { Floor, IFloor } from "@/models/Floor";
 import { validateInput } from "@/handlers/validators";
 import { NotFoundException } from "@/exceptions/runtime.exceptions";
 import {
-  createFloorSchema,
   printerInFloorSchema,
   removePrinterInFloorSchema,
   updateFloorNameSchema,
   updateFloorLevelSchema,
-  updateFloorSchema,
+  createOrUpdateFloorSchema,
 } from "../validators/floor-service.validation";
 import { PrinterCache } from "@/state/printer.cache";
 import { MongoIdType } from "@/shared.constants";
@@ -54,7 +53,7 @@ export class FloorService implements IFloorService<MongoIdType> {
   }
 
   async create(floor: CreateFloorDto<MongoIdType>) {
-    const validatedInput = await validateInput(floor, createFloorSchema(false));
+    const validatedInput = await validateInput(floor, createOrUpdateFloorSchema(false));
 
     return Floor.create(validatedInput);
   }
@@ -74,7 +73,7 @@ export class FloorService implements IFloorService<MongoIdType> {
       printers: update.printers,
       floor: update.floor,
     };
-    const input = await validateInput(floorUpdate, updateFloorSchema(false));
+    const input = await validateInput(floorUpdate, createOrUpdateFloorSchema(false));
 
     existingFloor.name = input.name;
     existingFloor.floor = input.floor;
@@ -129,7 +128,7 @@ export class FloorService implements IFloorService<MongoIdType> {
       (position) => position.printerId.toString() === validInput.printerId.toString()
     );
     if (positionIndex !== -1) {
-      floor.printers[positionIndex] = validInput as PositionDto<MongoIdType> as IPosition;
+      floor.printers[positionIndex] = validInput as PositionDto<MongoIdType>;
     } else {
       floor.printers.push(validInput);
     }

--- a/src/services/mongoose/print-completion.service.ts
+++ b/src/services/mongoose/print-completion.service.ts
@@ -1,5 +1,5 @@
 import { PrintCompletion } from "@/models";
-import { createPrintCompletionRules } from "../validators/print-completion-service.validation";
+import { createPrintCompletionSchema } from "../validators/print-completion-service.validation";
 import { validateInput } from "@/handlers/validators";
 import { EVENT_TYPES } from "../octoprint/constants/octoprint-websocket.constants";
 import { LoggerService } from "@/handlers/logger";
@@ -30,7 +30,10 @@ export class PrintCompletionService implements IPrintCompletionService<MongoIdTy
   }
 
   async create(input: CreatePrintCompletionDto<MongoIdType>) {
-    const { printerId, fileName, completionLog, status, context } = await validateInput(input, createPrintCompletionRules);
+    const { printerId, fileName, completionLog, status, context } = await validateInput(
+      input,
+      createPrintCompletionSchema(false)
+    );
 
     return PrintCompletion.create({
       printerId,

--- a/src/services/mongoose/printer.service.ts
+++ b/src/services/mongoose/printer.service.ts
@@ -3,9 +3,9 @@ import { Printer } from "@/models";
 import { NotFoundException } from "@/exceptions/runtime.exceptions";
 import { validateInput } from "@/handlers/validators";
 import {
-  createMongoPrinterRules,
-  updatePrinterDisabledReasonRule,
-  updatePrinterEnabledRule,
+  createPrinterSchema,
+  updatePrinterDisabledReasonSchema,
+  updatePrinterEnabledSchema,
 } from "../validators/printer-service.validation";
 import { printerEvents } from "@/constants/event.constants";
 import { LoggerService } from "@/handlers/logger";
@@ -88,7 +88,7 @@ export class PrinterService implements IPrinterService<MongoIdType> {
   async update(printerId: MongoIdType, updateData: Partial<IPrinter>) {
     const printer = await this.get(printerId);
     updateData.printerURL = normalizeUrl(updateData.printerURL, { defaultProtocol: defaultHttpProtocol });
-    const { printerURL, apiKey, enabled, name, printerType } = await validateInput(updateData, createMongoPrinterRules);
+    const { printerURL, apiKey, enabled, name, printerType } = await validateInput(updateData, createPrinterSchema);
 
     printer.printerURL = printerURL;
     printer.apiKey = apiKey;
@@ -166,7 +166,7 @@ export class PrinterService implements IPrinterService<MongoIdType> {
       printerType,
     };
 
-    await validateInput(update, createMongoPrinterRules);
+    await validateInput(update, createPrinterSchema);
     await this.get(printerId);
 
     const printer = await Printer.findByIdAndUpdate(printerId, update, {
@@ -185,7 +185,7 @@ export class PrinterService implements IPrinterService<MongoIdType> {
         }
       : { enabled };
 
-    await validateInput(update, updatePrinterEnabledRule);
+    await validateInput(update, updatePrinterEnabledSchema);
     await this.get(printerId);
 
     const printer = await Printer.findByIdAndUpdate(printerId, update, {
@@ -193,7 +193,7 @@ export class PrinterService implements IPrinterService<MongoIdType> {
       useFindAndModify: false,
     });
     this.eventEmitter2.emit(printerEvents.printerUpdated, { printer });
-    return printer;
+    return printer!;
   }
 
   async updateDisabledReason(printerId: MongoIdType, disabledReason: string) {
@@ -203,7 +203,7 @@ export class PrinterService implements IPrinterService<MongoIdType> {
       enabled,
     };
 
-    await validateInput(update, updatePrinterDisabledReasonRule);
+    await validateInput(update, updatePrinterDisabledReasonSchema);
     await this.get(printerId);
 
     const printer = await Printer.findByIdAndUpdate(printerId, update, {
@@ -211,7 +211,7 @@ export class PrinterService implements IPrinterService<MongoIdType> {
       useFindAndModify: false,
     });
     this.eventEmitter2.emit(printerEvents.printerUpdated, { printer });
-    return printer;
+    return printer!;
   }
 
   private async validateAndDefault(printer): Promise<IPrinter> {
@@ -222,6 +222,6 @@ export class PrinterService implements IPrinterService<MongoIdType> {
     if (mergedPrinter.printerURL?.length) {
       mergedPrinter.printerURL = normalizeUrl(mergedPrinter.printerURL, { defaultProtocol: defaultHttpProtocol });
     }
-    return await validateInput(mergedPrinter, createMongoPrinterRules);
+    return await validateInput(mergedPrinter, createPrinterSchema);
   }
 }

--- a/src/services/mongoose/printer.service.ts
+++ b/src/services/mongoose/printer.service.ts
@@ -12,7 +12,6 @@ import { LoggerService } from "@/handlers/logger";
 import { MongoIdType } from "@/shared.constants";
 import { IPrinterService } from "@/services/interfaces/printer.service.interface";
 import { ILoggerFactory } from "@/handlers/logger-factory";
-import { LoginDto } from "@/services/interfaces/login.dto";
 import { PrinterDto, PrinterUnsafeDto } from "@/services/interfaces/printer.dto";
 import { IPrinter } from "@/models/Printer";
 import { normalizeUrl } from "@/utils/normalize-url";
@@ -151,24 +150,6 @@ export class PrinterService implements IPrinterService<MongoIdType> {
   async updateFeedRate(printerId: MongoIdType, feedRate: number) {
     const update = { feedRate };
     await this.get(printerId);
-    const printer = await Printer.findByIdAndUpdate(printerId, update, {
-      new: true,
-      useFindAndModify: false,
-    });
-    this.eventEmitter2.emit(printerEvents.printerUpdated, { printer });
-    return printer;
-  }
-
-  async updateConnectionSettings(printerId: MongoIdType, { printerURL, apiKey, printerType }: LoginDto) {
-    const update = {
-      printerURL: normalizeUrl(printerURL, { defaultProtocol: defaultHttpProtocol }),
-      apiKey,
-      printerType,
-    };
-
-    await validateInput(update, createPrinterSchema);
-    await this.get(printerId);
-
     const printer = await Printer.findByIdAndUpdate(printerId, update, {
       new: true,
       useFindAndModify: false,

--- a/src/services/mongoose/settings.service.ts
+++ b/src/services/mongoose/settings.service.ts
@@ -16,12 +16,12 @@ import {
 } from "@/constants/server-settings.constants";
 import { validateInput } from "@/handlers/validators";
 import {
-  credentialSettingPatchRules,
-  fileCleanSettingsUpdateRules,
-  frontendSettingsUpdateRules,
-  serverSettingsUpdateRules,
-  timeoutSettingsUpdateRules,
-  wizardUpdateRules,
+  credentialSettingPatchSchema,
+  fileCleanSettingsUpdateSchema,
+  frontendSettingsUpdateSchema,
+  serverSettingsUpdateSchema,
+  timeoutSettingsUpdateSchema,
+  wizardUpdateSchema,
 } from "../validators/settings-service.validation";
 import { ISettingsService } from "@/services/interfaces/settings.service.interface";
 import {
@@ -115,7 +115,7 @@ export class SettingsService implements ISettingsService<MongoIdType> {
   }
 
   async patchFileCleanSettings(patchUpdate: Partial<IFileCleanSettings>) {
-    const validatedInput = await validateInput(patchUpdate, fileCleanSettingsUpdateRules);
+    const validatedInput = await validateInput(patchUpdate, fileCleanSettingsUpdateSchema);
 
     const settingsDoc = await this.getOrCreate();
     settingsDoc[printerFileCleanSettingKey] = Object.assign(settingsDoc[printerFileCleanSettingKey], validatedInput);
@@ -125,7 +125,7 @@ export class SettingsService implements ISettingsService<MongoIdType> {
   }
 
   async patchWizardSettings(patchUpdate: Partial<IWizardSettings>) {
-    const validatedInput = await validateInput(patchUpdate, wizardUpdateRules);
+    const validatedInput = await validateInput(patchUpdate, wizardUpdateSchema);
 
     const settingsDoc = await this.getOrCreate();
     settingsDoc[wizardSettingKey] = Object.assign(settingsDoc[wizardSettingKey], validatedInput);
@@ -135,7 +135,7 @@ export class SettingsService implements ISettingsService<MongoIdType> {
   }
 
   async updateFrontendSettings(patchUpdate: IFrontendSettings) {
-    const validatedInput = await validateInput(patchUpdate, frontendSettingsUpdateRules);
+    const validatedInput = await validateInput(patchUpdate, frontendSettingsUpdateSchema);
 
     const settingsDoc = await this.getOrCreate();
     const frontendSettings = settingsDoc[frontendSettingKey];
@@ -146,7 +146,7 @@ export class SettingsService implements ISettingsService<MongoIdType> {
   }
 
   async patchCredentialSettings(patchUpdate: Partial<ICredentialSettings>) {
-    const validatedInput = await validateInput(patchUpdate, credentialSettingPatchRules);
+    const validatedInput = await validateInput(patchUpdate, credentialSettingPatchSchema);
 
     const settingsDoc = await this.getOrCreate();
     const credentialSettings = settingsDoc[credentialSettingsKey];
@@ -157,7 +157,7 @@ export class SettingsService implements ISettingsService<MongoIdType> {
   }
 
   async patchServerSettings(patchUpdate: Partial<IServerSettings>) {
-    const validatedInput = await validateInput(patchUpdate, serverSettingsUpdateRules);
+    const validatedInput = await validateInput(patchUpdate, serverSettingsUpdateSchema);
 
     const settingsDoc = await this.getOrCreate();
     const serverSettings = settingsDoc[serverSettingsKey];
@@ -168,7 +168,7 @@ export class SettingsService implements ISettingsService<MongoIdType> {
   }
 
   async updateTimeoutSettings(patchUpdate: Partial<ITimeoutSettings>) {
-    const validatedInput = await validateInput(patchUpdate, timeoutSettingsUpdateRules);
+    const validatedInput = await validateInput(patchUpdate, timeoutSettingsUpdateSchema);
 
     const settingsDoc = await this.getOrCreate();
     const timeoutSettings = settingsDoc[timeoutSettingKey];

--- a/src/services/mongoose/user.service.ts
+++ b/src/services/mongoose/user.service.ts
@@ -1,7 +1,7 @@
 import { User } from "@/models";
 import { InternalServerException, NotFoundException } from "@/exceptions/runtime.exceptions";
 import { validateInput } from "@/handlers/validators";
-import { newPasswordRules, registerUserRules } from "../validators/user-service.validation";
+import { newPasswordSchema, registerUserSchema } from "../validators/user-service.validation";
 import { ROLES } from "@/constants/authorization.constants";
 import { comparePasswordHash, hashPassword } from "@/utils/crypto.utils";
 import { RoleService } from "@/services/mongoose/role.service";
@@ -80,7 +80,6 @@ export class UserService implements IUserService<MongoIdType> {
   }
 
   async deleteUser(userId: MongoIdType) {
-    // Validate
     const user = await this.getUser(userId);
 
     if (user.isRootUser) {
@@ -115,14 +114,14 @@ export class UserService implements IUserService<MongoIdType> {
       throw new NotFoundException("User old password incorrect");
     }
 
-    const { password } = await validateInput({ password: newPassword }, newPasswordRules);
+    const { password } = await validateInput({ password: newPassword }, newPasswordSchema);
     user.passwordHash = hashPassword(password);
     user.needsPasswordChange = false;
     return await user.save();
   }
 
   async updatePasswordUnsafeByUsername(username: string, newPassword: string) {
-    const { password } = await validateInput({ password: newPassword }, newPasswordRules);
+    const { password } = await validateInput({ password: newPassword }, newPasswordSchema);
     const passwordHash = hashPassword(password);
     const user = await this.findRawByUsername(username);
     if (!user) throw new NotFoundException("User not found");
@@ -171,7 +170,7 @@ export class UserService implements IUserService<MongoIdType> {
   async register(input: RegisterUserDto<MongoIdType>) {
     const { username, password, roles, isDemoUser, isRootUser, needsPasswordChange, isVerified } = await validateInput(
       input,
-      registerUserRules(false)
+      registerUserSchema(false)
     );
 
     const passwordHash = hashPassword(password);

--- a/src/services/octoprint/constants/octoprint-websocket.constants.ts
+++ b/src/services/octoprint/constants/octoprint-websocket.constants.ts
@@ -38,3 +38,7 @@ export const EVENT_TYPES = {
   Waiting: "Waiting",
   ZChange: "ZChange",
 } as const;
+
+export const EVENT_TYPES_ARRAY = Object.values(EVENT_TYPES);
+
+export type EventType = typeof EVENT_TYPES_ARRAY[number];

--- a/src/services/orm/base.service.ts
+++ b/src/services/orm/base.service.ts
@@ -60,7 +60,7 @@ export function BaseService<
       if (dto.id) {
         delete dto.id;
       }
-      await validate(dto);
+
       const entity = this.repository.create(dto) as T;
       await validate(entity);
 

--- a/src/services/orm/custom-gcode.service.ts
+++ b/src/services/orm/custom-gcode.service.ts
@@ -8,7 +8,7 @@ export class CustomGcodeService
   extends BaseService(CustomGcode, CustomGcodeDto<SqliteIdType>, CustomGcodeDto<SqliteIdType>)
   implements ICustomGcodeService<SqliteIdType, CustomGcode>
 {
-  toDto(entity: CustomGcode): CustomGcodeDto {
+  toDto(entity: CustomGcode): CustomGcodeDto<SqliteIdType> {
     return {
       id: entity.id,
       name: entity.name,

--- a/src/services/orm/floor.service.ts
+++ b/src/services/orm/floor.service.ts
@@ -6,7 +6,13 @@ import { FloorPositionService } from "./floor-position.service";
 import { TypeormService } from "@/services/typeorm/typeorm.service";
 import { CreateFloorDto, FloorDto, PositionDto, UpdateFloorDto } from "@/services/interfaces/floor.dto";
 import { validateInput } from "@/handlers/validators";
-import { createFloorRules, updateFloorRules } from "@/services/validators/floor-service.validation";
+import {
+  createFloorSchema,
+  updateFloorNameSchema,
+  updateFloorLevelSchema,
+  updateFloorSchema,
+  printerInFloorSchema,
+} from "@/services/validators/floor-service.validation";
 import { NotFoundException } from "@/exceptions/runtime.exceptions";
 import { FindManyOptions, FindOneOptions } from "typeorm";
 
@@ -37,10 +43,11 @@ export class FloorService
   }
 
   async create(dto: CreateFloorDto<SqliteIdType>): Promise<Floor> {
-    await validateInput(dto, createFloorRules);
+    const outcome = await validateInput(dto, createFloorSchema(true));
+
     const floor = await super.create({
-      name: dto.name,
-      floor: dto.floor,
+      name: outcome.name,
+      floor: outcome.floor,
       printers: [],
     });
 
@@ -83,57 +90,66 @@ export class FloorService
    * @param update
    */
   async update(floorId: SqliteIdType, update: UpdateFloorDto<SqliteIdType>) {
-    const floor = await this.get(floorId);
+    const existingFloor = await this.get(floorId);
     const floorUpdate = {
-      ...floor,
+      ...existingFloor,
       name: update.name,
       printers: update.printers,
       floor: update.floor,
     };
+    const validatedFloor = await validateInput(floorUpdate, updateFloorSchema(true));
 
-    await validateInput(floorUpdate, updateFloorRules);
-    const desiredPositions = floorUpdate.printers;
+    // Add new printer positions
+    const desiredPositions = validatedFloor.printers;
     if (desiredPositions?.length) {
-      for (let printer of desiredPositions) {
-        await this.addOrUpdatePrinter(floor.id, printer);
+      for (const printer of desiredPositions) {
+        await this.addOrUpdatePrinter(existingFloor.id, printer as PositionDto<SqliteIdType>);
       }
     }
+
     // Remove any printers that should not exist on floor
-    const undesiredPositions = floor.printers.filter((pos) => !desiredPositions.find((dp) => dp.printerId === pos.printerId));
+    const undesiredPositions = existingFloor.printers.filter(
+      (pos) => !desiredPositions.find((dp) => dp.printerId === pos.printerId)
+    );
     if (undesiredPositions?.length) {
       await this.floorPositionService.deleteMany(undesiredPositions.map((pos) => pos.id));
     }
     delete floorUpdate.printers;
 
+    // Persist the floor entity changes itself
     return super.update(floorId, floorUpdate);
   }
 
-  async updateName(floorId: SqliteIdType, name: string) {
-    let floor = await this.get(floorId);
+  async updateName(floorId: SqliteIdType, floorName: string) {
+    const { name } = await validateInput({ name: floorName }, updateFloorNameSchema);
+
+    const floor = await this.get(floorId);
     floor.name = name;
-    floor = await this.update(floorId, floor);
-    return floor;
+    return this.update(floorId, floor);
   }
 
   async updateLevel(floorId: SqliteIdType, level: number): Promise<Floor> {
-    let floor = await this.get(floorId);
-    floor.floor = level;
-    floor = await this.update(floorId, floor);
-    return floor;
+    const { floor: validLevel } = await validateInput({ floor: level }, updateFloorLevelSchema);
+
+    const floor = await this.get(floorId);
+    floor.floor = validLevel;
+    return await this.update(floorId, floor);
   }
 
   async addOrUpdatePrinter(floorId: SqliteIdType, positionDto: PositionDto<SqliteIdType>): Promise<Floor> {
     // Validation only
     await this.get(floorId, true);
+    positionDto.floorId = floorId;
+    const validInput = await validateInput(positionDto, printerInFloorSchema(true));
 
-    const position = await this.floorPositionService.findPrinterPosition(positionDto.printerId as SqliteIdType);
+    const position = await this.floorPositionService.findPrinterPosition(validInput.printerId as SqliteIdType);
     // Optimization if position is in desired state already
     if (
       position &&
       position.floorId === floorId &&
-      position.x === positionDto.x &&
-      position.x === positionDto.y &&
-      position.printerId === positionDto.printerId
+      position.x === validInput.x &&
+      position.x === validInput.y &&
+      position.printerId === validInput.printerId
     ) {
       return this.get(floorId);
     }
@@ -143,16 +159,16 @@ export class FloorService
       await this.floorPositionService.delete(position.id);
     }
 
-    const xyPosition = await this.floorPositionService.findPosition(floorId, positionDto.x, positionDto.y);
+    const xyPosition = await this.floorPositionService.findPosition(floorId, validInput.x, validInput.y);
     if (xyPosition) {
       await this.floorPositionService.delete(xyPosition.id);
     }
 
     const newPosition = new FloorPosition();
     Object.assign(newPosition, {
-      x: positionDto.x,
-      y: positionDto.y,
-      printerId: positionDto.printerId as SqliteIdType,
+      x: validInput.x,
+      y: validInput.y,
+      printerId: validInput.printerId as SqliteIdType,
       floorId: floorId as SqliteIdType,
     });
 

--- a/src/services/orm/floor.service.ts
+++ b/src/services/orm/floor.service.ts
@@ -7,10 +7,9 @@ import { TypeormService } from "@/services/typeorm/typeorm.service";
 import { CreateFloorDto, FloorDto, PositionDto, UpdateFloorDto } from "@/services/interfaces/floor.dto";
 import { validateInput } from "@/handlers/validators";
 import {
-  createFloorSchema,
   updateFloorNameSchema,
   updateFloorLevelSchema,
-  updateFloorSchema,
+  createOrUpdateFloorSchema,
   printerInFloorSchema,
 } from "@/services/validators/floor-service.validation";
 import { NotFoundException } from "@/exceptions/runtime.exceptions";
@@ -43,7 +42,7 @@ export class FloorService
   }
 
   async create(dto: CreateFloorDto<SqliteIdType>): Promise<Floor> {
-    const outcome = await validateInput(dto, createFloorSchema(true));
+    const outcome = await validateInput(dto, createOrUpdateFloorSchema(true));
 
     const floor = await super.create({
       name: outcome.name,
@@ -51,9 +50,9 @@ export class FloorService
       printers: [],
     });
 
-    if (dto.printers?.length) {
-      for (const printer of dto.printers) {
-        await this.addOrUpdatePrinter(floor.id, printer);
+    if (outcome.printers?.length) {
+      for (const position of outcome.printers) {
+        await this.addOrUpdatePrinter(floor.id, position as PositionDto<number>);
       }
     }
 
@@ -97,7 +96,7 @@ export class FloorService
       printers: update.printers,
       floor: update.floor,
     };
-    const validatedFloor = await validateInput(floorUpdate, updateFloorSchema(true));
+    const validatedFloor = await validateInput(floorUpdate, createOrUpdateFloorSchema(true));
 
     // Add new printer positions
     const desiredPositions = validatedFloor.printers;

--- a/src/services/orm/permission.service.ts
+++ b/src/services/orm/permission.service.ts
@@ -70,7 +70,7 @@ export class PermissionService
     }
   }
 
-  normalizePermission(assignedPermission: string | number): string {
+  normalizePermission(assignedPermission: string | number) {
     const permissionInstance = this.permissions.find((r) => r.id === assignedPermission || r.name === assignedPermission);
     if (!permissionInstance) {
       this.logger.warn(`The permission by provided id is not found. Skipping`);

--- a/src/services/orm/printer.service.ts
+++ b/src/services/orm/printer.service.ts
@@ -51,9 +51,6 @@ export class PrinterService
     });
   }
 
-  /**
-   * Stores a new printer into the database.
-   */
   async create(newPrinter: PrinterUnsafeDto<SqliteIdType>, emitEvent = true): Promise<Printer> {
     if (newPrinter.id) {
       delete newPrinter.id;
@@ -122,10 +119,6 @@ export class PrinterService
     if (emitEvent) {
       this.eventEmitter2.emit(printerEvents.printersDeleted, { printerIds });
     }
-  }
-
-  updateConnectionSettings(printerId: SqliteIdType, partial: { printerUrl: string; apiKey: string }): Promise<Printer> {
-    return this.update(printerId, partial);
   }
 
   updateDisabledReason(printerId: SqliteIdType, disabledReason: string): Promise<Printer> {

--- a/src/services/orm/printer.service.ts
+++ b/src/services/orm/printer.service.ts
@@ -8,7 +8,6 @@ import { SqliteIdType } from "@/shared.constants";
 import { validateInput } from "@/handlers/validators";
 import { printerEvents } from "@/constants/event.constants";
 import EventEmitter2 from "eventemitter2";
-import { DeleteResult } from "typeorm";
 import { ILoggerFactory } from "@/handlers/logger-factory";
 import { normalizeUrl } from "@/utils/normalize-url";
 import { defaultHttpProtocol } from "@/utils/url.utils";
@@ -111,20 +110,18 @@ export class PrinterService
     return newPrinters;
   }
 
-  override async delete(printerId: SqliteIdType, emitEvent = true): Promise<DeleteResult> {
-    const result = await this.repository.delete([printerId]);
+  override async delete(printerId: SqliteIdType, emitEvent = true): Promise<void> {
+    await this.repository.delete([printerId]);
     if (emitEvent) {
       this.eventEmitter2.emit(printerEvents.printersDeleted, { printerIds: [[printerId]] });
     }
-    return result;
   }
 
-  async deleteMany(printerIds: SqliteIdType[], emitEvent = true): Promise<DeleteResult> {
-    const result = await this.repository.delete(printerIds);
+  async deleteMany(printerIds: SqliteIdType[], emitEvent = true): Promise<void> {
+    await this.repository.delete(printerIds);
     if (emitEvent) {
       this.eventEmitter2.emit(printerEvents.printersDeleted, { printerIds });
     }
-    return result;
   }
 
   updateConnectionSettings(printerId: SqliteIdType, partial: { printerUrl: string; apiKey: string }): Promise<Printer> {

--- a/src/services/orm/printer.service.ts
+++ b/src/services/orm/printer.service.ts
@@ -6,13 +6,13 @@ import { TypeormService } from "@/services/typeorm/typeorm.service";
 import { IPrinterService } from "@/services/interfaces/printer.service.interface";
 import { SqliteIdType } from "@/shared.constants";
 import { validateInput } from "@/handlers/validators";
-import { createPrinterRules } from "@/services/validators/printer-service.validation";
 import { printerEvents } from "@/constants/event.constants";
 import EventEmitter2 from "eventemitter2";
 import { DeleteResult } from "typeorm";
 import { ILoggerFactory } from "@/handlers/logger-factory";
 import { normalizeUrl } from "@/utils/normalize-url";
 import { defaultHttpProtocol } from "@/utils/url.utils";
+import { createPrinterSchema } from "@/services/validators/printer-service.validation";
 
 export class PrinterService
   extends BaseService(Printer, PrinterDto<SqliteIdType>)
@@ -78,7 +78,7 @@ export class PrinterService
       partial.printerURL = normalizeUrl(partial.printerURL, { defaultProtocol: defaultHttpProtocol });
     }
     Object.assign(printer, partial);
-    const { printerURL, apiKey, enabled, name, printerType } = await validateInput(printer, createPrinterRules);
+    const { printerURL, apiKey, enabled, name, printerType } = await validateInput(printer, createPrinterSchema);
 
     const updatedPrinter = await super.update(printerId, {
       printerURL,
@@ -155,6 +155,8 @@ export class PrinterService
     if (mergedPrinter.printerURL?.length) {
       mergedPrinter.printerURL = normalizeUrl(mergedPrinter.printerURL, { defaultProtocol: defaultHttpProtocol });
     }
-    return await validateInput(mergedPrinter, createPrinterRules);
+    await validateInput(mergedPrinter, createPrinterSchema);
+
+    return mergedPrinter;
   }
 }

--- a/src/services/orm/settings.service.ts
+++ b/src/services/orm/settings.service.ts
@@ -1,7 +1,6 @@
 import { Settings } from "@/entities";
 import {
   credentialSettingsKey,
-  printerFileCleanSettingKey,
   frontendSettingKey,
   getDefaultCredentialSettings,
   getDefaultFileCleanSettings,
@@ -9,6 +8,7 @@ import {
   getDefaultServerSettings,
   getDefaultTimeout,
   getDefaultWizardSettings,
+  printerFileCleanSettingKey,
   serverSettingsKey,
   timeoutSettingKey,
   wizardSettingKey,

--- a/src/services/orm/user.service.ts
+++ b/src/services/orm/user.service.ts
@@ -161,10 +161,10 @@ export class UserService extends BaseService(User, UserDto<SqliteIdType>) implem
   }
 
   async register(input: RegisterUserDto<SqliteIdType>): Promise<User> {
-    const { username, password, roles, isDemoUser, isRootUser, needsPasswordChange, isVerified } = (await validateInput(
+    const { username, password, roles, isDemoUser, isRootUser, needsPasswordChange, isVerified } = await validateInput(
       input,
       registerUserSchema(true)
-    )) as RegisterUserDto<SqliteIdType>;
+    );
 
     const passwordHash = hashPassword(password);
     const result = await this.create({

--- a/src/services/orm/user.service.ts
+++ b/src/services/orm/user.service.ts
@@ -6,7 +6,7 @@ import { IUserService } from "@/services/interfaces/user-service.interface";
 import { DeleteResult, In } from "typeorm";
 import { InternalServerException, NotFoundException } from "@/exceptions/runtime.exceptions";
 import { validateInput } from "@/handlers/validators";
-import { newPasswordRules, registerUserRules } from "@/services/validators/user-service.validation";
+import { newPasswordSchema, registerUserSchema } from "@/services/validators/user-service.validation";
 import { comparePasswordHash, hashPassword } from "@/utils/crypto.utils";
 import { TypeormService } from "@/services/typeorm/typeorm.service";
 import { UserRoleService } from "@/services/orm/user-role.service";
@@ -142,13 +142,13 @@ export class UserService extends BaseService(User, UserDto<SqliteIdType>) implem
       throw new NotFoundException("User old password incorrect");
     }
 
-    const { password } = await validateInput({ password: newPassword }, newPasswordRules);
+    const { password } = await validateInput({ password: newPassword }, newPasswordSchema);
     const passwordHash = hashPassword(password);
     return await this.update(userId, { passwordHash, needsPasswordChange: false });
   }
 
   async updatePasswordUnsafeByUsername(username: string, newPassword: string): Promise<User> {
-    const { password } = await validateInput({ password: newPassword }, newPasswordRules);
+    const { password } = await validateInput({ password: newPassword }, newPasswordSchema);
     const passwordHash = hashPassword(password);
     const user = await this.findRawByUsername(username);
     if (!user) throw new NotFoundException("User not found");
@@ -163,7 +163,7 @@ export class UserService extends BaseService(User, UserDto<SqliteIdType>) implem
   async register(input: RegisterUserDto<SqliteIdType>): Promise<User> {
     const { username, password, roles, isDemoUser, isRootUser, needsPasswordChange, isVerified } = (await validateInput(
       input,
-      registerUserRules(true)
+      registerUserSchema(true)
     )) as RegisterUserDto<SqliteIdType>;
 
     const passwordHash = hashPassword(password);

--- a/src/services/printer-api.interface.ts
+++ b/src/services/printer-api.interface.ts
@@ -5,8 +5,10 @@ import { SettingsDto } from "@/services/octoprint/dto/settings/settings.dto";
 import { ConnectionState } from "@/services/octoprint/dto/connection/connection-state.type";
 import { IdType } from "@/shared.constants";
 
-export const OctoprintType = 0;
-export const MoonrakerType = 1;
+export const OctoprintType = 0 as const;
+export const MoonrakerType = 1 as const;
+export const PrinterTypes = [OctoprintType, MoonrakerType];
+export type PrinterTypes = typeof PrinterTypes[number];
 export type PrinterType = typeof OctoprintType | typeof MoonrakerType;
 
 export interface StatusFlags {
@@ -22,7 +24,6 @@ export interface FileDto {
   path: string;
   size: number;
   date: number;
-  // hash?: number | string;
 }
 
 export const capabilities = {

--- a/src/services/printer-api.interface.ts
+++ b/src/services/printer-api.interface.ts
@@ -5,9 +5,9 @@ import { SettingsDto } from "@/services/octoprint/dto/settings/settings.dto";
 import { ConnectionState } from "@/services/octoprint/dto/connection/connection-state.type";
 import { IdType } from "@/shared.constants";
 
-export const OctoprintType = 0 as const;
-export const MoonrakerType = 1 as const;
-export const PrinterTypes = [OctoprintType, MoonrakerType];
+export const OctoprintType = 0;
+export const MoonrakerType = 1;
+export const PrinterTypes = [OctoprintType, MoonrakerType] as const;
 export type PrinterTypes = typeof PrinterTypes[number];
 export type PrinterType = typeof OctoprintType | typeof MoonrakerType;
 

--- a/src/services/validators/camera-service.validation.ts
+++ b/src/services/validators/camera-service.validation.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+import { idRuleV2 } from "@/controllers/validation/generic.validation";
+
+export const createCameraStreamSchema = (isSqlite: boolean) =>
+  z.object({
+    printerId: idRuleV2(isSqlite),
+    streamURL: z
+      .string()
+      .url("Invalid URL format")
+      .refine((val) => /^https?:\/\//.test(val), {
+        message: "Stream URL must be a valid HTTP or HTTPS URL",
+      }),
+    name: z.string().min(1, "Name is required").optional(),
+  });

--- a/src/services/validators/camera-service.validation.ts
+++ b/src/services/validators/camera-service.validation.ts
@@ -3,7 +3,7 @@ import { idRuleV2 } from "@/controllers/validation/generic.validation";
 
 export const createCameraStreamSchema = (isSqlite: boolean) =>
   z.object({
-    printerId: idRuleV2(isSqlite),
+    printerId: idRuleV2(isSqlite).nullish(),
     streamURL: z
       .string()
       .url("Invalid URL format")

--- a/src/services/validators/camera-service.validation.ts
+++ b/src/services/validators/camera-service.validation.ts
@@ -4,11 +4,6 @@ import { idRuleV2 } from "@/controllers/validation/generic.validation";
 export const createCameraStreamSchema = (isSqlite: boolean) =>
   z.object({
     printerId: idRuleV2(isSqlite).nullish(),
-    streamURL: z
-      .string()
-      .url("Invalid URL format")
-      .refine((val) => /^https?:\/\//.test(val), {
-        message: "Stream URL must be a valid HTTP or HTTPS URL",
-      }),
-    name: z.string().min(1, "Name is required").optional(),
+    streamURL: z.string().url(),
+    name: z.string().min(1).optional(),
   });

--- a/src/services/validators/floor-service.validation.ts
+++ b/src/services/validators/floor-service.validation.ts
@@ -7,33 +7,38 @@ export const removePrinterInFloorSchema = (isSqlite: boolean) =>
     printerId: idRuleV2(isSqlite),
   });
 
+export const xValidator = z.number().int().min(0).max(12);
+export const yValidator = z.number().int().min(0).max(12);
+export const floorLevelValidator = z.number().int();
+export const floorNameValidator = z.string().min(minFloorNameLength);
+
 export const printerInFloorSchema = (isSqlite: boolean) =>
   z.object({
     printerId: idRuleV2(isSqlite),
     floorId: idRuleV2(isSqlite),
-    x: z.number().int().min(0).max(12),
-    y: z.number().int().min(0).max(12),
+    x: xValidator,
+    y: yValidator,
   });
 
 export const updateFloorNameSchema = z.object({
-  name: z.string().min(minFloorNameLength),
+  name: floorNameValidator,
 });
 
 export const updateFloorLevelSchema = z.object({
-  floor: z.number().int(),
+  floor: floorLevelValidator,
 });
 
 export const updateFloorSchema = (isSqlite: boolean) =>
   z.object({
-    name: z.string().min(minFloorNameLength),
-    floor: z.number().int(),
+    name: floorNameValidator,
+    floor: floorLevelValidator,
     printers: z
       .array(
         z.object({
           printerId: idRuleV2(isSqlite),
           floorId: idRuleV2(isSqlite),
-          x: z.number().min(0).max(12),
-          y: z.number().min(0).max(12),
+          x: xValidator,
+          y: yValidator,
         })
       )
       .optional(),
@@ -41,6 +46,6 @@ export const updateFloorSchema = (isSqlite: boolean) =>
 
 export const createFloorSchema = (isSqlite: boolean) =>
   z.object({
-    name: z.string().min(minFloorNameLength),
-    floor: z.number().int(),
+    name: floorNameValidator,
+    floor: floorLevelValidator,
   });

--- a/src/services/validators/floor-service.validation.ts
+++ b/src/services/validators/floor-service.validation.ts
@@ -28,7 +28,7 @@ export const updateFloorLevelSchema = z.object({
   floor: floorLevelValidator,
 });
 
-export const updateFloorSchema = (isSqlite: boolean) =>
+export const createOrUpdateFloorSchema = (isSqlite: boolean) =>
   z.object({
     name: floorNameValidator,
     floor: floorLevelValidator,
@@ -36,16 +36,10 @@ export const updateFloorSchema = (isSqlite: boolean) =>
       .array(
         z.object({
           printerId: idRuleV2(isSqlite),
-          floorId: idRuleV2(isSqlite),
+          floorId: idRuleV2(isSqlite).optional(),
           x: xValidator,
           y: yValidator,
         })
       )
       .optional(),
-  });
-
-export const createFloorSchema = (isSqlite: boolean) =>
-  z.object({
-    name: floorNameValidator,
-    floor: floorLevelValidator,
   });

--- a/src/services/validators/floor-service.validation.ts
+++ b/src/services/validators/floor-service.validation.ts
@@ -1,36 +1,46 @@
+import { z } from "zod";
 import { minFloorNameLength } from "@/constants/service.constants";
 import { idRuleV2 } from "@/controllers/validation/generic.validation";
 
-export const removePrinterInFloorRules = (isSqlite: boolean) => ({
-  printerId: idRuleV2(isSqlite),
+export const removePrinterInFloorSchema = (isSqlite: boolean) =>
+  z.object({
+    printerId: idRuleV2(isSqlite),
+  });
+
+export const printerInFloorSchema = (isSqlite: boolean) =>
+  z.object({
+    printerId: idRuleV2(isSqlite),
+    floorId: idRuleV2(isSqlite),
+    x: z.number().int().min(0).max(12),
+    y: z.number().int().min(0).max(12),
+  });
+
+export const updateFloorNameSchema = z.object({
+  name: z.string().min(minFloorNameLength),
 });
 
-export const printerInFloorRules = (isSqlite: boolean) => ({
-  printerId: idRuleV2(isSqlite),
-  floorId: idRuleV2(isSqlite),
-  x: "required|integer|between:0,12",
-  y: "required|integer|between:0,12",
+export const updateFloorLevelSchema = z.object({
+  floor: z.number().int(),
 });
 
-export const updateFloorNameRules = {
-  name: `required|minLength:${minFloorNameLength}`,
-};
+export const updateFloorSchema = (isSqlite: boolean) =>
+  z.object({
+    name: z.string().min(minFloorNameLength),
+    floor: z.number().int(),
+    printers: z
+      .array(
+        z.object({
+          printerId: idRuleV2(isSqlite),
+          floorId: idRuleV2(isSqlite),
+          x: z.number().min(0).max(12),
+          y: z.number().min(0).max(12),
+        })
+      )
+      .optional(),
+  });
 
-export const updateFloorNumberRules = {
-  floor: "required|integer",
-};
-
-export const updateFloorRules = {
-  name: `required|minLength:${minFloorNameLength}`,
-  floor: "required|integer",
-  printers: "array",
-  "printer.*.printerId": "required|mongoId",
-  "printer.*.x": "required|integer|between:0,12",
-  "printer.*.y": "required|integer|between:0,12",
-};
-
-export const createFloorRules = {
-  name: `required|minLength:${minFloorNameLength}`,
-  floor: "required|integer",
-  printers: "array",
-};
+export const createFloorSchema = (isSqlite: boolean) =>
+  z.object({
+    name: z.string().min(minFloorNameLength),
+    floor: z.number().int(),
+  });

--- a/src/services/validators/print-completion-service.validation.ts
+++ b/src/services/validators/print-completion-service.validation.ts
@@ -15,5 +15,5 @@ export const createPrintCompletionSchema = (isSqlite: boolean) =>
     }),
     printerId: idRuleV2(isSqlite),
     completionLog: z.string().optional(),
-    context: z.object({}).strict("Context is required"), // Adjust depending on the expected shape of the context
+    context: z.any(),
   });

--- a/src/services/validators/print-completion-service.validation.ts
+++ b/src/services/validators/print-completion-service.validation.ts
@@ -1,9 +1,19 @@
-import { EVENT_TYPES } from "../octoprint/constants/octoprint-websocket.constants";
+import { z } from "zod";
+import { EVENT_TYPES, EVENT_TYPES_ARRAY } from "../octoprint/constants/octoprint-websocket.constants";
+import { idRuleV2 } from "@/controllers/validation/generic.validation";
 
-export const createPrintCompletionRules = {
-  fileName: "required",
-  status: `required|string|in:${Object.values(EVENT_TYPES)}`,
-  printerId: "required|string|mongoId",
-  completionLog: "string",
-  context: "required|object",
-};
+export const createPrintCompletionSchema = (isSqlite: boolean) =>
+  z.object({
+    fileName: z.string().min(1, "File name is required"),
+    status: z.enum(EVENT_TYPES_ARRAY as [string, ...string[]], {
+      errorMap: (issue) => {
+        if (issue.code === "invalid_type") {
+          return { message: `Status must be one of: ${Object.values(EVENT_TYPES).join(", ")}` };
+        }
+        return { message: "Invalid status" };
+      },
+    }),
+    printerId: idRuleV2(isSqlite),
+    completionLog: z.string().optional(),
+    context: z.object({}).strict("Context is required"), // Adjust depending on the expected shape of the context
+  });

--- a/src/services/validators/printer-service.validation.ts
+++ b/src/services/validators/printer-service.validation.ts
@@ -1,49 +1,66 @@
 import { apiKeyLengthMaxDefault, apiKeyLengthMinDefault } from "@/constants/service.constants";
 import { OctoprintType, PrinterTypes } from "@/services/printer-api.interface";
-import { z } from "zod";
+import { RefinementCtx, z } from "zod";
 import { numberEnum } from "@/handlers/validators";
 
-export const validateApiKey = z
+export const printerApiKeyValidator = z
   .string()
   .min(apiKeyLengthMinDefault)
   .max(apiKeyLengthMaxDefault)
   .regex(/^[a-zA-Z0-9_-]+$/, "Alpha-numeric, dash, and underscore only")
+  // Requires superRefine to validate whether required or not
   .optional();
 
-export const createPrinterSchema = z
-  .object({
-    printerURL: z.string().url(),
-    printerType: z.number().superRefine(numberEnum(PrinterTypes)),
-    apiKey: validateApiKey,
-    enabled: z.boolean().optional(), // Optional, adjust as needed
-    name: z.string(), // Name is required
-  })
-  .strip()
-  .superRefine((data, ctx) => {
-    if (data.printerType === OctoprintType && !data.apiKey?.length) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "apiKey is required when printerType is OctoprintType",
-        path: ["apiKey"],
-      });
-      return ctx;
-    }
+export const printerNameValidator = z.string();
+export const printerEnabledValidator = z.boolean();
+export const printerDisabledReasonValidator = z.string().optional();
+export const printerUrlValidator = z.string().url();
+export const printerTypeValidator = z.number().superRefine(numberEnum(PrinterTypes));
 
-    // Validate that apiKey length is either 32 or 43 characters if it exists
-    if (data.apiKey && data.apiKey.length !== 32 && data.apiKey.length !== 43) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "apiKey must be either 32 or 43 characters long",
-        path: ["apiKey"],
-      });
-    }
-  });
+const basePrinterSchema = z
+  .object({
+    printerURL: printerUrlValidator,
+    printerType: printerTypeValidator,
+    apiKey: printerApiKeyValidator,
+    enabled: printerEnabledValidator.optional(),
+    name: printerNameValidator,
+  })
+  .strip();
+
+// Infer base schema required to do superRefine
+const apiKeyPrinterTypeSchema = z.object({
+  apiKey: printerApiKeyValidator,
+  printerType: printerTypeValidator,
+});
+type ApiKeyPrinterTypeSchema = z.infer<typeof apiKeyPrinterTypeSchema>;
+
+export const refineApiKeyValidator = <T extends ApiKeyPrinterTypeSchema>(data: T, ctx: RefinementCtx) => {
+  if (data.printerType === OctoprintType && !data.apiKey?.length) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "apiKey is required when printerType is OctoprintType",
+      path: ["apiKey"],
+    });
+    return ctx;
+  }
+
+  // Validate that apiKey length is either 32 or 43 characters if it exists
+  if (data.apiKey && data.apiKey.length !== 32 && data.apiKey.length !== 43) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "apiKey must be either 32 or 43 characters long",
+      path: ["apiKey"],
+    });
+  }
+};
+
+export const createPrinterSchema = basePrinterSchema.superRefine(refineApiKeyValidator);
 
 export const updatePrinterEnabledSchema = z.object({
-  enabled: z.boolean(),
+  enabled: printerEnabledValidator,
 });
 
 export const updatePrinterDisabledReasonSchema = z.object({
-  disabledReason: z.string().nullable(),
-  enabled: z.boolean().optional(),
+  disabledReason: printerDisabledReasonValidator,
+  enabled: printerEnabledValidator.optional(),
 });

--- a/src/services/validators/printer-service.validation.ts
+++ b/src/services/validators/printer-service.validation.ts
@@ -1,28 +1,49 @@
 import { apiKeyLengthMaxDefault, apiKeyLengthMinDefault } from "@/constants/service.constants";
-import { OctoprintType, MoonrakerType } from "@/services/printer-api.interface";
+import { OctoprintType, PrinterTypes } from "@/services/printer-api.interface";
+import { z } from "zod";
+import { numberEnum } from "@/handlers/validators";
 
-export const createMongoPrinterRules = {
-  _id: "not",
-  printerURL: "required|httpurl",
-  printerType: `required|integer|in:${OctoprintType},${MoonrakerType}`,
-  apiKey: `requiredIf:printerType,${OctoprintType}|length:${apiKeyLengthMaxDefault},${apiKeyLengthMinDefault}|alphaDash`,
-  enabled: "boolean",
-  name: "string",
-};
+export const validateApiKey = z
+  .string()
+  .min(apiKeyLengthMinDefault)
+  .max(apiKeyLengthMaxDefault)
+  .regex(/^[a-zA-Z0-9_-]+$/, "Alpha-numeric, dash, and underscore only")
+  .optional();
 
-export const createPrinterRules = {
-  printerURL: "required|httpurl",
-  printerType: `required|integer|in:${OctoprintType},${MoonrakerType}`,
-  apiKey: `requiredIf:printerType,${OctoprintType}|length:${apiKeyLengthMaxDefault},${apiKeyLengthMinDefault}|alphaDash`,
-  enabled: "boolean",
-  name: "required|string",
-};
+export const createPrinterSchema = z
+  .object({
+    printerURL: z.string().url(),
+    printerType: z.number().superRefine(numberEnum(PrinterTypes)),
+    apiKey: validateApiKey,
+    enabled: z.boolean().optional(), // Optional, adjust as needed
+    name: z.string(), // Name is required
+  })
+  .strip()
+  .superRefine((data, ctx) => {
+    if (data.printerType === OctoprintType && !data.apiKey?.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "apiKey is required when printerType is OctoprintType",
+        path: ["apiKey"],
+      });
+      return ctx;
+    }
 
-export const updatePrinterEnabledRule = {
-  enabled: "required|boolean",
-};
+    // Validate that apiKey length is either 32 or 43 characters if it exists
+    if (data.apiKey && data.apiKey.length !== 32 && data.apiKey.length !== 43) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "apiKey must be either 32 or 43 characters long",
+        path: ["apiKey"],
+      });
+    }
+  });
 
-export const updatePrinterDisabledReasonRule = {
-  disabledReason: "required|nullable|string",
-  enabled: "boolean",
-};
+export const updatePrinterEnabledSchema = z.object({
+  enabled: z.boolean(),
+});
+
+export const updatePrinterDisabledReasonSchema = z.object({
+  disabledReason: z.string().nullable(),
+  enabled: z.boolean().optional(),
+});

--- a/src/services/validators/settings-service.validation.ts
+++ b/src/services/validators/settings-service.validation.ts
@@ -1,57 +1,70 @@
 import { isProductionEnvironment } from "@/utils/env.utils";
+import { z } from "zod";
 
-export const serverSettingsUpdateRules = {
-  registration: "boolean",
-  loginRequired: "boolean",
-  debugSettings: "object",
-  "debugSettings.debugSocketEvents": "boolean",
-  "debugSettings.debugSocketReconnect": "boolean",
-  experimentalMoonrakerSupport: "boolean",
-  experimentalThumbnailSupport: "boolean",
-};
+export const serverSettingsUpdateSchema = z.object({
+  registration: z.boolean().optional(),
+  loginRequired: z.boolean().optional(),
+  debugSettings: z
+    .object({
+      debugSocketEvents: z.boolean().optional(),
+      debugSocketReconnect: z.boolean().optional(),
+    })
+    .optional(),
+  experimentalMoonrakerSupport: z.boolean().optional(),
+  experimentalThumbnailSupport: z.boolean().optional(),
+});
 
-export const timeoutSettingsUpdateRules = {
-  apiTimeout: "integer|min:1000",
-};
+export const timeoutSettingsUpdateSchema = z.object({
+  apiTimeout: z.number().int().min(1000).optional(),
+});
 
-export const frontendSettingsUpdateRules = {
-  gridCols: "integer|min:1",
-  gridRows: "integer|min:1",
-  largeTiles: "boolean",
-  tilePreferCancelOverQuickStop: "boolean",
-};
+export const frontendSettingsUpdateSchema = z.object({
+  gridCols: z.number().int().min(1).optional(),
+  gridRows: z.number().int().min(1).optional(),
+  largeTiles: z.boolean().optional(),
+  tilePreferCancelOverQuickStop: z.boolean().optional(),
+});
 
-export const credentialSettingPatchRules = {
-  jwtSecret: "string",
-  jwtExpiresIn: isProductionEnvironment() ? "integer|min:120|max:7200" : "integer|min:0",
-  refreshTokenAttempts: "integer|min:-1",
-  refreshTokenExpiry: isProductionEnvironment() ? "integer|min:240" : "integer|min:0",
-};
+export const credentialSettingPatchSchema = z.object({
+  jwtSecret: z.string().optional(),
+  jwtExpiresIn: z
+    .number()
+    .int()
+    .min(isProductionEnvironment() ? 120 : 0)
+    .max(isProductionEnvironment() ? 7200 : Infinity)
+    .optional(),
+  refreshTokenAttempts: z.number().int().min(-1).optional(),
+  refreshTokenExpiry: z
+    .number()
+    .int()
+    .min(isProductionEnvironment() ? 240 : 0)
+    .optional(),
+});
 
-export const wizardUpdateRules = {
-  wizardCompleted: "required|boolean",
-  wizardCompletedAt: "required|date|nullable",
-  wizardVersion: "required|integer|min:0",
-};
+export const wizardUpdateSchema = z.object({
+  wizardCompleted: z.boolean(),
+  wizardCompletedAt: z.date().nullable(),
+  wizardVersion: z.number().int().min(0),
+});
 
-export const fileCleanSettingsUpdateRules = {
-  autoRemoveOldFilesBeforeUpload: "required|boolean",
-  autoRemoveOldFilesAtBoot: "required|boolean",
-  autoRemoveOldFilesCriteriumDays: "required|integer|min:0",
-};
+export const fileCleanSettingsUpdateSchema = z.object({
+  autoRemoveOldFilesBeforeUpload: z.boolean(),
+  autoRemoveOldFilesAtBoot: z.boolean(),
+  autoRemoveOldFilesCriteriumDays: z.number().int().min(0),
+});
 
-export const sentryDiagnosticsEnabledRules = {
-  enabled: "required|boolean",
-};
+export const sentryDiagnosticsEnabledSchema = z.object({
+  enabled: z.boolean(),
+});
 
-export const moonrakerSupportRules = {
-  enabled: "required|boolean",
-};
+export const moonrakerSupportSchema = z.object({
+  enabled: z.boolean(),
+});
 
-export const thumbnailSupportRules = {
-  enabled: "required|boolean",
-};
+export const thumbnailSupportSchema = z.object({
+  enabled: z.boolean(),
+});
 
-export const clientNextRules = {
-  enabled: "required|boolean",
-};
+export const clientNextSchema = z.object({
+  enabled: z.boolean(),
+});

--- a/src/services/validators/user-service.validation.ts
+++ b/src/services/validators/user-service.validation.ts
@@ -1,16 +1,18 @@
+import { z } from "zod";
 import { AppConstants } from "@/server.constants";
+import { idRuleV2 } from "@/controllers/validation/generic.validation";
 
-export const registerUserRules = (isSqlite: boolean) => ({
-  username: `required|string|minLength:${AppConstants.DEFAULT_USERNAME_MINLEN}`,
-  password: `required|string|minLength:${AppConstants.DEFAULT_PASSWORD_MINLEN}`,
-  needsPasswordChange: "boolean",
-  roles: "required|array",
-  isDemoUser: "boolean",
-  isRootUser: "boolean",
-  "roles.*": `required|${isSqlite ? "integer|min:1" : "mongoId"}`,
-  isVerified: "boolean",
+export const registerUserSchema = (isSqlite: boolean) =>
+  z.object({
+    username: z.string().min(AppConstants.DEFAULT_USERNAME_MINLEN), // Ensures username length
+    password: z.string().min(AppConstants.DEFAULT_PASSWORD_MINLEN), // Ensures password length
+    needsPasswordChange: z.boolean().optional(),
+    roles: z.array(idRuleV2(isSqlite)).min(1), // Ensure at least one role is provided
+    isDemoUser: z.boolean().optional(),
+    isRootUser: z.boolean().optional(),
+    isVerified: z.boolean().optional(),
+  });
+
+export const newPasswordSchema = z.object({
+  password: z.string().min(AppConstants.DEFAULT_PASSWORD_MINLEN),
 });
-
-export const newPasswordRules = {
-  password: `required|string|minLength:${AppConstants.DEFAULT_PASSWORD_MINLEN}`,
-};

--- a/src/services/validators/user-service.validation.ts
+++ b/src/services/validators/user-service.validation.ts
@@ -4,10 +4,10 @@ import { idRuleV2 } from "@/controllers/validation/generic.validation";
 
 export const registerUserSchema = (isSqlite: boolean) =>
   z.object({
-    username: z.string().min(AppConstants.DEFAULT_USERNAME_MINLEN), // Ensures username length
-    password: z.string().min(AppConstants.DEFAULT_PASSWORD_MINLEN), // Ensures password length
+    username: z.string().min(AppConstants.DEFAULT_USERNAME_MINLEN),
+    password: z.string().min(AppConstants.DEFAULT_PASSWORD_MINLEN),
     needsPasswordChange: z.boolean().optional(),
-    roles: z.array(idRuleV2(isSqlite)).min(1), // Ensure at least one role is provided
+    roles: z.array(idRuleV2(isSqlite)),
     isDemoUser: z.boolean().optional(),
     isRootUser: z.boolean().optional(),
     isVerified: z.boolean().optional(),

--- a/src/services/validators/yaml-service.validation.ts
+++ b/src/services/validators/yaml-service.validation.ts
@@ -1,64 +1,109 @@
 import { apiKeyLengthMaxDefault, apiKeyLengthMinDefault } from "@/constants/service.constants";
-import { OctoprintType, MoonrakerType } from "@/services/printer-api.interface";
+import { PrinterTypes } from "@/services/printer-api.interface";
+import { z } from "zod";
+import { numberEnum } from "@/handlers/validators";
+import { idRuleV2 } from "@/controllers/validation/generic.validation";
 
-export const exportPrintersFloorsYamlRules = {
-  // Used to export
-  exportPrinters: "required|boolean",
-  exportFloorGrid: "required|boolean",
-  exportFloors: "required|boolean",
-  // TODO in V2 this should be required
-  exportGroups: "boolean",
-  // Used to determine import strategy
-  printerComparisonStrategiesByPriority: "required|arrayUnique|minLength:1",
-  "printerComparisonStrategiesByPriority.*": "required|string|in:name,url,id",
-  floorComparisonStrategiesByPriority: "required|string|in:name,floor,id",
-  // Helpful reference
-  notes: "string",
-  // Future ideas
-  // dropPrinterIds: "required|boolean", // optional idea for future
-  // dropFloorIds: "required|boolean", // optional idea for future
-};
+export const exportPrintersFloorsYamlSchema = z.object({
+  exportPrinters: z.boolean(),
+  exportFloorGrid: z.boolean(),
+  exportFloors: z.boolean(),
+  exportGroups: z.boolean(),
+  printerComparisonStrategiesByPriority: z
+    .array(
+      z.string().refine((val) => ["name", "url", "id"].includes(val), {
+        message: "Must be one of: name, url, id",
+      })
+    )
+    .min(1),
+  floorComparisonStrategiesByPriority: z.string().refine((val) => ["name", "floor", "id"].includes(val), {
+    message: "Must be one of: name, floor, id",
+  }),
+  notes: z.string().optional(),
+});
 
-export const importPrintersFloorsYamlRules = (
+export const importPrintersFloorsYamlSchema = (
   importPrinters: boolean,
   importFloorGrid: boolean,
   importFloors: boolean,
   importGroups: boolean
-) => {
-  return {
-    version: "required|string",
-    config: "required|object",
-    "config.exportPrinters": "required|boolean",
-    "config.exportFloorGrid": "required|boolean",
-    "config.exportFloors": "required|boolean",
-    "config.exportGroups": "boolean",
-    "config.printerComparisonStrategiesByPriority": "required|arrayUnique|minLength:1",
-    "config.printerComparisonStrategiesByPriority.*": "required|string|in:name,url,id",
-    "config.floorComparisonStrategiesByPriority": "required|string|in:name,floor,id",
-    printers: `${!!importPrinters ? "array|minLength:0" : "not"}`,
-    "printers.*.id": "required",
-    "printers.*.apiKey": `requiredIf:printerType,${OctoprintType}|length:${apiKeyLengthMaxDefault},${apiKeyLengthMinDefault}|alphaDash`,
-    "printers.*.printerURL": "required|httpurl",
-    "printers.*.enabled": "boolean",
-    "printers.*.printerType": `integer|in:${OctoprintType},${MoonrakerType}`,
-    "printers.*.name": "required|string",
-    floors: `${!!importFloors ? "array|minLength:0" : "not"}`,
-    "floors.*.id": "required",
-    "floors.*.floor": "required|integer",
-    "floors.*.name": "required|string",
-    // TODO no grid check?
-    groups: `${!!importGroups ? "array|minLength:0" : "not"}`,
-    "groups.*.id": "required",
-    "groups.*.name": "required|string",
-    // "groups.*.printers": "required|array",
-    // "groups.*.printers.*.printerId": "required",
-  };
-};
+) =>
+  z.object({
+    version: z.string(),
+    config: z.object({
+      exportPrinters: z.boolean(),
+      exportFloorGrid: z.boolean(),
+      exportFloors: z.boolean(),
+      exportGroups: z.boolean().optional(),
+      printerComparisonStrategiesByPriority: z.array(z.string().refine((val) => ["name", "url", "id"].includes(val))).min(1),
+      floorComparisonStrategiesByPriority: z.string().refine((val) => ["name", "floor", "id"].includes(val)),
+    }),
+    printers: importPrinters
+      ? z
+          .array(
+            z.object({
+              id: z.union([z.number(), z.string()]),
+              apiKey: z
+                .string()
+                .min(apiKeyLengthMinDefault)
+                .max(apiKeyLengthMaxDefault)
+                .regex(/^[a-zA-Z0-9_-]+$/),
+              printerURL: z.string().url(),
+              enabled: z.boolean().optional(),
+              printerType: z.number().superRefine(numberEnum(PrinterTypes)),
+              name: z.string(),
+            })
+          )
+          .min(0)
+      : z.array(z.any()).optional(),
+    floors: importFloors
+      ? z
+          .array(
+            z.object({
+              id: z.union([z.number(), z.string()]),
+              floor: z.number().int(),
+              name: z.string(),
+              printers: z.array(
+                z.object({
+                  printerId: z.union([z.number(), z.string()]),
+                  // Added on multiple places
+                  floorId: z.union([z.number(), z.string()]).optional(),
+                  x: z.number().int().min(0).max(12),
+                  y: z.number().int().min(0).max(12),
+                })
+              ),
+            })
+          )
+          .min(0)
+      : z.array(z.any()).optional(),
+    groups: importGroups
+      ? z
+          .array(
+            z.object({
+              id: z.union([z.number(), z.string()]),
+              name: z.string(),
+              printers: z.array(
+                z.object({
+                  printerId: z.union([z.number(), z.string()]),
+                })
+              ),
+            })
+          )
+          .min(0)
+      : z.array(z.any()).optional(),
+  });
 
-export const importPrinterPositionsRules = (isTypeormMode: boolean) => ({
-  printers: "array|minLength:0",
-  "printers.*.printerId": "required",
-  // isTypeormMode ? "integer|min:1" : "mongoId",
-  "printers.*.x": "required|integer|min:0|max:12",
-  "printers.*.y": "required|integer|min:0|max:12",
-});
+export const importPrinterPositionsSchema = (isSqliteMode: boolean) =>
+  z.object({
+    printers: z
+      .array(
+        z.object({
+          printerId: z.union([z.number(), z.string()]),
+          floorId: z.union([z.number(), z.string()]).optional(),
+          x: z.number().int().min(0).max(12),
+          y: z.number().int().min(0).max(12),
+        })
+      )
+      .min(0)
+      .optional(),
+  });

--- a/src/services/validators/yaml-service.validation.ts
+++ b/src/services/validators/yaml-service.validation.ts
@@ -93,7 +93,7 @@ export const importPrinterPositionsSchema = (isSqliteMode: boolean) =>
       .array(
         z.object({
           printerId: numberOrStringIdValidator,
-          floorId: numberOrStringIdValidator,
+          floorId: numberOrStringIdValidator.optional(),
           x: xValidator,
           y: yValidator,
         })

--- a/src/services/validators/yaml-service.validation.ts
+++ b/src/services/validators/yaml-service.validation.ts
@@ -56,6 +56,13 @@ export const importPrintersFloorsYamlSchema = z.object({
         apiKey: printerApiKeyValidator,
         enabled: printerEnabledValidator,
         name: printerNameValidator,
+        // Legacy properties
+        printerName: z.string().optional(),
+        settingsAppearance: z
+          .object({
+            name: z.string().optional(),
+          })
+          .optional(),
       })
     )
     .min(0)

--- a/src/services/validators/yaml-service.validation.ts
+++ b/src/services/validators/yaml-service.validation.ts
@@ -1,26 +1,24 @@
-import { apiKeyLengthMaxDefault, apiKeyLengthMinDefault } from "@/constants/service.constants";
-import { PrinterTypes } from "@/services/printer-api.interface";
 import { z } from "zod";
-import { numberEnum } from "@/handlers/validators";
-import { idRuleV2 } from "@/controllers/validation/generic.validation";
+import {
+  printerApiKeyValidator,
+  printerEnabledValidator,
+  printerNameValidator,
+  printerTypeValidator,
+  printerUrlValidator,
+} from "@/services/validators/printer-service.validation";
+import { floorLevelValidator, floorNameValidator, xValidator, yValidator } from "@/services/validators/floor-service.validation";
 
 export const exportPrintersFloorsYamlSchema = z.object({
   exportPrinters: z.boolean(),
   exportFloorGrid: z.boolean(),
   exportFloors: z.boolean(),
   exportGroups: z.boolean(),
-  printerComparisonStrategiesByPriority: z
-    .array(
-      z.string().refine((val) => ["name", "url", "id"].includes(val), {
-        message: "Must be one of: name, url, id",
-      })
-    )
-    .min(1),
-  floorComparisonStrategiesByPriority: z.string().refine((val) => ["name", "floor", "id"].includes(val), {
-    message: "Must be one of: name, floor, id",
-  }),
+  printerComparisonStrategiesByPriority: z.array(z.string().refine((val) => ["name", "url", "id"].includes(val))).min(1),
+  floorComparisonStrategiesByPriority: z.string().refine((val) => ["name", "floor", "id"].includes(val)),
   notes: z.string().optional(),
 });
+
+export const numberOrStringIdValidator = z.union([z.number(), z.string()]);
 
 export const importPrintersFloorsYamlSchema = (
   importPrinters: boolean,
@@ -42,16 +40,12 @@ export const importPrintersFloorsYamlSchema = (
       ? z
           .array(
             z.object({
-              id: z.union([z.number(), z.string()]),
-              apiKey: z
-                .string()
-                .min(apiKeyLengthMinDefault)
-                .max(apiKeyLengthMaxDefault)
-                .regex(/^[a-zA-Z0-9_-]+$/),
-              printerURL: z.string().url(),
-              enabled: z.boolean().optional(),
-              printerType: z.number().superRefine(numberEnum(PrinterTypes)),
-              name: z.string(),
+              id: numberOrStringIdValidator,
+              printerURL: printerUrlValidator,
+              printerType: printerTypeValidator,
+              apiKey: printerApiKeyValidator,
+              enabled: printerEnabledValidator,
+              name: printerNameValidator,
             })
           )
           .min(0)
@@ -60,16 +54,16 @@ export const importPrintersFloorsYamlSchema = (
       ? z
           .array(
             z.object({
-              id: z.union([z.number(), z.string()]),
-              floor: z.number().int(),
-              name: z.string(),
+              id: numberOrStringIdValidator,
+              floor: floorLevelValidator,
+              name: floorNameValidator,
               printers: z.array(
                 z.object({
-                  printerId: z.union([z.number(), z.string()]),
+                  printerId: numberOrStringIdValidator,
                   // Added on multiple places
-                  floorId: z.union([z.number(), z.string()]).optional(),
-                  x: z.number().int().min(0).max(12),
-                  y: z.number().int().min(0).max(12),
+                  floorId: numberOrStringIdValidator.optional(),
+                  x: xValidator,
+                  y: yValidator,
                 })
               ),
             })
@@ -80,11 +74,11 @@ export const importPrintersFloorsYamlSchema = (
       ? z
           .array(
             z.object({
-              id: z.union([z.number(), z.string()]),
+              id: numberOrStringIdValidator,
               name: z.string(),
               printers: z.array(
                 z.object({
-                  printerId: z.union([z.number(), z.string()]),
+                  printerId: numberOrStringIdValidator,
                 })
               ),
             })
@@ -98,10 +92,10 @@ export const importPrinterPositionsSchema = (isSqliteMode: boolean) =>
     printers: z
       .array(
         z.object({
-          printerId: z.union([z.number(), z.string()]),
-          floorId: z.union([z.number(), z.string()]).optional(),
-          x: z.number().int().min(0).max(12),
-          y: z.number().int().min(0).max(12),
+          printerId: numberOrStringIdValidator,
+          floorId: numberOrStringIdValidator,
+          x: xValidator,
+          y: yValidator,
         })
       )
       .min(0)

--- a/src/state/test-printer-socket.store.ts
+++ b/src/state/test-printer-socket.store.ts
@@ -1,6 +1,6 @@
 import { setInterval, setTimeout } from "timers/promises";
 import { validateInput } from "@/handlers/validators";
-import { createPrinterSchema } from "./validation/create-test-printer.validation";
+import { createTestPrinterSchema } from "./validation/create-test-printer.validation";
 import { octoPrintEvent, WsMessage } from "@/services/octoprint/octoprint-websocket.adapter";
 import { AppConstants } from "@/server.constants";
 import { SocketIoGateway } from "@/state/socket-io.gateway";
@@ -37,7 +37,7 @@ export class TestPrinterSocketStore {
       this.testSocket = null;
     }
 
-    const validatedData = await validateInput(printer, createPrinterSchema);
+    const validatedData = await validateInput(printer, createTestPrinterSchema);
     validatedData.enabled = true;
 
     // Create a new socket if it doesn't exist

--- a/src/state/test-printer-socket.store.ts
+++ b/src/state/test-printer-socket.store.ts
@@ -1,6 +1,6 @@
 import { setInterval, setTimeout } from "timers/promises";
 import { validateInput } from "@/handlers/validators";
-import { createTestPrinterRules } from "./validation/create-test-printer.validation";
+import { createPrinterSchema } from "./validation/create-test-printer.validation";
 import { octoPrintEvent, WsMessage } from "@/services/octoprint/octoprint-websocket.adapter";
 import { AppConstants } from "@/server.constants";
 import { SocketIoGateway } from "@/state/socket-io.gateway";
@@ -37,7 +37,7 @@ export class TestPrinterSocketStore {
       this.testSocket = null;
     }
 
-    const validatedData = await validateInput(printer, createTestPrinterRules);
+    const validatedData = await validateInput(printer, createPrinterSchema);
     validatedData.enabled = true;
 
     // Create a new socket if it doesn't exist

--- a/src/state/validation/create-test-printer.validation.ts
+++ b/src/state/validation/create-test-printer.validation.ts
@@ -1,34 +1,21 @@
-import { OctoprintType, PrinterTypes } from "@/services/printer-api.interface";
 import { z } from "zod";
-import { numberEnum } from "@/handlers/validators";
-import { validateApiKey } from "@/services/validators/printer-service.validation";
+import {
+  printerApiKeyValidator,
+  printerEnabledValidator,
+  printerNameValidator,
+  printerTypeValidator,
+  printerUrlValidator,
+  refineApiKeyValidator,
+} from "@/services/validators/printer-service.validation";
 
-export const createPrinterSchema = z
+export const createTestPrinterSchema = z
   .object({
-    printerURL: z.string().url(),
+    printerURL: printerUrlValidator,
+    printerType: printerTypeValidator,
+    apiKey: printerApiKeyValidator,
+    enabled: printerEnabledValidator.optional(),
+    name: printerNameValidator,
     correlationToken: z.string(),
-    printerType: z.number().superRefine(numberEnum(PrinterTypes)),
-    apiKey: validateApiKey,
-    enabled: z.boolean().optional(), // Optional, adjust as needed
-    name: z.string(), // Name is required
   })
   .strict()
-  .superRefine((data, ctx) => {
-    if (data.printerType === OctoprintType && !data.apiKey?.length) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "apiKey is required when printerType is OctoprintType",
-        path: ["apiKey"],
-      });
-      return ctx;
-    }
-
-    // Validate that apiKey length is either 32 or 43 characters if it exists
-    if (data.apiKey && data.apiKey.length !== 32 && data.apiKey.length !== 43) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "apiKey must be either 32 or 43 characters long",
-        path: ["apiKey"],
-      });
-    }
-  });
+  .superRefine(refineApiKeyValidator);

--- a/src/state/validation/create-test-printer.validation.ts
+++ b/src/state/validation/create-test-printer.validation.ts
@@ -1,10 +1,34 @@
-import { apiKeyLengthMaxDefault, apiKeyLengthMinDefault } from "@/constants/service.constants";
-import { MoonrakerType, OctoprintType } from "@/services/printer-api.interface";
+import { OctoprintType, PrinterTypes } from "@/services/printer-api.interface";
+import { z } from "zod";
+import { numberEnum } from "@/handlers/validators";
+import { validateApiKey } from "@/services/validators/printer-service.validation";
 
-export const createTestPrinterRules = {
-  enabled: "boolean",
-  printerType: `required|integer|in:${OctoprintType},${MoonrakerType}`,
-  correlationToken: "required|string",
-  apiKey: `requiredIf:printerType,${OctoprintType}|length:${apiKeyLengthMaxDefault},${apiKeyLengthMinDefault}|alphaDash`,
-  printerURL: "required|httpurl",
-};
+export const createPrinterSchema = z
+  .object({
+    printerURL: z.string().url(),
+    correlationToken: z.string(),
+    printerType: z.number().superRefine(numberEnum(PrinterTypes)),
+    apiKey: validateApiKey,
+    enabled: z.boolean().optional(), // Optional, adjust as needed
+    name: z.string(), // Name is required
+  })
+  .strict()
+  .superRefine((data, ctx) => {
+    if (data.printerType === OctoprintType && !data.apiKey?.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "apiKey is required when printerType is OctoprintType",
+        path: ["apiKey"],
+      });
+      return ctx;
+    }
+
+    // Validate that apiKey length is either 32 or 43 characters if it exists
+    if (data.apiKey && data.apiKey.length !== 32 && data.apiKey.length !== 43) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "apiKey must be either 32 or 43 characters long",
+        path: ["apiKey"],
+      });
+    }
+  });

--- a/test/api/printer-controller.test.ts
+++ b/test/api/printer-controller.test.ts
@@ -210,24 +210,6 @@ describe(PrinterController.name, () => {
     });
   });
 
-  it("should update printer connection settings correctly", async () => {
-    const printer = await createTestPrinter(request);
-
-    nock(printer.printerURL).get(`/api/version`).reply(200, { server: "1.2.3" });
-
-    const updatePatch = await request.patch(connectionRoute(printer.id)).send({
-      printerURL: "https://test.com/",
-      apiKey,
-      name,
-      printerType: MoonrakerType,
-    });
-    expectOkResponse(updatePatch, {
-      printerURL: "https://test.com",
-      apiKey,
-      printerType: MoonrakerType,
-    });
-  });
-
   it("should invalidate empty test printer connection", async () => {
     const res = await request.post(testPrinterRoute).send();
     expectInvalidResponse(res, [

--- a/test/api/printer-controller.test.ts
+++ b/test/api/printer-controller.test.ts
@@ -44,7 +44,20 @@ describe(PrinterController.name, () => {
       apiKey: "notcorrect",
       tempTriggers: { heatingVariation: null },
     });
-    expectInvalidResponse(response, ["apiKey"]);
+    expectInvalidResponse(
+      response,
+      [
+        {
+          code: "invalid_type",
+          path: "printerType",
+        },
+        {
+          code: "too_small",
+          path: "apiKey",
+        },
+      ],
+      true
+    );
   });
 
   it(`should be able to POST ${createRoute} moonraker without api key`, async () => {
@@ -132,7 +145,12 @@ describe(PrinterController.name, () => {
 
   it("should invalidate to malformed singular printer json array", async () => {
     const response = await request.post(batchRoute).send([{}]);
-    expectInvalidResponse(response, ["printerURL"]);
+    expectInvalidResponse(response, [
+      {
+        code: "invalid_type",
+        path: "printerURL",
+      },
+    ]);
   });
 
   it("should import to singular printer json array", async () => {
@@ -212,7 +230,13 @@ describe(PrinterController.name, () => {
 
   it("should invalidate empty test printer connection", async () => {
     const res = await request.post(testPrinterRoute).send();
-    expectInvalidResponse(res, ["printerType", "printerURL"]);
+    expectInvalidResponse(res, [
+      {
+        path: "printerType",
+        code: "invalid_type",
+      },
+      { path: "printerURL", code: "invalid_type" },
+    ]);
   });
 
   it("should test printer connection", async () => {

--- a/test/api/server-private-controller.test.ts
+++ b/test/api/server-private-controller.test.ts
@@ -4,11 +4,11 @@ import { load } from "js-yaml";
 import { exportYamlBuffer1_3_1 } from "../application/test-data/yaml-import";
 import { AppConstants } from "@/server.constants";
 import { validateInput } from "@/handlers/validators";
-import { importPrintersFloorsYamlRules } from "@/services/validators/yaml-service.validation";
 import { Test } from "supertest";
 import { ServerPrivateController } from "@/controllers/server-private.controller";
 import TestAgent from "supertest/lib/agent";
 import nock from "nock";
+import { importPrintersFloorsYamlSchema } from "@/services/validators/yaml-service.validation";
 
 let request: TestAgent<Test>;
 
@@ -68,7 +68,7 @@ describe(ServerPrivateController.name, () => {
     expectOkResponse(response);
 
     const yamlObject = load(response.text);
-    await validateInput(yamlObject, importPrintersFloorsYamlRules(true, true, true, true));
+    await validateInput(yamlObject, importPrintersFloorsYamlSchema(true, true, true, true));
   });
 
   test.skip("should import YAML and have data loaded", async () => {

--- a/test/api/server-private-controller.test.ts
+++ b/test/api/server-private-controller.test.ts
@@ -68,7 +68,7 @@ describe(ServerPrivateController.name, () => {
     expectOkResponse(response);
 
     const yamlObject = load(response.text) as YamlExportSchema;
-    expect(yamlObject!).toBeDefined();
+    expect(yamlObject).toBeDefined();
     await validateInput(yamlObject, importPrintersFloorsYamlSchema);
   });
 

--- a/test/api/server-private-controller.test.ts
+++ b/test/api/server-private-controller.test.ts
@@ -8,7 +8,7 @@ import { Test } from "supertest";
 import { ServerPrivateController } from "@/controllers/server-private.controller";
 import TestAgent from "supertest/lib/agent";
 import nock from "nock";
-import { importPrintersFloorsYamlSchema } from "@/services/validators/yaml-service.validation";
+import { importPrintersFloorsYamlSchema, YamlExportSchema } from "@/services/validators/yaml-service.validation";
 
 let request: TestAgent<Test>;
 
@@ -67,8 +67,9 @@ describe(ServerPrivateController.name, () => {
     });
     expectOkResponse(response);
 
-    const yamlObject = load(response.text);
-    await validateInput(yamlObject, importPrintersFloorsYamlSchema(true, true, true, true));
+    const yamlObject = load(response.text) as YamlExportSchema;
+    expect(yamlObject!).toBeDefined();
+    await validateInput(yamlObject, importPrintersFloorsYamlSchema);
   });
 
   test.skip("should import YAML and have data loaded", async () => {

--- a/test/application/yaml-service.test.ts
+++ b/test/application/yaml-service.test.ts
@@ -89,10 +89,11 @@ describe(YamlService.name, () => {
     await yamlService.importPrintersAndFloors(buffer.toString());
 
     const printers = await printerService.list();
-    const printer = printers.find((p) => p.name === "Dragon Eggggg");
+    const printer = printers.find((p) => p.name === "Dragon Eggggg")!;
+    expect(printer).toBeDefined();
 
     const floors = await floorService.list();
-    const floor = floors.find((f) => f.name === "Default Floor1_5_2");
+    const floor = floors.find((f) => f.name === "Default Floor1_5_2")!;
     expect(floor).toBeDefined();
     expect(floor.printers).toHaveLength(2);
     if (isTypeormMode) {
@@ -108,7 +109,7 @@ describe(YamlService.name, () => {
     await yamlService.importPrintersAndFloors(exportYamlBuffer1_6_0(true));
 
     const floors = await floorService.list();
-    const floor = floors.find((f) => f.name === "Default Floor1_6_0");
+    const floor = floors.find((f) => f.name === "Default Floor1_6_0")!;
     expect(floor).toBeDefined();
     expect(floor.printers).toHaveLength(2);
   });
@@ -119,10 +120,11 @@ describe(YamlService.name, () => {
     await yamlService.importPrintersAndFloors(buffer.toString());
 
     const printers = await printerService.list();
-    const printer = printers.find((p) => p.name === "Minipi Local");
+    const printer = printers.find((p) => p.name === "Minipi Local")!;
+    expect(printer).toBeDefined();
 
     const floors = await floorService.list();
-    const floor = floors.find((f) => f.name === "Default Floor1_6_0");
+    const floor = floors.find((f) => f.name === "Default Floor1_6_0")!;
     expect(floor).toBeDefined();
     expect(floor.printers).toHaveLength(3);
     expect(floor.printers.find((p) => p.printerId.toString() === printer.id.toString())).toBeDefined();
@@ -139,21 +141,23 @@ describe(YamlService.name, () => {
     await yamlService.importPrintersAndFloors(buffer.toString());
 
     const printers = await printerService.list();
-    const printer = printers.find((p) => p.name === "Minipi Local1_6_1");
+    const printer = printers.find((p) => p.name === "Minipi Local1_6_1")!;
+    expect(printer).toBeDefined();
 
     const floors = await floorService.list();
     expect(floors).toHaveLength(1);
-    const floor = floors.find((f) => f.name === "Default Floor1_6_1");
+    const floor = floors.find((f) => f.name === "Default Floor1_6_1")!;
     expect(floor).toBeDefined();
     expect(floor.printers).toHaveLength(4);
     expect(floor.printers.find((p) => p.printerId.toString() === printer.id.toString())).toBeDefined();
 
     if (isTypeormMode) {
-      const groups = await printerGroupService.listGroups();
-      const group = groups.find((g) => g.name === "Group A123_1.6.1");
+      const groups = (await printerGroupService.listGroups())!;
+      expect(groups).toBeDefined();
+      const group = groups.find((g) => g.name === "Group A123_1.6.1")!;
       expect(group).toBeDefined();
       expect(group.printers).toHaveLength(2);
-      expect(groups.find((g) => g.name === "Group test_1.6.1").printers).toHaveLength(0);
+      expect(groups.find((g) => g.name === "Group test_1.6.1")!.printers).toHaveLength(0);
     } else {
       expect(printerGroupService).toBeNull();
     }
@@ -182,7 +186,9 @@ describe(YamlService.name, () => {
     // Probe the new floor and assert a position on it is taken
     const floors = await floorService.list();
     expect(floors).toHaveLength(2);
-    const newFloor2 = floors.find((f) => f.name === "Floor2");
+    const newFloor2 = floors.find((f) => f.name === "Floor2")!;
+    expect(newFloor2).toBeDefined();
+
     if (isTypeormMode) {
       expect(typeof newFloor2.id).toBe("number");
     } else {
@@ -198,7 +204,9 @@ describe(YamlService.name, () => {
 
     // The original floor's name is now gone, and the original printer has not been removed from it (overwrite action)
     expect(floors.find((f) => f.name === "Floor1_DifferentName")).toBeUndefined();
-    const mutatedFloor1 = floors.find((f) => f.name === "Floor1" && f.floor === 15);
+    const mutatedFloor1 = floors.find((f) => f.name === "Floor1" && f.floor === 15)!;
+    expect(mutatedFloor1).toBeDefined();
+
     expect(mutatedFloor1.printers).toHaveLength(1);
     expect(mutatedFloor1).toBeDefined();
     const originalPrinterPos = mutatedFloor1.printers.find((p) => p.printerId === printer.id);
@@ -208,6 +216,8 @@ describe(YamlService.name, () => {
 
     // Test that caching is not the cause
     const cache = await floorStore.listCache();
-    expect(cache.find((f) => f.name === "Floor2").printers).toHaveLength(1);
+    const foundPrinters = cache.find((f) => f.name === "Floor2")!;
+    expect(foundPrinters).toBeDefined();
+    expect(foundPrinters.printers).toHaveLength(1);
   });
 });

--- a/test/application/yaml-service.test.ts
+++ b/test/application/yaml-service.test.ts
@@ -14,7 +14,6 @@ import { FloorStore } from "@/state/floor.store";
 import { FloorPositionService } from "@/services/orm/floor-position.service";
 import { OctoprintType } from "@/services/printer-api.interface";
 
-let container: AwilixContainer;
 let yamlService: YamlService;
 let printerCache: PrinterCache;
 let printerService: IPrinterService;
@@ -152,7 +151,7 @@ describe(YamlService.name, () => {
     expect(floor.printers.find((p) => p.printerId.toString() === printer.id.toString())).toBeDefined();
 
     if (isTypeormMode) {
-      const groups = (await printerGroupService.listGroups())!;
+      const groups = await printerGroupService.listGroups();
       expect(groups).toBeDefined();
       const group = groups.find((g) => g.name === "Group A123_1.6.1")!;
       expect(group).toBeDefined();

--- a/test/application/yaml-service.test.ts
+++ b/test/application/yaml-service.test.ts
@@ -1,6 +1,5 @@
 import { YamlService } from "@/services/core/yaml.service";
 import { PrinterCache } from "@/state/printer.cache";
-import { AwilixContainer } from "awilix";
 import { DITokens } from "@/container.tokens";
 import { exportYamlBuffer1_3_1, exportYamlBuffer1_5_0, exportYamlBuffer1_6_0 } from "./test-data/yaml-import";
 import { setupTestApp } from "../test-server";

--- a/test/extensions.ts
+++ b/test/extensions.ts
@@ -1,5 +1,6 @@
 import { Response } from "supertest";
 import CustomMatcherResult = jest.CustomMatcherResult;
+import { ZodIssue } from "zod";
 
 export function getExpectExtensions() {
   return {
@@ -31,12 +32,25 @@ export function expectOkResponse(response: Response, matchedBody?: any) {
   return response.body;
 }
 
-export function expectValidationError(object: any, keys: string[], exact = false) {
-  const objectErrors = Object.keys(object.errors);
+export function expectValidationError(response: any, expectedErrors: Array<{ code: string; path: string }>, exact = false) {
+  // Extract the issues array from the ZodError
+  const issues: ZodIssue[] = response.errors?.issues || [];
+
+  // Convert each issue's path array to a dot-notation string
+  const responseErrors = issues.map((issue) => ({
+    code: issue.code,
+    path: issue.path.join("."),
+  }));
+
   if (!exact) {
-    keys.forEach((key) => expect(objectErrors).toContain(key));
+    const missingErrors = expectedErrors.filter(
+      (expected) => !responseErrors.some((actual) => actual.code === expected.code && actual.path === expected.path)
+    );
+    expect(missingErrors).toEqual([]);
   } else {
-    expect(keys).toMatchObject(objectErrors);
+    // For exact matching, both arrays should have the same errors
+    expect(responseErrors).toEqual(expect.arrayContaining(expectedErrors));
+    expect(expectedErrors).toEqual(expect.arrayContaining(responseErrors));
   }
 }
 
@@ -65,12 +79,12 @@ export function expectForbiddenResponse(response: Response) {
   expect(response.statusCode).toEqual(403);
 }
 
-export function expectInvalidResponse(response: Response, keys?: string[], exact = false) {
+export function expectInvalidResponse(response: Response, expectedErrors: Array<{ code: string; path: string }>, exact = false) {
   expect(response.statusCode).toEqual(400);
 
-  if (!keys) return;
+  if (!expectedErrors?.length) return;
 
-  expectValidationError(response.body, keys, exact);
+  expectValidationError(response.body, expectedErrors, exact);
 }
 
 export function expectNotFoundResponse(response: Response) {

--- a/test/setup-global.ts
+++ b/test/setup-global.ts
@@ -17,6 +17,6 @@ module.exports = async () => {
   process.env[AppConstants.VERSION_KEY] = "1.0.0";
   process.env[AppConstants.OVERRIDE_IS_DEMO_MODE] = "false";
   process.env[AppConstants.DATABASE_FILE] = ":memory:";
-  process.env[AppConstants.ENABLE_EXPERIMENTAL_TYPEORM] = false; // (process.env["MONGODB_MODE"] !== "true").toString();
+  process.env[AppConstants.ENABLE_EXPERIMENTAL_TYPEORM] = (process.env["MONGODB_MODE"] !== "true").toString();
   process.env["NODE_NO_WARNINGS"] = "1";
 };

--- a/test/setup-global.ts
+++ b/test/setup-global.ts
@@ -17,6 +17,6 @@ module.exports = async () => {
   process.env[AppConstants.VERSION_KEY] = "1.0.0";
   process.env[AppConstants.OVERRIDE_IS_DEMO_MODE] = "false";
   process.env[AppConstants.DATABASE_FILE] = ":memory:";
-  process.env[AppConstants.ENABLE_EXPERIMENTAL_TYPEORM] = (process.env["MONGODB_MODE"] !== "true").toString();
+  process.env[AppConstants.ENABLE_EXPERIMENTAL_TYPEORM] = false; // (process.env["MONGODB_MODE"] !== "true").toString();
   process.env["NODE_NO_WARNINGS"] = "1";
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1094,7 +1094,6 @@ __metadata:
     mongoose: "npm:6.13.8"
     multer: "npm:1.4.5-lts.2"
     nock: "npm:13.5.6"
-    node-input-validator: "npm:4.5.1"
     octokit: "npm:3.2.1"
     passport: "npm:0.7.0"
     passport-anonymous: "npm:1.0.1"
@@ -1111,6 +1110,7 @@ __metadata:
     uuid: "npm:11.1.0"
     winston: "npm:3.17.0"
     ws: "npm:8.18.1"
+    zod: "npm:3.24.2"
   bin:
     fdm-monster: dist/index.js
     fdmm: dist/index.js
@@ -3954,15 +3954,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abort-controller@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "abort-controller@npm:3.0.0"
-  dependencies:
-    event-target-shim: "npm:^5.0.0"
-  checksum: 10c0/90ccc50f010250152509a344eb2e71977fbf8db0ab8f1061197e3275ddf6c61a41a6edfd7b9409c664513131dd96e962065415325ef23efa5db931b382d24ca5
-  languageName: node
-  linkType: hard
-
 "accepts@npm:~1.3.4, accepts@npm:~1.3.8":
   version: 1.3.8
   resolution: "accepts@npm:1.3.8"
@@ -6006,24 +5997,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"event-target-shim@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "event-target-shim@npm:5.0.1"
-  checksum: 10c0/0255d9f936215fd206156fd4caa9e8d35e62075d720dc7d847e89b417e5e62cf1ce6c9b4e0a1633a9256de0efefaf9f8d26924b1f3c8620cffb9db78e7d3076b
-  languageName: node
-  linkType: hard
-
 "eventemitter2@npm:6.4.9":
   version: 6.4.9
   resolution: "eventemitter2@npm:6.4.9"
   checksum: 10c0/b2adf7d9f1544aa2d95ee271b0621acaf1e309d85ebcef1244fb0ebc7ab0afa6ffd5e371535d0981bc46195ad67fd6ff57a8d1db030584dee69aa5e371a27ea7
-  languageName: node
-  linkType: hard
-
-"events@npm:^3.3.0":
-  version: 3.3.0
-  resolution: "events@npm:3.3.0"
-  checksum: 10c0/d6b6f2adbccbcda74ddbab52ed07db727ef52e31a61ed26db9feb7dc62af7fc8e060defa65e5f8af9449b86b52cc1a1f6a79f2eafcf4e62add2b7a1fa4a432f6
   languageName: node
   linkType: hard
 
@@ -6240,17 +6217,6 @@ __metadata:
   dependencies:
     flat-cache: "npm:^4.0.0"
   checksum: 10c0/9e2b5938b1cd9b6d7e3612bdc533afd4ac17b2fc646569e9a8abbf2eb48e5eb8e316bc38815a3ef6a1b456f4107f0d0f055a614ca613e75db6bf9ff4d72c1638
-  languageName: node
-  linkType: hard
-
-"file-type@npm:^16.5.4":
-  version: 16.5.4
-  resolution: "file-type@npm:16.5.4"
-  dependencies:
-    readable-web-to-node-stream: "npm:^3.0.0"
-    strtok3: "npm:^6.2.4"
-    token-types: "npm:^4.1.1"
-  checksum: 10c0/a6c9ab8bc05bc9c212bec239fb0d5bf59ddc9b3912f00c4ef44622e67ae4e553a1cc8372e9e595e14859035188eb305d05d488fa3c5c2a2ad90bb7745b3004ef
   languageName: node
   linkType: hard
 
@@ -6914,17 +6880,6 @@ __metadata:
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
   checksum: 10c0/f9f652c957983634ded1e7f02da3b559a0d4cc210fca3792cb67f1b153623c9c42efdc1c4121af171e295444459fc4a9201101fb041b1104a3c000bccb188337
-  languageName: node
-  linkType: hard
-
-"image-size@npm:^0.8.3":
-  version: 0.8.3
-  resolution: "image-size@npm:0.8.3"
-  dependencies:
-    queue: "npm:6.0.1"
-  bin:
-    image-size: bin/image-size.js
-  checksum: 10c0/c2764db09d08916269bf34dcff5945a2ffeec8f4a4a69a1794dd4c86af37de28e3ebdade7975eb95d58381f518be4db9478bec8e7cbc8c35e0036c4b2e956991
   languageName: node
   linkType: hard
 
@@ -8109,13 +8064,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.has@npm:^4.5.2":
-  version: 4.5.2
-  resolution: "lodash.has@npm:4.5.2"
-  checksum: 10c0/3ffa9e549f321996a5fdf6204494c035ff550b2df703f936a448c553131bbb55492b4e7995bb13500648b50b268ed8afc974a7a0c0a43744d28d61cc95cb1ffe
-  languageName: node
-  linkType: hard
-
 "lodash.includes@npm:^4.3.0":
   version: 4.3.0
   resolution: "lodash.includes@npm:4.3.0"
@@ -8384,7 +8332,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12, mime-types@npm:^2.1.28, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
+"mime-types@npm:^2.1.12, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
@@ -8565,13 +8513,6 @@ __metadata:
   version: 1.0.3
   resolution: "module-details-from-path@npm:1.0.3"
   checksum: 10c0/3d881f3410c142e4c2b1307835a2862ba04e5b3ec6e90655614a0ee2c4b299b4c1d117fb525d2435bf436990026f18d338a197b54ad6bd36252f465c336ff423
-  languageName: node
-  linkType: hard
-
-"moment@npm:^2.29.1":
-  version: 2.30.1
-  resolution: "moment@npm:2.30.1"
-  checksum: 10c0/865e4279418c6de666fca7786607705fd0189d8a7b7624e2e56be99290ac846f90878a6f602e34b4e0455c549b85385b1baf9966845962b313699e7cb847543a
   languageName: node
   linkType: hard
 
@@ -8824,21 +8765,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-input-validator@npm:4.5.1":
-  version: 4.5.1
-  resolution: "node-input-validator@npm:4.5.1"
-  dependencies:
-    file-type: "npm:^16.5.4"
-    image-size: "npm:^0.8.3"
-    lodash.has: "npm:^4.5.2"
-    mime-types: "npm:^2.1.28"
-    moment: "npm:^2.29.1"
-    read-chunk: "npm:^3.2.0"
-    validator: "npm:^13.5.2"
-  checksum: 10c0/fee6976c235b15f39eede05661874e12d5b87b6b29a3305d46cb7e1751e74930d5ed563875ca794ffe7226d803137ba69bdd61c3cefb03c15287b64a692ad756
-  languageName: node
-  linkType: hard
-
 "node-int64@npm:^0.4.0":
   version: 0.4.0
   resolution: "node-int64@npm:0.4.0"
@@ -9069,13 +8995,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-finally@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "p-finally@npm:1.0.0"
-  checksum: 10c0/6b8552339a71fe7bd424d01d8451eea92d379a711fc62f6b2fe64cad8a472c7259a236c9a22b4733abca0b5666ad503cb497792a0478c5af31ded793d00937e7
-  languageName: node
-  linkType: hard
-
 "p-limit@npm:^2.2.0":
   version: 2.3.0
   resolution: "p-limit@npm:2.3.0"
@@ -9119,7 +9038,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-try@npm:^2.0.0, p-try@npm:^2.1.0":
+"p-try@npm:^2.0.0":
   version: 2.2.0
   resolution: "p-try@npm:2.2.0"
   checksum: 10c0/c36c19907734c904b16994e6535b02c36c2224d433e01a2f1ab777237f4d86e6289fd5fd464850491e940379d4606ed850c03e0f9ab600b0ebddb511312e177f
@@ -9260,13 +9179,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"peek-readable@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "peek-readable@npm:4.1.0"
-  checksum: 10c0/f9b81ce3eed185cc9ebbf7dff0b6e130dd6da7b05f1802bbf726a78e4d84990b0a65f8e701959c50eb1124cc2ad352205147954bf39793faba29bb00ce742a44
-  languageName: node
-  linkType: hard
-
 "peek-readable@npm:^5.3.1":
   version: 5.4.2
   resolution: "peek-readable@npm:5.4.2"
@@ -9341,13 +9253,6 @@ __metadata:
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 10c0/26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be
-  languageName: node
-  linkType: hard
-
-"pify@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "pify@npm:4.0.1"
-  checksum: 10c0/6f9d404b0d47a965437403c9b90eca8bb2536407f03de165940e62e72c8c8b75adda5516c6b9b23675a5877cc0bcac6bdfb0ef0e39414cd2476d5495da40e7cf
   languageName: node
   linkType: hard
 
@@ -9525,13 +9430,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"process@npm:^0.11.10":
-  version: 0.11.10
-  resolution: "process@npm:0.11.10"
-  checksum: 10c0/40c3ce4b7e6d4b8c3355479df77aeed46f81b279818ccdc500124e6a5ab882c0cc81ff7ea16384873a95a74c4570b01b120f287abbdd4c877931460eca6084b3
-  languageName: node
-  linkType: hard
-
 "promise-retry@npm:^2.0.1":
   version: 2.0.1
   resolution: "promise-retry@npm:2.0.1"
@@ -9625,15 +9523,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"queue@npm:6.0.1":
-  version: 6.0.1
-  resolution: "queue@npm:6.0.1"
-  dependencies:
-    inherits: "npm:~2.0.3"
-  checksum: 10c0/5a123fedfd61f00faa75ea365cc105cf95f5a871a35265d2c4169668496f87605964554c1ed01066c21e63f715a84a2f9c556c19cee19a61bf4c0698c9133083
-  languageName: node
-  linkType: hard
-
 "quick-lru@npm:^5.1.1":
   version: 5.1.1
   resolution: "quick-lru@npm:5.1.1"
@@ -9681,16 +9570,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"read-chunk@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "read-chunk@npm:3.2.0"
-  dependencies:
-    pify: "npm:^4.0.1"
-    with-open-file: "npm:^0.1.6"
-  checksum: 10c0/cf62522dc85a96d54f1e0886cadcdfdd491bdcd250408695c8d63cea2eae5b1a31da8317c9a58a095ee9b15c67e84e0bed1a917c820bcccf1c74749a9fcad797
-  languageName: node
-  linkType: hard
-
 "readable-stream@npm:^2.2.2":
   version: 2.3.8
   resolution: "readable-stream@npm:2.3.8"
@@ -9714,28 +9593,6 @@ __metadata:
     string_decoder: "npm:^1.1.1"
     util-deprecate: "npm:^1.0.1"
   checksum: 10c0/e37be5c79c376fdd088a45fa31ea2e423e5d48854be7a22a58869b4e84d25047b193f6acb54f1012331e1bcd667ffb569c01b99d36b0bd59658fb33f513511b7
-  languageName: node
-  linkType: hard
-
-"readable-stream@npm:^4.7.0":
-  version: 4.7.0
-  resolution: "readable-stream@npm:4.7.0"
-  dependencies:
-    abort-controller: "npm:^3.0.0"
-    buffer: "npm:^6.0.3"
-    events: "npm:^3.3.0"
-    process: "npm:^0.11.10"
-    string_decoder: "npm:^1.3.0"
-  checksum: 10c0/fd86d068da21cfdb10f7a4479f2e47d9c0a9b0c862fc0c840a7e5360201580a55ac399c764b12a4f6fa291f8cee74d9c4b7562e0d53b3c4b2769f2c98155d957
-  languageName: node
-  linkType: hard
-
-"readable-web-to-node-stream@npm:^3.0.0":
-  version: 3.0.4
-  resolution: "readable-web-to-node-stream@npm:3.0.4"
-  dependencies:
-    readable-stream: "npm:^4.7.0"
-  checksum: 10c0/2dc417d5d0b0c0191fcf57f87df3b2853db21d1da5554ec32b1e1c5a515e5a1243fc077a23f74046d711c2d736628f64b31054a8379b95bb016212430b5110c5
   languageName: node
   linkType: hard
 
@@ -10509,7 +10366,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string_decoder@npm:^1.1.1, string_decoder@npm:^1.3.0":
+"string_decoder@npm:^1.1.1":
   version: 1.3.0
   resolution: "string_decoder@npm:1.3.0"
   dependencies:
@@ -10594,16 +10451,6 @@ __metadata:
   version: 1.1.2
   resolution: "strnum@npm:1.1.2"
   checksum: 10c0/a0fce2498fa3c64ce64a40dada41beb91cabe3caefa910e467dc0518ef2ebd7e4d10f8c2202a6104f1410254cae245066c0e94e2521fb4061a5cb41831952392
-  languageName: node
-  linkType: hard
-
-"strtok3@npm:^6.2.4":
-  version: 6.3.0
-  resolution: "strtok3@npm:6.3.0"
-  dependencies:
-    "@tokenizer/token": "npm:^0.3.0"
-    peek-readable: "npm:^4.1.0"
-  checksum: 10c0/8f1483a2a6758404502f2fc431586fcf37d747b10b125596ab5ec92319c247dd1195f82ba0bc2eaa582db3d807b5cca4b67ff61411756fec6622d051f8e255c2
   languageName: node
   linkType: hard
 
@@ -10789,16 +10636,6 @@ __metadata:
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
   checksum: 10c0/93937279934bd66cc3270016dd8d0afec14fb7c94a05c72dc57321f8bd1fa97e5bea6d1f7c89e728d077ca31ea125b78320a616a6c6cd0e6b9cb94cb864381c1
-  languageName: node
-  linkType: hard
-
-"token-types@npm:^4.1.1":
-  version: 4.2.1
-  resolution: "token-types@npm:4.2.1"
-  dependencies:
-    "@tokenizer/token": "npm:^0.3.0"
-    ieee754: "npm:^1.2.1"
-  checksum: 10c0/e9a4a139deba9515770cd7ac36a8f53f953b9d035d309e88a66d706760dba0df420753f2b8bdee6b9f3cbff8d66b24e69571e8dea27baa7b378229ab1bcca399
   languageName: node
   linkType: hard
 
@@ -11244,7 +11081,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"validator@npm:^13.5.2, validator@npm:^13.9.0":
+"validator@npm:^13.9.0":
   version: 13.15.0
   resolution: "validator@npm:13.15.0"
   checksum: 10c0/0f13fd7031ac575e8d7828431da8ef5859bac6a38ee65e1d7fdd367dbf1c3d94d95182aecc3183f7fa7a30ff4474bf864d1aff54707620227a2cdbfd36d894c2
@@ -11407,17 +11244,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"with-open-file@npm:^0.1.6":
-  version: 0.1.7
-  resolution: "with-open-file@npm:0.1.7"
-  dependencies:
-    p-finally: "npm:^1.0.0"
-    p-try: "npm:^2.1.0"
-    pify: "npm:^4.0.1"
-  checksum: 10c0/28a0c67718f0b9f14669636d5a69fa66bc87a4bdbc5913a245b68f0cbd0c96a3f83559147d647dc30332f3eee76688924654587cc58e4d5b944ef04155f9fe36
-  languageName: node
-  linkType: hard
-
 "word-wrap@npm:^1.2.5":
   version: 1.2.5
   resolution: "word-wrap@npm:1.2.5"
@@ -11572,5 +11398,12 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
+  languageName: node
+  linkType: hard
+
+"zod@npm:3.24.2":
+  version: 3.24.2
+  resolution: "zod@npm:3.24.2"
+  checksum: 10c0/c638c7220150847f13ad90635b3e7d0321b36cce36f3fc6050ed960689594c949c326dfe2c6fa87c14b126ee5d370ccdebd6efb304f41ef5557a4aaca2824565
   languageName: node
   linkType: hard


### PR DESCRIPTION
# Description

- Fixes #3721 by replacing it with zod schema
  - Adjusted expectValidationError for zod issues
- Fixes #4184 
  - Add CradleService to easily inject container for factories
- Fixes #4186 
- `app.use(loadControllers(...))` caused swc module resolution issues, `loadControllers(..)` has been called from its own nodejs module now
- All controllers now use decorator based endpoints
- Introduce ParamId, ParamInt, ParamBool, ParamString for strict param type constraints
  - use in `req.local.*` for example `req.local.id` if `@before[ParamId("id")]` is used
- `tsconfig.json` strictNullChecks and strictPropertyInitialization set to true

## TODO

- Split up decorator based API endpoints into separate PR
- "should avoid adding invalid printer" test validation can now be simplified
- Decide whether floorId in positionDto is required
- Reduce complexity of apiKey validation and reuse across codebase
- Setup test plan

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Vue test
- [x] Node test 

# Checklist:

- [ ] I checked my changes
- [x] I have commented my code concisely
- [ ] I have covered my changes with tests
