### PR TITLE
fix: OctoPrint 1.8.7 needs explicit passive flag in body instead of header to login

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,5 +1,11 @@
 # Develop
 
+## Fixes
+
+- fix: OctoPrint 1.8.7 needs explicit passive flag in body instead of header to login
+
+# FDM Monster 1.9.0-rc1
+
 ## Features
 - Introduce PrusaLink adapter for limited printer support for these printers: MK3S(+) (needs PrusaLink extension with Raspberry Pi), Mini(+), MK4(S), XL, Core One
 - Add opt-in Prometheus integration (still experimental)

--- a/src/services/octoprint/octoprint-api.routes.ts
+++ b/src/services/octoprint/octoprint-api.routes.ts
@@ -19,7 +19,7 @@ export class OctoprintRoutes {
   apiSystemCommands = `${this.apiSystem}/commands`;
   apiServerRestartCommand = `${this.apiSystemCommands}/core/restart`;
   apiUsers = `${this.apiBase}/users`;
-  apiLogin = `${this.apiBase}/login?passive=true`;
+  apiLogin = `${this.apiBase}/login`;
 
   get disconnectCommand() {
     return { command: "disconnect" };

--- a/src/services/octoprint/octoprint.client.ts
+++ b/src/services/octoprint/octoprint.client.ts
@@ -51,7 +51,9 @@ export class OctoprintClient extends OctoprintRoutes {
   }
 
   async login(login: LoginDto) {
-    return await this.createClient(login).post<OP_LoginDto>(this.apiLogin);
+    return await this.createClient(login).post<OP_LoginDto>(this.apiLogin, {
+      passive: true
+    });
   }
 
   async sendConnectionCommand(login: LoginDto, commandData: any) {

--- a/src/services/octoprint/utils/octoprint-http-client.builder.ts
+++ b/src/services/octoprint/utils/octoprint-http-client.builder.ts
@@ -11,7 +11,7 @@ export class OctoprintHttpClientBuilder extends DefaultHttpClientBuilder {
     return super.build<D>();
   }
 
-  public withXApiKeyHeader(apiKey?: string): OctoprintHttpClientBuilder {
+  public withXApiKeyHeader(apiKey?: string): this {
     if (!apiKey?.length) {
       throw new Error("XApiKey header may not be an empty string");
     }


### PR DESCRIPTION
Bug for specific OctoPrint versions