### PR TITLE
Updates to version 2.0.7 with client 2.2.7

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,5 +1,7 @@
 # Develop
 
+# FDM Monster 2.0.7
+
 ## Fixes
 
 - Improves Bambu FTP file handling and print commands (file paths corrected for listings and print commands)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "author": "David Zwart",
   "license": "AGPL-3.0-or-later",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "bin": {
     "fdm-monster-server": "dist/index.js",
     "fdmm-server": "dist/index.js"
@@ -44,7 +44,6 @@
   },
   "keywords": [
     "fdm-monster",
-    "fdm-connector",
     "octoprint",
     "moonraker",
     "klipper",
@@ -54,13 +53,16 @@
     "3d printing",
     "pi",
     "node",
-    "vue"
+    "vue",
+    "MonsterPi",
+    "RaspberryPi",
+    "Unraid"
   ],
   "resolutions": {
     "tr46": "6.0.0"
   },
   "dependencies": {
-    "@fdm-monster/client-next": "2.2.6",
+    "@fdm-monster/client-next": "2.2.7",
     "@octokit/plugin-throttling": "8.2.0",
     "@sentry/node": "10.36.0",
     "adm-zip": "0.5.16",

--- a/src/server.constants.ts
+++ b/src/server.constants.ts
@@ -73,7 +73,7 @@ export const AppConstants = {
   orgName: "fdm-monster",
   // Wizard version changes will trigger a re-run of the wizard
   currentWizardVersion: 1,
-  defaultClientMinimum: "2.2.6",
+  defaultClientMinimum: "2.2.7",
 
   // Websocket values
   defaultWebsocketHandshakeTimeout: 3000,

--- a/yarn.lock
+++ b/yarn.lock
@@ -566,10 +566,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fdm-monster/client-next@npm:2.2.6":
-  version: 2.2.6
-  resolution: "@fdm-monster/client-next@npm:2.2.6"
-  checksum: 10c0/98628efa5b4362b63ef9366ead438c1456e7458dd4694497311b120366b725e53eda03622e76bd6423bdab1145a23dc646a9eebcc0bcb8d622f6022dc5e73031
+"@fdm-monster/client-next@npm:2.2.7":
+  version: 2.2.7
+  resolution: "@fdm-monster/client-next@npm:2.2.7"
+  checksum: 10c0/81bd43fbe88220015ff3a4cc1fd8564fa8c415a86b91b10685bd07f8f2bfe1ca53e41ca7c214d520bc5b02d2a7ffc6ea067e47c359ea4af0bf8aba44472ea8d6
   languageName: node
   linkType: hard
 
@@ -578,7 +578,7 @@ __metadata:
   resolution: "@fdm-monster/server@workspace:."
   dependencies:
     "@biomejs/biome": "npm:2.3.13"
-    "@fdm-monster/client-next": "npm:2.2.6"
+    "@fdm-monster/client-next": "npm:2.2.7"
     "@lcov-viewer/cli": "npm:1.3.0"
     "@lcov-viewer/istanbul-report": "npm:1.4.0"
     "@octokit/plugin-throttling": "npm:8.2.0"


### PR DESCRIPTION
# Description

Updates the server to version 2.0.7 and includes the corresponding client update to version 2.2.7. This release incorporates improvements to Bambu FTP file handling and print commands.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Vue test
- [ ] Node test 

**Test Configuration**:
* Node version:
* OctoPrint version:
* Klipper version:
* Nodemon/PM2/docker:

# Checklist:

- [x] I checked my changes
- [ ] I have commented my code concisely
- [ ] I have covered my changes with tests