### PR TITLE
release 1.9.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ coverage
 **/yarn-error.log
 
 test/requests/*.env.json
+
+mosquitto/

--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,5 +1,16 @@
 # Develop
 
+# FDM Monster 1.9.4
+
+## Fixes
+
+- Bambu mqtt adapter should connect using mqtts
+- Bambu FTP works with .3mf (as well as gcode), FDM Monster now supports 3mf upload for bambu printer types
+- Bambu: implemented socket state emitting for test functionality
+- PrusaLink: implemented socket state emitting for test functionality
+- Bambu: download file implemented via FTP
+- FDM-Monster API: file upload now checks file extension after upload (not during upload)
+
 # FDM Monster 1.9.3
 
 ## Fixes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,19 @@ services:
       - ./fdm-monster:/data
     restart: unless-stopped
 
+  mosquitto:
+    container_name: fdmm-mosquitto
+    image: eclipse-mosquitto:2.0.22
+    restart: unless-stopped
+    ports:
+#      - "1883:1883"   # plain MQTT
+      - "8883:8883"   # MQTT over TLS
+    volumes:
+      - ./mosquitto/config:/mosquitto/config
+      - ./mosquitto/data:/mosquitto/data
+      - ./mosquitto/log:/mosquitto/log
+      - ./mosquitto/certs:/mosquitto/certs
+
   # docker build --platform linux/amd64,linux/arm64 -t 1.5.0-alpha . -f .\docker\Dockerfile
   fdm-monster:
     container_name: fdm-monster

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "author": "David Zwart",
   "license": "AGPL-3.0-or-later",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "bin": {
     "fdm-monster": "dist/index.js",
     "fdmm": "dist/index.js"
@@ -133,7 +133,6 @@
     "@types/supertest": "6.0.3",
     "@types/uuid": "10.0.0",
     "@types/ws": "8.18.1",
-    "aedes": "0.51.3",
     "chokidar": "5.0.0",
     "express-list-routes": "1.3.2",
     "ftp-srv": "4.6.3",

--- a/src/server.constants.ts
+++ b/src/server.constants.ts
@@ -19,6 +19,7 @@ export const AppConstants = {
   defaultPrinterThumbnailsStorage: "./media/printer-thumbnails",
   defaultFileUploadsStorage: "./media/file-uploads",
   defaultAcceptedGcodeExtensions: [".gcode", ".bgcode"],
+  defaultAcceptedBambuExtensions: [".gcode", ".3mf"],
   defaultServerPort: 4000,
   defaultMongoStringUnauthenticated: "mongodb://127.0.0.1:27017/fdm-monster",
   apiRoute: "/api",
@@ -72,7 +73,7 @@ export const AppConstants = {
   orgName: "fdm-monster",
   // Wizard version changes will trigger a re-run of the wizard
   currentWizardVersion: 1,
-  defaultClientMinimum: "1.12.0",
+  defaultClientMinimum: "1.12.3",
 
   influxUrl: "INFLUX_URL",
   influxToken: "INFLUX_TOKEN",
@@ -103,3 +104,4 @@ export const AppConstants = {
   LOKI_TIMEOUT_SECONDS: "LOKI_TIMEOUT_SECONDS",
   LOKI_INTERVAL: "LOKI_INTERVAL"
 };
+

--- a/src/state/test-printer-socket.store.ts
+++ b/src/state/test-printer-socket.store.ts
@@ -13,6 +13,8 @@ import { captureException } from "@sentry/node";
 import { SOCKET_STATE } from "@/shared/dtos/socket-state.type";
 import { IWebsocketAdapter } from "@/services/websocket-adapter.interface";
 import { moonrakerEvent } from "@/services/moonraker/constants/moonraker.constants";
+import { bambuEvent } from "@/services/bambu/bambu-mqtt.adapter";
+import { prusaLinkEvent } from "@/services/prusa-link/constants/prusalink.constants";
 import { printerEvents } from "@/constants/event.constants";
 import { OctoPrintEventDto } from "@/services/octoprint/dto/octoprint-event.dto";
 import { z } from "zod";
@@ -65,6 +67,16 @@ export class TestPrinterSocketStore {
       moonrakerEvent(WsMessage.WS_CLOSED),
       moonrakerEvent(WsMessage.WS_OPENED),
       moonrakerEvent(WsMessage.WS_ERROR),
+      bambuEvent(WsMessage.WS_STATE_UPDATED),
+      bambuEvent(WsMessage.API_STATE_UPDATED),
+      bambuEvent(WsMessage.WS_CLOSED),
+      bambuEvent(WsMessage.WS_OPENED),
+      bambuEvent(WsMessage.WS_ERROR),
+      prusaLinkEvent(WsMessage.WS_STATE_UPDATED),
+      prusaLinkEvent(WsMessage.API_STATE_UPDATED),
+      prusaLinkEvent(WsMessage.WS_CLOSED),
+      prusaLinkEvent(WsMessage.WS_OPENED),
+      prusaLinkEvent(WsMessage.WS_ERROR),
     ];
     const listener = ({ event, payload, printerId }: OctoPrintEventDto) => {
       if (printerId !== correlationToken) {

--- a/test/api/print-completion-controller.test.ts
+++ b/test/api/print-completion-controller.test.ts
@@ -30,7 +30,7 @@ describe(PrintCompletionController.name, () => {
   it("should return empty print completion list", async () => {
     const response = await request.get(listRoute).send();
     expectOkResponse(response, []);
-  });
+  }, 10000);
 
   it("should return context list", async () => {
     const response = await request.get(contextsRoute).send();

--- a/test/api/stubs/bambu-ftp.adapter.stub.ts
+++ b/test/api/stubs/bambu-ftp.adapter.stub.ts
@@ -1,0 +1,209 @@
+import EventEmitter2 from "eventemitter2";
+import { SettingsStore } from "@/state/settings.store";
+import { LoggerService } from "@/handlers/logger";
+import { ILoggerFactory } from "@/handlers/logger-factory";
+import { FileInfo } from "basic-ftp";
+import { uploadDoneEvent, uploadFailedEvent, uploadProgressEvent } from "@/constants/event.constants";
+
+/**
+ * Stub implementation of BambuFtpAdapter for testing
+ * Avoids actual network connections while maintaining the same interface
+ */
+export class BambuFtpAdapterStub {
+  protected readonly logger: LoggerService;
+
+  private host: string | null = null;
+  private accessCode: string | null = null;
+  private isConnecting = false;
+  private connected = false;
+
+  constructor(
+    private readonly settingsStore: SettingsStore,
+    loggerFactory: ILoggerFactory,
+    private readonly eventEmitter2: EventEmitter2
+  ) {
+    this.settingsStore = settingsStore;
+    this.eventEmitter2 = eventEmitter2;
+    this.logger = loggerFactory("BambuFtpAdapterStub");
+  }
+
+  /**
+   * Connect to FTP server (stubbed)
+   */
+  async connect(host: string, accessCode: string): Promise<void> {
+    if (this.connected) {
+      this.logger.debug("FTP already connected (stub)");
+      return;
+    }
+
+    if (this.isConnecting) {
+      throw new Error("Connection already in progress");
+    }
+
+    this.host = host;
+    this.accessCode = accessCode;
+    this.isConnecting = true;
+
+    this.logger.log(`[STUB] Connecting to Bambu FTP at ${host}:990`);
+
+    // Simulate connection delay
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    this.isConnecting = false;
+    this.connected = true;
+    this.logger.log("[STUB] FTP connected successfully");
+  }
+
+  /**
+   * Disconnect FTP (stubbed)
+   */
+  async disconnect(): Promise<void> {
+    if (!this.connected) {
+      return;
+    }
+
+    this.logger.log("[STUB] Disconnecting FTP");
+    this.connected = false;
+    this.host = null;
+    this.accessCode = null;
+  }
+
+  /**
+   * List files in directory (stubbed)
+   */
+  async listFiles(dirPath: string = "/"): Promise<FileInfo[]> {
+    this.ensureConnected();
+
+    this.logger.debug(`[STUB] Listing files in ${dirPath}`);
+
+    // Return mock file list
+    const now = new Date();
+    return [
+      {
+        name: "sample.3mf",
+        size: 1024,
+        modifiedAt: now,
+        rawModifiedAt: now.toISOString(),
+        date: now.toISOString().split("T")[0],
+        type: 1, // File type
+        isFile: true,
+        isDirectory: false,
+        isSymbolicLink: false
+      },
+      {
+        name: "test.gcode",
+        size: 2048,
+        modifiedAt: now,
+        rawModifiedAt: now.toISOString(),
+        date: now.toISOString().split("T")[0],
+        type: 1,
+        isFile: true,
+        isDirectory: false,
+        isSymbolicLink: false
+      }
+    ];
+  }
+
+  /**
+   * Upload file to printer (stubbed)
+   */
+  async uploadFile(
+    fileBuffer: Buffer,
+    filename: string,
+    progressToken?: string,
+  ): Promise<void> {
+    this.ensureConnected();
+
+    const remotePath = `/sdcard/${filename}`;
+
+    try {
+      this.logger.log(`[STUB] Uploading ${filename} to ${remotePath}`);
+
+      // Simulate progress updates
+      if (progressToken) {
+        const totalSize = fileBuffer.length;
+        let uploaded = 0;
+
+        const progressInterval = setInterval(() => {
+          uploaded = Math.min(uploaded + totalSize / 4, totalSize);
+          this.eventEmitter2.emit(
+            `${uploadProgressEvent(progressToken)}`,
+            progressToken,
+            {
+              loaded: uploaded,
+              total: totalSize,
+            },
+          );
+
+          if (uploaded >= totalSize) {
+            clearInterval(progressInterval);
+          }
+        }, 50);
+
+        // Wait for "upload" to complete
+        await new Promise(resolve => setTimeout(resolve, 200));
+      }
+
+      if (progressToken) {
+        this.eventEmitter2.emit(`${uploadDoneEvent(progressToken)}`, progressToken);
+      }
+
+      this.logger.log(`[STUB] File uploaded successfully: ${filename}`);
+    } catch (error) {
+      if (progressToken) {
+        this.eventEmitter2.emit(
+          `${uploadFailedEvent(progressToken)}`,
+          progressToken,
+          (error as Error)?.message,
+        );
+      }
+
+      this.logger.error(`[STUB] Upload failed for ${filename}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Download file from printer (stubbed)
+   */
+  async downloadFile(remotePath: string, localPath: string): Promise<void> {
+    this.ensureConnected();
+
+    this.logger.log(`[STUB] Downloading ${remotePath} to ${localPath}`);
+
+    // Simulate download delay
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    this.logger.log(`[STUB] File downloaded successfully: ${remotePath}`);
+  }
+
+  /**
+   * Delete file from printer (stubbed)
+   */
+  async deleteFile(remotePath: string): Promise<void> {
+    this.ensureConnected();
+
+    this.logger.log(`[STUB] Deleting file: ${remotePath}`);
+
+    // Simulate delete delay
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    this.logger.log(`[STUB] File deleted successfully: ${remotePath}`);
+  }
+
+  /**
+   * Get connection status
+   */
+  get isConnected(): boolean {
+    return this.connected;
+  }
+
+  /**
+   * Ensure FTP is connected
+   */
+  private ensureConnected(): void {
+    if (!this.connected) {
+      throw new Error("FTP not connected");
+    }
+  }
+}

--- a/test/api/stubs/bambu-mqtt.adapter.stub.ts
+++ b/test/api/stubs/bambu-mqtt.adapter.stub.ts
@@ -1,0 +1,315 @@
+import { ILoggerFactory } from "@/handlers/logger-factory";
+import EventEmitter2 from "eventemitter2";
+import { LoggerService } from "@/handlers/logger";
+import { PrintData } from "@/services/bambu/mqtt-message.types";
+import { IWebsocketAdapter } from "@/services/websocket-adapter.interface";
+import { ISocketLogin } from "@/shared/dtos/socket-login.dto";
+import { LoginDto } from "@/services/interfaces/login.dto";
+import { SOCKET_STATE, SocketState } from "@/shared/dtos/socket-state.type";
+import { API_STATE, ApiState } from "@/shared/dtos/api-state.type";
+import { BambuType } from "@/services/printer-api.interface";
+import { IdType } from "@/shared.constants";
+import { WsMessage } from "@/services/octoprint/octoprint-websocket.adapter";
+
+export const bambuEvent = (event: string) => `bambu.${event}`;
+
+export interface BambuEventDto {
+  event: string;
+  payload: any;
+  printerId?: IdType;
+  printerType: typeof BambuType;
+}
+
+/**
+ * Stub implementation of BambuMqttAdapter for testing
+ * Avoids actual MQTT connections while maintaining the same interface
+ */
+export class BambuMqttAdapterStub implements IWebsocketAdapter {
+  protected readonly logger: LoggerService;
+  private readonly eventEmitter2: EventEmitter2;
+
+  // IWebsocketAdapter required properties
+  public readonly printerType = BambuType;
+  public printerId?: IdType;
+  public socketState: SocketState = SOCKET_STATE.unopened;
+  public apiState: ApiState = API_STATE.unset;
+  public login!: LoginDto;
+  public lastMessageReceivedTimestamp: null | number = null;
+
+  private host: string | null = null;
+  private accessCode: string | null = null;
+  private serial: string | null = null;
+  private lastState: PrintData | null = null;
+  private isConnecting = false;
+  private eventsAllowed = true;
+  private connected = false;
+
+  constructor(
+    loggerFactory: ILoggerFactory,
+    eventEmitter2: EventEmitter2
+  ) {
+    this.logger = loggerFactory("BambuMqttAdapterStub");
+    this.eventEmitter2 = eventEmitter2;
+  }
+
+  /**
+   * Register credentials for connection
+   */
+  registerCredentials(socketLogin: ISocketLogin): void {
+    const login = socketLogin.loginDto;
+    this.login = login;
+    const host = this.extractHost(login.printerURL);
+    this.host = host;
+    this.accessCode = login.password || "";
+    this.serial = login.username || "";
+
+    this.logger.debug(`[STUB] Registered credentials for host ${host}`);
+  }
+
+  /**
+   * Open connection (stubbed)
+   */
+  open(): void {
+    if (!this.host || !this.accessCode || !this.serial) {
+      throw new Error("Cannot open connection: credentials not registered");
+    }
+
+    this.connect(this.host, this.accessCode, this.serial).catch((err) => {
+      this.logger.error("[STUB] Failed to open MQTT connection: " + err.toString());
+      this.updateSocketState(SOCKET_STATE.error);
+    });
+  }
+
+  /**
+   * Close connection (stubbed)
+   */
+  close(): void {
+    this.disconnect().catch((err) => {
+      this.logger.error("[STUB] Error during MQTT disconnect:", err);
+    });
+  }
+
+  /**
+   * Connect to MQTT (stubbed)
+   */
+  private async connect(host: string, accessCode: string, serial: string): Promise<void> {
+    if (this.connected) {
+      this.logger.debug("[STUB] MQTT already connected");
+      this.updateSocketState(SOCKET_STATE.authenticated);
+      return;
+    }
+
+    if (this.isConnecting) {
+      throw new Error("Connection already in progress");
+    }
+
+    this.isConnecting = true;
+    this.updateSocketState(SOCKET_STATE.opening);
+
+    this.logger.log(`[STUB] Connecting to Bambu MQTT at ${host}:8883`);
+
+    try {
+      // Simulate connection delay
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      this.connected = true;
+      this.isConnecting = false;
+      this.updateSocketState(SOCKET_STATE.authenticated);
+      this.updateApiState(API_STATE.responding);
+      this.lastMessageReceivedTimestamp = Date.now();
+
+      this.logger.log("[STUB] MQTT connected successfully");
+
+      // Emit mock connection event
+      this.emitEvent("connected", { host, serial });
+
+    } catch (error) {
+      this.isConnecting = false;
+      this.updateSocketState(SOCKET_STATE.error);
+      this.logger.error("[STUB] MQTT connection failed:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Disconnect from MQTT (stubbed)
+   */
+  private async disconnect(): Promise<void> {
+    if (!this.connected) {
+      return;
+    }
+
+    this.logger.log("[STUB] Disconnecting MQTT");
+
+    this.connected = false;
+    this.socketState = SOCKET_STATE.closed;
+    this.apiState = API_STATE.unset;
+
+    // Emit mock disconnect event
+    this.emitEvent("disconnected", {});
+  }
+
+  /**
+   * Start print job (stubbed)
+   */
+  async startPrint(filename: string): Promise<void> {
+    if (!this.connected) {
+      throw new Error("MQTT not connected");
+    }
+
+    this.logger.log(`[STUB] Starting print: ${filename}`);
+
+    // Simulate command delay
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    // Emit mock print started event
+    this.emitEvent("print_started", { filename });
+  }
+
+  /**
+   * Pause print (stubbed)
+   */
+  async pausePrint(): Promise<void> {
+    if (!this.connected) {
+      throw new Error("MQTT not connected");
+    }
+
+    this.logger.log("[STUB] Pausing print");
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    this.emitEvent("print_paused", {});
+  }
+
+  /**
+   * Resume print (stubbed)
+   */
+  async resumePrint(): Promise<void> {
+    if (!this.connected) {
+      throw new Error("MQTT not connected");
+    }
+
+    this.logger.log("[STUB] Resuming print");
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    this.emitEvent("print_resumed", {});
+  }
+
+  /**
+   * Stop print (stubbed)
+   */
+  async stopPrint(): Promise<void> {
+    if (!this.connected) {
+      throw new Error("MQTT not connected");
+    }
+
+    this.logger.log("[STUB] Stopping print");
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    this.emitEvent("print_stopped", {});
+  }
+
+  /**
+   * Get connection status
+   */
+  get isConnected(): boolean {
+    return this.connected && this.socketState === SOCKET_STATE.authenticated;
+  }
+
+  /**
+   * Extract host from printer URL
+   */
+  private extractHost(printerURL: string): string {
+    try {
+      const url = new URL(printerURL);
+      return url.hostname;
+    } catch {
+      // Fallback: assume it's already a host/IP
+      return printerURL.replace(/^https?:\/\//, '').split(':')[0];
+    }
+  }
+
+  /**
+   * Update socket state and emit event
+   */
+  private updateSocketState(state: SocketState): void {
+    this.socketState = state;
+    this.emitEvent(WsMessage.WS_STATE_UPDATED, state);
+  }
+
+  /**
+   * Update API state and emit event
+   */
+  private updateApiState(state: ApiState): void {
+    this.apiState = state;
+    this.emitEvent(WsMessage.API_STATE_UPDATED, state);
+  }
+
+  /**
+   * Emit Bambu-specific event
+   */
+  private emitEvent(event: string, payload: any): void {
+    if (!this.eventsAllowed) {
+      return;
+    }
+
+    const eventData: BambuEventDto = {
+      event,
+      payload,
+      printerId: this.printerId,
+      printerType: BambuType,
+    };
+
+    this.eventEmitter2.emit(bambuEvent(event), eventData);
+  }
+
+  // IWebsocketAdapter required methods
+
+  needsReopen(): boolean {
+    return this.socketState === SOCKET_STATE.closed || this.socketState === SOCKET_STATE.error;
+  }
+
+  needsSetup(): boolean {
+    return this.socketState === SOCKET_STATE.unopened;
+  }
+
+  needsReauth(): boolean {
+    return false;
+  }
+
+  isClosedOrAborted(): boolean {
+    return this.socketState === SOCKET_STATE.closed || this.socketState === SOCKET_STATE.aborted;
+  }
+
+  async reauthSession(): Promise<void> {
+    this.logger.debug("[STUB] reauthSession called");
+  }
+
+  async setupSocketSession(): Promise<void> {
+    this.logger.debug("[STUB] setupSocketSession called");
+    if (!this.host || !this.accessCode || !this.serial) {
+      this.updateSocketState(SOCKET_STATE.aborted);
+      this.updateApiState(API_STATE.noResponse);
+      throw new Error("Credentials not properly registered");
+    }
+
+    this.updateSocketState(SOCKET_STATE.opening);
+    this.updateApiState(API_STATE.responding);
+  }
+
+  resetSocketState(): void {
+    this.socketState = SOCKET_STATE.unopened;
+    this.apiState = API_STATE.unset;
+    this.connected = false;
+  }
+
+  allowEmittingEvents(): void {
+    this.eventsAllowed = true;
+  }
+
+  disallowEmittingEvents(): void {
+    this.eventsAllowed = false;
+  }
+}

--- a/test/api/stubs/bambu.api.stub.ts
+++ b/test/api/stubs/bambu.api.stub.ts
@@ -1,0 +1,276 @@
+import {
+  BambuType,
+  FileDto,
+  IPrinterApi,
+  PartialReprintFileDto,
+  PrinterType,
+  ReprintState,
+} from "@/services/printer-api.interface";
+import { LoggerService } from "@/handlers/logger";
+import { LoginDto } from "@/services/interfaces/login.dto";
+import { ILoggerFactory } from "@/handlers/logger-factory";
+import { PrinterSocketStore } from "@/state/printer-socket.store";
+import { AxiosPromise } from "axios";
+import { ServerConfigDto } from "@/services/moonraker/dto/server/server-config.dto";
+import { SettingsDto } from "@/services/octoprint/dto/settings/settings.dto";
+import { connectionStates } from "@/services/octoprint/dto/connection/connection-state.type";
+import { BambuClientStub } from "./bambu.client.stub";
+import { BambuMqttAdapterStub } from "./bambu-mqtt.adapter.stub";
+
+const defaultLog = { adapter: "bambu-lab-stub" };
+
+/**
+ * Stub implementation of Bambu Lab printer API for testing
+ * Uses stub adapters to avoid actual network connections while maintaining interface compatibility
+ */
+export class BambuApiStub implements IPrinterApi {
+  logger: LoggerService;
+  client: BambuClientStub;
+  printerLogin: LoginDto;
+  private readonly printerSocketStore: PrinterSocketStore;
+  private printerId?: string;
+
+  constructor(
+    bambuClient: BambuClientStub,
+    printerLogin: LoginDto,
+    printerSocketStore: PrinterSocketStore,
+    loggerFactory: ILoggerFactory
+  ) {
+    this.logger = loggerFactory("BambuApiStub");
+    this.client = bambuClient;
+    this.printerLogin = printerLogin;
+    this.printerSocketStore = printerSocketStore;
+    this.logger.debug("[STUB] Constructed Bambu API client", this.logMeta());
+  }
+
+  /**
+   * Set the printer ID for accessing the MQTT adapter
+   */
+  setPrinterId(printerId: string): void {
+    this.printerId = printerId;
+  }
+
+  /**
+   * Get the MQTT adapter from the printer socket store (stubbed)
+   */
+  private getMqttAdapter(): BambuMqttAdapterStub {
+    if (!this.printerId) {
+      // Return a default stub adapter for testing
+      return new BambuMqttAdapterStub(
+        () => ({ debug: () => {}, log: () => {}, warn: () => {}, error: () => {} } as unknown as LoggerService), // Logger factory stub
+        {} as any // EventEmitter2 stub
+      );
+    }
+
+    const adapter = this.printerSocketStore.getPrinterSocket(this.printerId);
+    if (adapter && adapter instanceof BambuMqttAdapterStub) {
+      return adapter;
+    }
+
+    // Return a default stub adapter for testing
+    return new BambuMqttAdapterStub(
+      () => ({ debug: () => {}, log: () => {}, warn: () => {}, error: () => {} } as unknown as LoggerService), // Logger factory stub
+      {} as any // EventEmitter2 stub
+    );
+  }
+
+  /**
+   * Ensure FTP is connected, auto-connect if needed (stubbed)
+   */
+  private async ensureFtpConnected(): Promise<void> {
+    if (!this.client.isConnected) {
+      this.logger.debug("[STUB] FTP not connected, connecting automatically");
+      await this.client.connect(this.printerLogin);
+    }
+  }
+
+  get type(): PrinterType {
+    return BambuType;
+  }
+
+  set login(login: LoginDto) {
+    this.printerLogin = login;
+  }
+
+  async getVersion(): Promise<string> {
+    const response = await this.client.getApiVersion(this.printerLogin);
+    return response.version;
+  }
+
+  async connect(): Promise<void> {
+    await this.client.connect(this.printerLogin);
+  }
+
+  async disconnect(): Promise<void> {
+    await this.client.disconnect();
+  }
+
+  restartServer(): Promise<void> {
+    this.logger.warn("[STUB] restartServer not supported by Bambu Lab printers");
+    throw new Error("Method not supported");
+  }
+
+  restartHost(): Promise<void> {
+    this.logger.warn("[STUB] restartHost not supported by Bambu Lab printers");
+    throw new Error("Method not supported");
+  }
+
+  restartPrinterFirmware(): Promise<void> {
+    this.logger.warn("[STUB] restartPrinterFirmware not supported by Bambu Lab printers");
+    throw new Error("Method not supported");
+  }
+
+  async startPrint(path: string): Promise<void> {
+    this.logger.log(`[STUB] Starting print: ${path}`, this.logMeta());
+    const mqttAdapter = this.getMqttAdapter();
+    await mqttAdapter.startPrint(path);
+  }
+
+  async pausePrint(): Promise<void> {
+    this.logger.log("[STUB] Pausing print", this.logMeta());
+    const mqttAdapter = this.getMqttAdapter();
+    await mqttAdapter.pausePrint();
+  }
+
+  async resumePrint(): Promise<void> {
+    this.logger.log("[STUB] Resuming print", this.logMeta());
+    const mqttAdapter = this.getMqttAdapter();
+    await mqttAdapter.resumePrint();
+  }
+
+  async cancelPrint(): Promise<void> {
+    this.logger.log("[STUB] Cancelling print", this.logMeta());
+    const mqttAdapter = this.getMqttAdapter();
+    await mqttAdapter.stopPrint();
+  }
+
+  async quickStop(): Promise<void> {
+    this.logger.log("[STUB] Quick stopping print", this.logMeta());
+    const mqttAdapter = this.getMqttAdapter();
+    await mqttAdapter.stopPrint();
+  }
+
+  async sendGcode(script: string): Promise<void> {
+    this.logger.warn(`[STUB] sendGcode not implemented for Bambu Lab printers: ${script}`);
+    throw new Error("Method not implemented");
+  }
+
+  movePrintHead(amounts: { x?: number; y?: number; z?: number; speed?: number }): Promise<void> {
+    this.logger.warn("[STUB] movePrintHead not implemented for Bambu Lab printers", amounts);
+    throw new Error("Method not implemented");
+  }
+
+  homeAxes(axes: { x?: boolean; y?: boolean; z?: boolean }): Promise<void> {
+    this.logger.warn("[STUB] homeAxes not implemented for Bambu Lab printers");
+    throw new Error("Method not implemented");
+  }
+
+  async getFile(path: string): Promise<FileDto> {
+    this.logger.debug(`[STUB] Getting file info: ${path}`, this.logMeta());
+    await this.ensureFtpConnected();
+    const files = await this.client.ftp.listFiles("/sdcard");
+
+    const file = files.find((f) => f.name === path || f.name.endsWith(path));
+    if (!file) {
+      throw new Error(`File not found: ${path}`);
+    }
+
+    return {
+      path: file.name,
+      size: file.size,
+      date: file.modifiedAt ? new Date(file.modifiedAt).getTime() : null,
+    };
+  }
+
+  async getFiles(): Promise<FileDto[]> {
+    this.logger.debug("[STUB] Getting files list", this.logMeta());
+    await this.ensureFtpConnected();
+    const files = await this.client.ftp.listFiles("/sdcard");
+
+    return files.map((file) => ({
+      path: file.name,
+      size: file.size,
+      date: file.modifiedAt ? new Date(file.modifiedAt).getTime() : null,
+    }));
+  }
+
+  downloadFile(path: string): AxiosPromise<NodeJS.ReadableStream> {
+    this.logger.warn("[STUB] downloadFile not implemented via HTTP for Bambu Lab printers");
+    throw new Error("Method not implemented. Use FTP adapter directly if needed.");
+  }
+
+  getFileChunk(path: string, startBytes: number, endBytes: number): AxiosPromise<string> {
+    this.logger.warn("[STUB] getFileChunk not implemented for Bambu Lab printers");
+    throw new Error("Method not implemented");
+  }
+
+  async uploadFile(
+    fileOrBuffer: Buffer | Express.Multer.File,
+    startPrint: boolean,
+    uploadToken?: string,
+  ): Promise<void> {
+    let fileBuffer: Buffer;
+    let filename: string;
+
+    // Get file buffer and name
+    if (Buffer.isBuffer(fileOrBuffer)) {
+      this.logger.log("[STUB] Using file directly from memory buffer for upload");
+      fileBuffer = fileOrBuffer;
+      filename = `upload_${Date.now()}.3mf`; // Default name for buffer uploads
+    } else {
+      const filePath = fileOrBuffer.path;
+      filename = fileOrBuffer.originalname;
+      this.logger.log(`[STUB] Reading file from disk for upload: ${filePath}`);
+      // In stub mode, create a mock buffer instead of reading from disk
+      fileBuffer = Buffer.from(`[STUB] Mock file content for ${filename}`);
+    }
+
+    this.logger.log(`[STUB] Uploading file: ${filename} (${fileBuffer.length} bytes)`, this.logMeta());
+
+    try {
+      await this.ensureFtpConnected();
+      await this.client.ftp.uploadFile(fileBuffer, filename, uploadToken);
+
+      if (startPrint) {
+        this.logger.log(`[STUB] Starting print after upload: ${filename}`, this.logMeta());
+        const mqttAdapter = this.getMqttAdapter();
+        await mqttAdapter.startPrint(filename);
+      }
+    } catch (error) {
+      this.logger.error(`[STUB] Upload failed: ${(error as Error).message}`, this.logMeta());
+      throw error;
+    }
+  }
+
+  async deleteFile(path: string): Promise<void> {
+    this.logger.log(`[STUB] Deleting file: ${path}`, this.logMeta());
+    await this.ensureFtpConnected();
+    await this.client.ftp.deleteFile(`/sdcard/${path}`);
+  }
+
+  deleteFolder(path: string): Promise<void> {
+    this.logger.warn("[STUB] deleteFolder not implemented for Bambu Lab printers");
+    throw new Error("Method not implemented");
+  }
+
+  getSettings(): Promise<ServerConfigDto | SettingsDto> {
+    this.logger.warn("[STUB] getSettings not implemented for Bambu Lab printers");
+    throw new Error("Method not implemented");
+  }
+
+  async getReprintState(): Promise<PartialReprintFileDto> {
+    this.logger.warn("[STUB] getReprintState not implemented for Bambu Lab printers");
+    return {
+      connectionState: connectionStates.Operational,
+      reprintState: ReprintState.NoLastPrint,
+    };
+  }
+
+  private logMeta() {
+    return {
+      ...defaultLog,
+      printerId: this.printerId,
+      host: this.printerLogin?.printerURL,
+    };
+  }
+}

--- a/test/api/stubs/bambu.client.stub.ts
+++ b/test/api/stubs/bambu.client.stub.ts
@@ -1,0 +1,100 @@
+import EventEmitter2 from "eventemitter2";
+import { LoggerService } from "@/handlers/logger";
+import { SettingsStore } from "@/state/settings.store";
+import { ILoggerFactory } from "@/handlers/logger-factory";
+import { LoginDto } from "@/services/interfaces/login.dto";
+import { BambuFtpAdapterStub } from "./bambu-ftp.adapter.stub";
+
+/**
+ * Stub implementation of Bambu Lab printer client for testing
+ * Uses stub adapters to avoid actual network connections
+ */
+export class BambuClientStub {
+  readonly eventEmitter2: EventEmitter2;
+  readonly settingsStore: SettingsStore;
+  protected readonly logger: LoggerService;
+  private readonly ftpAdapter: BambuFtpAdapterStub;
+  private connected = false;
+
+  constructor(
+    settingsStore: SettingsStore,
+    loggerFactory: ILoggerFactory,
+    eventEmitter2: EventEmitter2,
+    bambuFtpAdapter: BambuFtpAdapterStub
+  ) {
+    this.settingsStore = settingsStore;
+    this.eventEmitter2 = eventEmitter2;
+    this.logger = loggerFactory("BambuClientStub");
+    this.ftpAdapter = bambuFtpAdapter;
+  }
+
+  /**
+   * Connect to Bambu Lab printer FTP (stubbed)
+   */
+  async connect(login: LoginDto): Promise<void> {
+    const host = this.extractHost(login.printerURL);
+    const accessCode = login.password || "";
+
+    if (!accessCode) {
+      throw new Error("Access code (password) is required for Bambu Lab printers");
+    }
+
+    this.logger.log(`[STUB] Connecting to Bambu Lab printer FTP at ${host}`);
+
+    try {
+      await this.ftpAdapter.connect(host, accessCode);
+      this.connected = true;
+      this.logger.log("[STUB] Successfully connected to Bambu Lab printer FTP");
+    } catch (error) {
+      this.logger.error("[STUB] Failed to connect to Bambu Lab printer FTP:", error);
+      await this.disconnect();
+      throw error;
+    }
+  }
+
+  /**
+   * Disconnect from printer FTP (stubbed)
+   */
+  async disconnect(): Promise<void> {
+    this.logger.log("[STUB] Disconnecting from Bambu Lab printer FTP");
+    await this.ftpAdapter.disconnect();
+    this.connected = false;
+    this.logger.log("[STUB] Disconnected from Bambu Lab printer FTP");
+  }
+
+  /**
+   * Get FTP adapter for direct access
+   */
+  get ftp(): BambuFtpAdapterStub {
+    return this.ftpAdapter;
+  }
+
+  /**
+   * Check if FTP client is connected
+   */
+  get isConnected(): boolean {
+    return this.connected && this.ftpAdapter.isConnected;
+  }
+
+  /**
+   * Extract host from printer URL (remove protocol, port, etc.)
+   */
+  private extractHost(printerURL: string): string {
+    try {
+      const url = new URL(printerURL);
+      return url.hostname;
+    } catch {
+      // If not a valid URL, assume it's just the hostname/IP
+      return printerURL.replace(/^https?:\/\//, "").split(":")[0].split("/")[0];
+    }
+  }
+
+  /**
+   * Get API version (for compatibility with existing interface)
+   * Note: Bambu Lab printers don't have a traditional API version endpoint
+   */
+  async getApiVersion(_login: LoginDto): Promise<{ version: string }> {
+    this.logger.debug("[STUB] Getting Bambu API version");
+    return { version: "bambu-1.0" };
+  }
+}

--- a/test/api/test-data/create-printer.ts
+++ b/test/api/test-data/create-printer.ts
@@ -2,7 +2,7 @@ import { AppConstants } from "@/server.constants";
 import { expectOkResponse } from "../../extensions";
 import { Test } from "supertest";
 import { SqliteIdType } from "@/shared.constants";
-import { OctoprintType } from "@/services/printer-api.interface";
+import { BambuType, OctoprintType } from "@/services/printer-api.interface";
 import TestAgent from "supertest/lib/agent";
 import { PrinterDto } from "@/services/interfaces/printer.dto";
 
@@ -19,3 +19,16 @@ export async function createTestPrinter(request: TestAgent<Test>, enabled = fals
   });
   return expectOkResponse(createResponse, { enabled, id: expect.anything() });
 }
+
+export async function createTestBambuPrinter(request: TestAgent<Test>, enabled = false): Promise<PrinterDto<SqliteIdType>> {
+  const createResponse = await request.post(printerRoute).query("forceSave=true").send({
+    printerURL: "http://192.168.1.100",
+    printerType: BambuType,
+    username: "AC12345678901234",
+    password: "12345678",
+    enabled,
+    name: "testBambuPrinter 123",
+  });
+  return expectOkResponse(createResponse, { enabled, id: expect.anything() });
+}
+

--- a/test/api/test-data/sample.3mf
+++ b/test/api/test-data/sample.3mf
@@ -1,0 +1,6 @@
+# Sample .3mf file for testing Bambu printer support
+# This is a minimal test file to verify .3mf upload functionality
+# In a real scenario, this would be a binary file format containing 3D model data
+PK     # This would normally be the ZIP file header for .3MF format
+test content for bambu printer 3mf upload
+

--- a/test/application/bambu/bambu-api.test.ts
+++ b/test/application/bambu/bambu-api.test.ts
@@ -159,12 +159,6 @@ describe(BambuApi.name, () => {
       expect(() => api.homeAxes({ x: true, y: true })).toThrow();
     });
 
-    it("should throw error on downloadFile", () => {
-      const api = printerApiFactory.getScopedPrinter(auth);
-
-      expect(() => api.downloadFile("test.3mf")).toThrow();
-    });
-
     it("should throw error on getFileChunk", () => {
       const api = printerApiFactory.getScopedPrinter(auth);
 

--- a/test/application/multer.service.test.ts
+++ b/test/application/multer.service.test.ts
@@ -14,10 +14,6 @@ beforeAll(async () => {
 });
 
 describe("MulterService", () => {
-  const fileFilterCallBack: (error: Error | null) => void = (err: any) => {
-    if (err) throw err;
-  };
-
   it("should find file", () => {
     expect(multerService.fileExists("file", "storage")).toBeFalsy();
   });
@@ -43,21 +39,5 @@ describe("MulterService", () => {
   it("should provide multer filter middleware", async () => {
     const result = multerService.getMulterGCodeFileFilter(false);
     expect(typeof result).toBe("function");
-  });
-
-  it("gcode filter should throw on non-gcode extension", async () => {
-    const incorrectFile = { originalname: "file.gco" } as Express.Multer.File;
-
-    expect(() =>
-      multerService.multerFileFilter([".gcode", ".bgcode"])(null, incorrectFile, fileFilterCallBack),
-    ).toThrow();
-  });
-
-  it("gcode filter should accept gcode extension", async () => {
-    const correctFile = { originalname: "file.gcode" } as Express.Multer.File;
-
-    expect(() =>
-      multerService.multerFileFilter([".gcode", ".bgcode"])(null, correctFile, fileFilterCallBack),
-    ).not.toThrow();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -896,7 +896,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.8, @babel/runtime@npm:^7.24.5, @babel/runtime@npm:^7.28.4":
+"@babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.28.4":
   version: 7.28.4
   resolution: "@babel/runtime@npm:7.28.4"
   checksum: 10c0/792ce7af9750fb9b93879cc9d1db175701c4689da890e6ced242ea0207c9da411ccf16dc04e689cc01158b28d7898c40d75598f4559109f761c12ce01e959bf7
@@ -1160,7 +1160,6 @@ __metadata:
     "@types/uuid": "npm:10.0.0"
     "@types/ws": "npm:8.18.1"
     adm-zip: "npm:0.5.16"
-    aedes: "npm:0.51.3"
     awilix: "npm:12.0.5"
     awilix-express: "npm:9.0.2"
     axios: "npm:1.13.2"
@@ -4528,45 +4527,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aedes-packet@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "aedes-packet@npm:3.0.0"
-  dependencies:
-    mqtt-packet: "npm:^7.0.0"
-  checksum: 10c0/370d921af8bf0feb3613d0ffd439a2ed3d281612a88bae033d5b4c1a33a48815f523b346b0ed05f48af5527e1e9db0b0466255a22b7a6ae2b56c1ecd2c84e616
-  languageName: node
-  linkType: hard
-
-"aedes-persistence@npm:^9.1.2":
-  version: 9.1.2
-  resolution: "aedes-persistence@npm:9.1.2"
-  dependencies:
-    aedes-packet: "npm:^3.0.0"
-    qlobber: "npm:^7.0.0"
-  checksum: 10c0/997716d4c87e779c67ecc8e0dc033c9dc7a816ec4447670cc1b04369da4ee8d39f6cfbd5ec101c2b67847f75cf05c0037026ecc61de39b2f2cbbc649443dd696
-  languageName: node
-  linkType: hard
-
-"aedes@npm:0.51.3":
-  version: 0.51.3
-  resolution: "aedes@npm:0.51.3"
-  dependencies:
-    aedes-packet: "npm:^3.0.0"
-    aedes-persistence: "npm:^9.1.2"
-    end-of-stream: "npm:^1.4.4"
-    fastfall: "npm:^1.5.1"
-    fastparallel: "npm:^2.4.1"
-    fastseries: "npm:^2.0.0"
-    hyperid: "npm:^3.2.0"
-    mqemitter: "npm:^6.0.0"
-    mqtt-packet: "npm:^9.0.0"
-    retimer: "npm:^4.0.0"
-    reusify: "npm:^1.0.4"
-    uuid: "npm:^10.0.0"
-  checksum: 10c0/99ba3bd6b10108c48429f4ea872ede813e092f5d2e1781e481b5b9e72c5a3415b13555b7d6af11b70f24ad74adfa9335618794bbd6a68039a5554bed9feddb0c
-  languageName: node
-  linkType: hard
-
 "agent-base@npm:^7.1.0, agent-base@npm:^7.1.2":
   version: 7.1.4
   resolution: "agent-base@npm:7.1.4"
@@ -5013,7 +4973,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bl@npm:^4.0.2, bl@npm:^4.0.3":
+"bl@npm:^4.0.3":
   version: 4.1.0
   resolution: "bl@npm:4.1.0"
   dependencies:
@@ -6025,7 +5985,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"end-of-stream@npm:^1.1.0, end-of-stream@npm:^1.4.1, end-of-stream@npm:^1.4.4":
+"end-of-stream@npm:^1.1.0, end-of-stream@npm:^1.4.1":
   version: 1.4.5
   resolution: "end-of-stream@npm:1.4.5"
   dependencies:
@@ -6334,16 +6294,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-unique-numbers@npm:^8.0.13":
-  version: 8.0.13
-  resolution: "fast-unique-numbers@npm:8.0.13"
-  dependencies:
-    "@babel/runtime": "npm:^7.23.8"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/bf826d92345083c3146debf44e7dc93414d428eb81bd095dd46fcc6654f77977e0d04a2f65bccfcf0b9fc495a4276259afe99dbee009f463d19a1503f4e9bfac
-  languageName: node
-  linkType: hard
-
 "fast-unique-numbers@npm:^9.0.24":
   version: 9.0.24
   resolution: "fast-unique-numbers@npm:9.0.24"
@@ -6365,38 +6315,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fastfall@npm:^1.5.1":
-  version: 1.5.1
-  resolution: "fastfall@npm:1.5.1"
-  dependencies:
-    reusify: "npm:^1.0.0"
-  checksum: 10c0/ec015528def39cc0f68ce0ccb47a6a19f9c4328ac3f1bb53c18e1c3c03f1fc8f82b01cd4a0bdbeb927d0b800fa7ee5514bc920d4c4cec2b7a513ce26a56a9c2b
-  languageName: node
-  linkType: hard
-
-"fastparallel@npm:^2.4.1":
-  version: 2.4.1
-  resolution: "fastparallel@npm:2.4.1"
-  dependencies:
-    reusify: "npm:^1.0.4"
-    xtend: "npm:^4.0.2"
-  checksum: 10c0/247f088db5798fab393074197869a24f6eb399089896bfa0001e5bdd37aca0a173ece37dd9ba7320e500aeb6bbc1663b0c9b13bb4a311832fbcab32b8693ebbd
-  languageName: node
-  linkType: hard
-
 "fastq@npm:^1.6.0":
   version: 1.20.1
   resolution: "fastq@npm:1.20.1"
   dependencies:
     reusify: "npm:^1.0.4"
   checksum: 10c0/e5dd725884decb1f11e5c822221d76136f239d0236f176fab80b7b8f9e7619ae57e6b4e5b73defc21e6b9ef99437ee7b545cff8e6c2c337819633712fa9d352e
-  languageName: node
-  linkType: hard
-
-"fastseries@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "fastseries@npm:2.0.0"
-  checksum: 10c0/96c56e9d99359f633a382ec7ab6f9a817256ea346b259982d4ff74f0e002563bb99e782a22506655784ae00faf1acc24d3f372b3505f9bb768d53ee9ce5c8cd8
   languageName: node
   linkType: hard
 
@@ -6981,17 +6905,6 @@ __metadata:
   version: 2.1.0
   resolution: "human-signals@npm:2.1.0"
   checksum: 10c0/695edb3edfcfe9c8b52a76926cd31b36978782062c0ed9b1192b36bebc75c4c87c82e178dfcb0ed0fc27ca59d434198aac0bd0be18f5781ded775604db22304a
-  languageName: node
-  linkType: hard
-
-"hyperid@npm:^3.2.0":
-  version: 3.3.0
-  resolution: "hyperid@npm:3.3.0"
-  dependencies:
-    buffer: "npm:^5.2.1"
-    uuid: "npm:^8.3.2"
-    uuid-parse: "npm:^1.1.0"
-  checksum: 10c0/709dafd2a25e21086a2d881adb3436a16eafd28692ebd967829ca1d5f10adf001925feb23b6aadfee464ea313d851e7ba7a5452869aaf6cde15e9149793a09e0
   languageName: node
   linkType: hard
 
@@ -8538,28 +8451,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mqemitter@npm:^6.0.0":
-  version: 6.0.2
-  resolution: "mqemitter@npm:6.0.2"
-  dependencies:
-    fastparallel: "npm:^2.4.1"
-    qlobber: "npm:^8.0.1"
-  checksum: 10c0/11fa811d53b5cf7a7def3b9cc42c0bb11739da29bcde4b6df0e93395e605a98917847b99b50d709885af746f99060c0d6a327723bcc463ad79c2fa8575d526c8
-  languageName: node
-  linkType: hard
-
-"mqtt-packet@npm:^7.0.0":
-  version: 7.1.2
-  resolution: "mqtt-packet@npm:7.1.2"
-  dependencies:
-    bl: "npm:^4.0.2"
-    debug: "npm:^4.1.1"
-    process-nextick-args: "npm:^2.0.1"
-  checksum: 10c0/13d961d0a897c31c4548d134c2de7d3eb7f06e4964d7a385ef58d1e44cede315e6caf3b6c4ab0090b86e2bcd9221f7a8e94538c8730a4fe3bf6cd377b45ed394
-  languageName: node
-  linkType: hard
-
-"mqtt-packet@npm:^9.0.0, mqtt-packet@npm:^9.0.2":
+"mqtt-packet@npm:^9.0.2":
   version: 9.0.2
   resolution: "mqtt-packet@npm:9.0.2"
   dependencies:
@@ -9371,24 +9263,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qlobber@npm:^7.0.0":
-  version: 7.0.1
-  resolution: "qlobber@npm:7.0.1"
-  dependencies:
-    node-gyp: "npm:latest"
-  checksum: 10c0/a0f5c66b9a5507a9f8ea284a1ca2cadccf422a16b27f58f84886d901bd12d73dfb040bf9cb82c9707fe21c224fd776411a6d6d8720ebcd711b82c21e05c98663
-  languageName: node
-  linkType: hard
-
-"qlobber@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "qlobber@npm:8.0.1"
-  dependencies:
-    node-gyp: "npm:latest"
-  checksum: 10c0/97945cf6d1e956dface682678174b2ab7a6f376e1874eed3baedfb089254ed15cd559a9e2633955e9fea655589ea528b499576da35a1da632a9dd378d8f21ae1
-  languageName: node
-  linkType: hard
-
 "qs@npm:^6.11.2, qs@npm:~6.14.0":
   version: 6.14.0
   resolution: "qs@npm:6.14.0"
@@ -9579,15 +9453,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"retimer@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "retimer@npm:4.0.0"
-  dependencies:
-    worker-timers: "npm:^7.0.75"
-  checksum: 10c0/eb7a86fa6b3e52da16be9011fc8bb170d5e882a7015c8035c98d81fdd535f9828d3badd1c41cac375ed88cbe1e43c7122401861bf29a741a5bc7b27d6a89b826
-  languageName: node
-  linkType: hard
-
 "retry@npm:^0.12.0":
   version: 0.12.0
   resolution: "retry@npm:0.12.0"
@@ -9595,7 +9460,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reusify@npm:^1.0.0, reusify@npm:^1.0.4":
+"reusify@npm:^1.0.4":
   version: 1.1.0
   resolution: "reusify@npm:1.1.0"
   checksum: 10c0/4eff0d4a5f9383566c7d7ec437b671cc51b25963bd61bf127c3f3d3f68e44a026d99b8d2f1ad344afff8d278a8fe70a8ea092650a716d22287e8bef7126bb2fa
@@ -10806,13 +10671,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid-parse@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "uuid-parse@npm:1.1.0"
-  checksum: 10c0/513d5b0407b8929c54d452e8e286a1f6f00d40a2ebf6607fc7297b9caa40eee35230dcc4ce3f178f84d89704e8147e24d1a33d680a8afb7e12a5700714db7f51
-  languageName: node
-  linkType: hard
-
 "uuid@npm:11.1.0, uuid@npm:^11.1.0":
   version: 11.1.0
   resolution: "uuid@npm:11.1.0"
@@ -10822,30 +10680,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "uuid@npm:10.0.0"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 10c0/eab18c27fe4ab9fb9709a5d5f40119b45f2ec8314f8d4cf12ce27e4c6f4ffa4a6321dc7db6c515068fa373c075b49691ba969f0010bf37f44c37ca40cd6bf7fe
-  languageName: node
-  linkType: hard
-
 "uuid@npm:^3.2.1":
   version: 3.4.0
   resolution: "uuid@npm:3.4.0"
   bin:
     uuid: ./bin/uuid
   checksum: 10c0/1c13950df865c4f506ebfe0a24023571fa80edf2e62364297a537c80af09c618299797bbf2dbac6b1f8ae5ad182ba474b89db61e0e85839683991f7e08795347
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 10c0/bcbb807a917d374a49f475fae2e87fdca7da5e5530820ef53f65ba1d12131bd81a92ecf259cc7ce317cbe0f289e7d79fdfebcef9bfa3087c8c8a2fa304c9be54
   languageName: node
   linkType: hard
 
@@ -11019,18 +10859,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"worker-timers-broker@npm:^6.1.8":
-  version: 6.1.8
-  resolution: "worker-timers-broker@npm:6.1.8"
-  dependencies:
-    "@babel/runtime": "npm:^7.24.5"
-    fast-unique-numbers: "npm:^8.0.13"
-    tslib: "npm:^2.6.2"
-    worker-timers-worker: "npm:^7.0.71"
-  checksum: 10c0/95257411662bd4f23b17f33fc17872d61c4bfc5ea4f438c370b525d40dc33a4fd7d89e2efb60b38a6d42b5c6f36ab5a9ca8220a6dab1aabb2fc9b7346037dbb7
-  languageName: node
-  linkType: hard
-
 "worker-timers-broker@npm:^8.0.13":
   version: 8.0.13
   resolution: "worker-timers-broker@npm:8.0.13"
@@ -11044,16 +10872,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"worker-timers-worker@npm:^7.0.71":
-  version: 7.0.71
-  resolution: "worker-timers-worker@npm:7.0.71"
-  dependencies:
-    "@babel/runtime": "npm:^7.24.5"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/3e1eb4f500688540554bcd20d5abd4bceb80f2ee085aef6558a081c2fc3e1aa0dec9426e3f447cd811cd42a60d9ba13da951658378519f6ca4d2571c9bb525b5
-  languageName: node
-  linkType: hard
-
 "worker-timers-worker@npm:^9.0.11":
   version: 9.0.11
   resolution: "worker-timers-worker@npm:9.0.11"
@@ -11062,18 +10880,6 @@ __metadata:
     tslib: "npm:^2.8.1"
     worker-factory: "npm:^7.0.46"
   checksum: 10c0/32afbd7b6f57b18e3a35ff80bc4cd21abc1796caf8ea30571b59b66cca961598331eae12fb9ff993c28a2637b0557665a611db92a2c0334ba59ccdb67c83899c
-  languageName: node
-  linkType: hard
-
-"worker-timers@npm:^7.0.75":
-  version: 7.1.8
-  resolution: "worker-timers@npm:7.1.8"
-  dependencies:
-    "@babel/runtime": "npm:^7.24.5"
-    tslib: "npm:^2.6.2"
-    worker-timers-broker: "npm:^6.1.8"
-    worker-timers-worker: "npm:^7.0.71"
-  checksum: 10c0/ca36aee2bf7b9fd8a2d2c6da237f1bb8e6c9af09b14113532606966fd6c5df9cb903e321525a11d16642a8249e56e2d22c03ebbcb0cf69a23bb1e43f840dfe94
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

## Client

1.12.3+

## Fixes

- Bambu mqtt adapter should connect using mqtts
- Bambu FTP works with .3mf (as well as gcode), FDM Monster now supports 3mf upload for bambu printer types
- Bambu: implemented socket state emitting for test functionality
- PrusaLink: implemented socket state emitting for test functionality
- Bambu: download file implemented via FTP
- FDM-Monster API: file upload now checks file extension after upload (not during upload)