### PR TITLE
Improves PrintJob entity printer relation

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,13 +1,10 @@
 # Develop
 
-Fixes
-
-- PrintJob entity got in a migration loop
-
 ## Chores
 
 - Remove corepack from CICD as yarn is committed to repository
 - Switch docker container base to node 24
+- PrintJob entity printer relation improved
 
 # FDM Monster 2.0.1
 

--- a/src/entities/print-job.entity.ts
+++ b/src/entities/print-job.entity.ts
@@ -1,4 +1,13 @@
-import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Relation,
+  UpdateDateColumn
+} from "typeorm";
 import { Printer } from "@/entities/printer.entity";
 
 // Job lifecycle states (printing/queue related only)
@@ -154,9 +163,9 @@ export class PrintJob {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ManyToOne(() => Printer, { onDelete: "SET NULL" })
-  printer?: Printer;
-
+  @ManyToOne(() => Printer, { nullable: true, onDelete: "SET NULL" })
+  @JoinColumn({ name: "printerId" })
+  printer?: Relation<Printer>;
   @Column({ nullable: true })
   printerId: number | null;
 


### PR DESCRIPTION
Improves the PrintJob entity's relation to the Printer entity to prevent migration loops.

- Makes the printer relation nullable.
- Adds JoinColumn to explicitly define the foreign key relationship.