### PR TITLE
Tolerates printer deletion for camera streams

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -13,6 +13,7 @@
 - Floor service wouldn't update printer position, comparison was x==x, y==x
 - ExceptionFilter now logs using loggerFactory
 - YAML import service was brittle against printer type failures, added robustness
+- Camera should tolerate printer deletion: SET NULL applied to Foreign Key
 
 ## Chore
 - Remove batch/single set gcode analysis to false

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -23,6 +23,9 @@ import { RemovePrinterFile1720338804844 } from "@/migrations/1720338804844-Remov
 import { AddPrinterType1713897879622 } from "@/migrations/1713897879622-AddPrinterType";
 import { AddPrinterUsernamePassword1745141688926 } from "@/migrations/1745141688926-AddPrinterUsernamePassword";
 import { DropPermissions1766576698569 } from "@/migrations/1766576698569-DropPermissions";
+import {
+  ChangeCameraPrinterOnDeleteSetNull1767278216516
+} from "@/migrations/1767278216516-ChangeCameraPrinterOnDeleteSetNull";
 
 if (process.env.NODE_ENV !== "test") {
   dotenv.config({
@@ -63,6 +66,7 @@ export const AppDataSource = new DataSource({
     AddPrinterType1713897879622,
     AddPrinterUsernamePassword1745141688926,
     DropPermissions1766576698569,
+    ChangeCameraPrinterOnDeleteSetNull1767278216516
   ],
   subscribers: [],
 });

--- a/src/entities/camera-stream.entity.ts
+++ b/src/entities/camera-stream.entity.ts
@@ -12,7 +12,7 @@ export class CameraStream {
   @Column()
   name: string;
 
-  @OneToOne(() => Printer, { nullable: true })
+  @OneToOne(() => Printer, { nullable: true, onDelete: "SET NULL" })
   @JoinColumn({ name: "printerId" })
   printer?: Relation<Printer>;
   @Column({ nullable: true, unique: true })

--- a/src/migrations/1767278216516-ChangeCameraPrinterOnDeleteSetNull.ts
+++ b/src/migrations/1767278216516-ChangeCameraPrinterOnDeleteSetNull.ts
@@ -1,0 +1,179 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ChangeCameraPrinterOnDeleteSetNull1767278216516 implements MigrationInterface {
+    name = 'ChangeCameraPrinterOnDeleteSetNull1767278216516'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            CREATE TABLE "temporary_camera_stream" (
+                "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+                "streamURL" varchar NOT NULL,
+                "name" varchar NOT NULL,
+                "printerId" integer,
+                "aspectRatio" varchar NOT NULL DEFAULT ('16:9'),
+                "rotationClockwise" integer NOT NULL DEFAULT (0),
+                "flipHorizontal" boolean NOT NULL DEFAULT (0),
+                "flipVertical" boolean NOT NULL DEFAULT (0),
+                CONSTRAINT "UQ_565f1b0713258ce710e9fb48273" UNIQUE ("printerId")
+            )
+        `);
+        await queryRunner.query(`
+            INSERT INTO "temporary_camera_stream"(
+                    "id",
+                    "streamURL",
+                    "name",
+                    "printerId",
+                    "aspectRatio",
+                    "rotationClockwise",
+                    "flipHorizontal",
+                    "flipVertical"
+                )
+            SELECT "id",
+                "streamURL",
+                "name",
+                "printerId",
+                "aspectRatio",
+                "rotationClockwise",
+                "flipHorizontal",
+                "flipVertical"
+            FROM "camera_stream"
+        `);
+        await queryRunner.query(`
+            DROP TABLE "camera_stream"
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "temporary_camera_stream"
+                RENAME TO "camera_stream"
+        `);
+        await queryRunner.query(`
+            CREATE TABLE "temporary_camera_stream" (
+                "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+                "streamURL" varchar NOT NULL,
+                "name" varchar NOT NULL,
+                "printerId" integer,
+                "aspectRatio" varchar NOT NULL DEFAULT ('16:9'),
+                "rotationClockwise" integer NOT NULL DEFAULT (0),
+                "flipHorizontal" boolean NOT NULL DEFAULT (0),
+                "flipVertical" boolean NOT NULL DEFAULT (0),
+                CONSTRAINT "UQ_565f1b0713258ce710e9fb48273" UNIQUE ("printerId"),
+                CONSTRAINT "FK_565f1b0713258ce710e9fb48273" FOREIGN KEY ("printerId") REFERENCES "printer" ("id") ON DELETE
+                SET NULL ON UPDATE NO ACTION
+            )
+        `);
+        await queryRunner.query(`
+            INSERT INTO "temporary_camera_stream"(
+                    "id",
+                    "streamURL",
+                    "name",
+                    "printerId",
+                    "aspectRatio",
+                    "rotationClockwise",
+                    "flipHorizontal",
+                    "flipVertical"
+                )
+            SELECT "id",
+                "streamURL",
+                "name",
+                "printerId",
+                "aspectRatio",
+                "rotationClockwise",
+                "flipHorizontal",
+                "flipVertical"
+            FROM "camera_stream"
+        `);
+        await queryRunner.query(`
+            DROP TABLE "camera_stream"
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "temporary_camera_stream"
+                RENAME TO "camera_stream"
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "camera_stream"
+                RENAME TO "temporary_camera_stream"
+        `);
+        await queryRunner.query(`
+            CREATE TABLE "camera_stream" (
+                "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+                "streamURL" varchar NOT NULL,
+                "name" varchar NOT NULL,
+                "printerId" integer,
+                "aspectRatio" varchar NOT NULL DEFAULT ('16:9'),
+                "rotationClockwise" integer NOT NULL DEFAULT (0),
+                "flipHorizontal" boolean NOT NULL DEFAULT (0),
+                "flipVertical" boolean NOT NULL DEFAULT (0),
+                CONSTRAINT "UQ_565f1b0713258ce710e9fb48273" UNIQUE ("printerId")
+            )
+        `);
+        await queryRunner.query(`
+            INSERT INTO "camera_stream"(
+                    "id",
+                    "streamURL",
+                    "name",
+                    "printerId",
+                    "aspectRatio",
+                    "rotationClockwise",
+                    "flipHorizontal",
+                    "flipVertical"
+                )
+            SELECT "id",
+                "streamURL",
+                "name",
+                "printerId",
+                "aspectRatio",
+                "rotationClockwise",
+                "flipHorizontal",
+                "flipVertical"
+            FROM "temporary_camera_stream"
+        `);
+        await queryRunner.query(`
+            DROP TABLE "temporary_camera_stream"
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "camera_stream"
+                RENAME TO "temporary_camera_stream"
+        `);
+        await queryRunner.query(`
+            CREATE TABLE "camera_stream" (
+                "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+                "streamURL" varchar NOT NULL,
+                "name" varchar NOT NULL,
+                "printerId" integer,
+                "aspectRatio" varchar NOT NULL DEFAULT ('16:9'),
+                "rotationClockwise" integer NOT NULL DEFAULT (0),
+                "flipHorizontal" boolean NOT NULL DEFAULT (0),
+                "flipVertical" boolean NOT NULL DEFAULT (0),
+                CONSTRAINT "UQ_565f1b0713258ce710e9fb48273" UNIQUE ("printerId"),
+                CONSTRAINT "FK_565f1b0713258ce710e9fb48273" FOREIGN KEY ("printerId") REFERENCES "printer" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+            )
+        `);
+        await queryRunner.query(`
+            INSERT INTO "camera_stream"(
+                    "id",
+                    "streamURL",
+                    "name",
+                    "printerId",
+                    "aspectRatio",
+                    "rotationClockwise",
+                    "flipHorizontal",
+                    "flipVertical"
+                )
+            SELECT "id",
+                "streamURL",
+                "name",
+                "printerId",
+                "aspectRatio",
+                "rotationClockwise",
+                "flipHorizontal",
+                "flipVertical"
+            FROM "temporary_camera_stream"
+        `);
+        await queryRunner.query(`
+            DROP TABLE "temporary_camera_stream"
+        `);
+    }
+
+}


### PR DESCRIPTION
Ensures camera streams remain functional even after a printer is deleted.

This is achieved by setting the `onDelete` property to `SET NULL` on the foreign key relationship between `CameraStream` and `Printer`. A migration is included to update the database schema.

Relates to #4817