### PR TITLE
Fix/4321 moonraker setup not failure tolerant, verbose error log with whole axios response

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@fdm-monster/client": "1.10.2",
-    "@fdm-monster/client-next": "0.0.19",
+    "@fdm-monster/client-next": "0.0.20",
     "@octokit/plugin-throttling": "8.2.0",
     "@sentry/node": "9.19.0",
     "adm-zip": "0.5.16",

--- a/src/controllers/server-public.controller.ts
+++ b/src/controllers/server-public.controller.ts
@@ -16,7 +16,8 @@ export class ServerPublicController {
     private readonly serverReleaseService: ServerReleaseService,
     private readonly monsterPiService: MonsterPiService,
     private readonly isTypeormMode: boolean,
-  ) {}
+  ) {
+  }
 
   @GET()
   @route("/")
@@ -41,6 +42,7 @@ export class ServerPublicController {
   getFeatures(req: Request, res: Response) {
     const serverSettings = this.settingsStore.getServerSettings();
     const moonrakerEnabled = serverSettings.experimentalMoonrakerSupport;
+    const prusaLinkEnabled = serverSettings.experimentalPrusaLinkSupport;
     res.send({
       printerGroupsApi: {
         // Only SQLite mode supported for this feature
@@ -52,7 +54,11 @@ export class ServerPublicController {
         available: true,
         version: 1,
         subFeatures: {
-          types: moonrakerEnabled ? ["octoprint", "klipper"] : ["octoprint"],
+          types: [
+            "octoprint",
+            ...(moonrakerEnabled ? ["klipper"] : []),
+            ...(prusaLinkEnabled ? ["prusaLink"] : []),
+          ],
         },
       },
     });

--- a/src/server.constants.ts
+++ b/src/server.constants.ts
@@ -71,7 +71,7 @@ export const AppConstants = {
   orgName: "fdm-monster",
   // Wizard version changes will trigger a re-run of the wizard
   currentWizardVersion: 1,
-  defaultClientMinimum: "1.10.1",
+  defaultClientMinimum: "1.10.2",
 
   influxUrl: "INFLUX_URL",
   influxToken: "INFLUX_TOKEN",

--- a/src/services/moonraker/moonraker.client.ts
+++ b/src/services/moonraker/moonraker.client.ts
@@ -795,7 +795,7 @@ export class MoonrakerClient {
   }
 
   /**
-   * @deprecated API might not be available in the future
+   * @description API might not be available in the future
    * @param login
    */
   async getApiVersion(login: LoginDto) {
@@ -803,7 +803,7 @@ export class MoonrakerClient {
   }
 
   /**
-   * @deprecated API might not be available in the future
+   * @description API might not be available in the future
    * @param login
    */
   async getServerVersion(login: LoginDto) {
@@ -811,7 +811,7 @@ export class MoonrakerClient {
   }
 
   /**
-   * @deprecated API might not be available in the future
+   * @description API might not be available in the future
    * @param login
    */
   async getApiLogin(login: LoginDto) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1029,10 +1029,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fdm-monster/client-next@npm:0.0.19":
-  version: 0.0.19
-  resolution: "@fdm-monster/client-next@npm:0.0.19"
-  checksum: 10c0/d6ecf4d8fad88c8a725164b9aba64f045073e7803ccc02b8d0aee6681c2988a8b15ef052240b8654364058ddf36218bcadf18cfb838bc54e3ebbf3a06f5157c6
+"@fdm-monster/client-next@npm:0.0.20":
+  version: 0.0.20
+  resolution: "@fdm-monster/client-next@npm:0.0.20"
+  checksum: 10c0/299539061c442830373a500fe9dc649f5252ed0783b742856f6de1b0b978869e723883a844aed796f226ddf2ed0b88b546f1b99ea17bfe2b70ad83819d8f9c52
   languageName: node
   linkType: hard
 
@@ -1049,7 +1049,7 @@ __metadata:
   dependencies:
     "@biomejs/biome": "npm:1.9.4"
     "@fdm-monster/client": "npm:1.10.2"
-    "@fdm-monster/client-next": "npm:0.0.19"
+    "@fdm-monster/client-next": "npm:0.0.20"
     "@lcov-viewer/cli": "npm:1.3.0"
     "@lcov-viewer/istanbul-report": "npm:1.4.0"
     "@octokit/plugin-throttling": "npm:8.2.0"


### PR DESCRIPTION
# Description

Fixes #4321 and adds better failure handling on first API call. ECONNREFUSED, ECONNRESET, ETIMEDOUT or EHOSTUNREACH should not result in huge object in the logs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Locally with a non-existent / down Moonraker API.

- [x] Node test 

# Checklist:

- [x] I checked my changes
- [x] I have commented my code concisely
- [ ] I have covered my changes with tests
