### PR TITLE
hotfix release 2.0.3 - updates default client minimum version

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,5 +1,11 @@
 # Develop
 
+# FDM Monster 2.0.3
+
+Hotfix release
+
+- Client wasn't updated to 2.2.0
+
 # FDM Monster 2.0.2
 
 ## Features

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "author": "David Zwart",
   "license": "AGPL-3.0-or-later",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "bin": {
     "fdm-monster-server": "dist/index.js",
     "fdmm-server": "dist/index.js"

--- a/src/server.constants.ts
+++ b/src/server.constants.ts
@@ -73,7 +73,7 @@ export const AppConstants = {
   orgName: "fdm-monster",
   // Wizard version changes will trigger a re-run of the wizard
   currentWizardVersion: 1,
-  defaultClientMinimum: "2.1.5",
+  defaultClientMinimum: "2.2.0",
 
   // Websocket values
   defaultWebsocketHandshakeTimeout: 3000,


### PR DESCRIPTION
Updates the default minimum client version to 2.2.0.

This hotfix release addresses an issue where the client was not updated to version 2.2.0.