### PR TITLE
fix: file search and recursive listing fallback

### DIFF
--- a/src/controllers/printer-files.controller.ts
+++ b/src/controllers/printer-files.controller.ts
@@ -60,8 +60,32 @@ export class PrinterFilesController {
     const { recursive: recursiveStr, startDir } = await validateInput(req.query, getFilesSchema);
     const recursive = recursiveStr === "true";
 
-    const files = await printerApi.getFiles(recursive, startDir);
+    const files = await this.getFilesWithRecursiveFallback(printerApi, recursive, startDir);
     res.send(files);
+  }
+
+  private async getFilesWithRecursiveFallback(
+    printerApi: IPrinterApi,
+    recursive: boolean,
+    startDir?: string,
+  ) {
+    try {
+      return await printerApi.getFiles(recursive, startDir);
+    } catch (error) {
+      if (!recursive || !this.isUnsupportedRecursiveError(error)) {
+        throw error;
+      }
+      this.logger.warn(
+        `Recursive listing unsupported for this printer. Falling back to non-recursive mode. ${errorSummary(error)}`,
+      );
+      return await printerApi.getFiles(false, startDir);
+    }
+  }
+
+  private isUnsupportedRecursiveError(error: unknown) {
+    const message =
+      error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+    return message.includes("recursive") && message.includes("not supported");
   }
 
   @POST()
@@ -161,7 +185,9 @@ export class PrinterFilesController {
         try {
           this.multerService.clearUploadedFile(uploadedFile);
         } catch (e) {
-          this.logger.error(`Could not remove uploaded file from temporary storage ${errorSummary(e)}`);
+          this.logger.error(
+            `Could not remove uploaded file from temporary storage ${errorSummary(e)}`,
+          );
         }
         throw e;
       });
@@ -192,7 +218,9 @@ export class PrinterFilesController {
 
       if (existingJob && existingJob.fileStorageId) {
         // Found duplicate by hash - REUSE existing storage file
-        const cachedMetadata = await this.fileStorageService.loadMetadata(existingJob.fileStorageId);
+        const cachedMetadata = await this.fileStorageService.loadMetadata(
+          existingJob.fileStorageId,
+        );
 
         if (cachedMetadata) {
           // Use cached metadata from JSON file (fastest - no re-analysis, no re-storage)
@@ -216,10 +244,17 @@ export class PrinterFilesController {
           fileStorageId = existingJob.fileStorageId; // REUSE existing storage!
 
           // Save metadata JSON for future deduplication (preserve original filename)
-          await this.fileStorageService.saveMetadata(fileStorageId, metadata, fileHash, uploadedFile.originalname);
+          await this.fileStorageService.saveMetadata(
+            fileStorageId,
+            metadata,
+            fileHash,
+            uploadedFile.originalname,
+          );
         } else {
           // Duplicate hash but not analyzed - reuse storage, analyze file
-          this.logger.log(`Duplicate file not analyzed - reusing storage ${existingJob.fileStorageId}, analyzing now`);
+          this.logger.log(
+            `Duplicate file not analyzed - reusing storage ${existingJob.fileStorageId}, analyzing now`,
+          );
 
           // Get existing file for analysis
           const existingFilePath = this.fileStorageService.getFilePath(existingJob.fileStorageId);
@@ -227,7 +262,12 @@ export class PrinterFilesController {
           metadata = analysisResult.metadata;
 
           fileStorageId = existingJob.fileStorageId; // REUSE existing storage!
-          await this.fileStorageService.saveMetadata(fileStorageId, metadata, fileHash, uploadedFile.originalname);
+          await this.fileStorageService.saveMetadata(
+            fileStorageId,
+            metadata,
+            fileHash,
+            uploadedFile.originalname,
+          );
           this.logger.log(`Analysis complete and cached: ${fileStorageId}`);
         }
       } else {
@@ -247,7 +287,10 @@ export class PrinterFilesController {
         // Save thumbnails
         let thumbnailMetadata: any[] = [];
         if (thumbnails.length > 0) {
-          thumbnailMetadata = await this.fileStorageService.saveThumbnails(fileStorageId, thumbnails);
+          thumbnailMetadata = await this.fileStorageService.saveThumbnails(
+            fileStorageId,
+            thumbnails,
+          );
           this.logger.log(`Saved ${thumbnailMetadata.length} thumbnail(s) for ${fileStorageId}`);
         }
 
@@ -297,7 +340,9 @@ export class PrinterFilesController {
       try {
         this.multerService.clearUploadedFile(uploadedFile);
       } catch (e) {
-        this.logger.error(`Could not remove uploaded file from temporary storage ${errorSummary(e)}`);
+        this.logger.error(
+          `Could not remove uploaded file from temporary storage ${errorSummary(e)}`,
+        );
       }
     }
 

--- a/src/services/file-storage.service.ts
+++ b/src/services/file-storage.service.ts
@@ -5,7 +5,17 @@ import { TypeormService } from "@/services/typeorm/typeorm.service";
 import { AppConstants } from "@/server.constants";
 import { getMediaPath } from "@/utils/fs.utils";
 import path, { basename, extname, join } from "node:path";
-import { mkdir, readdir, readFile, rename, rm, stat, unlink, writeFile, access } from "node:fs/promises";
+import {
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  unlink,
+  writeFile,
+  access,
+} from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { existsSync, createReadStream, statSync } from "node:fs";
 import { Readable } from "node:stream";
@@ -29,7 +39,9 @@ export interface IFileStorageService {
   loadMetadata(fileStorageId: string): Promise<any | null>;
   hasMetadata(fileStorageId: string): Promise<boolean>;
   getDeterministicId(fileHash: string, fileName: string): string;
-  findDuplicateByOriginalFileName(originalFileName: string): Promise<{ fileStorageId: string; metadata: any } | null>;
+  findDuplicateByOriginalFileName(
+    originalFileName: string,
+  ): Promise<{ fileStorageId: string; metadata: any } | null>;
   saveThumbnails(
     fileStorageId: string,
     thumbnails: Array<{ data?: string; format?: string; width?: number; height?: number }>,
@@ -457,7 +469,7 @@ export class FileStorageService implements IFileStorageService {
 
           files.push({
             fileStorageId: fileId,
-            fileName: metadata?._fileName || file,
+            fileName: metadata?._originalFileName || file,
             fileFormat: subdir,
             fileSize: stats.size,
             fileHash: metadata?._fileHash || "",

--- a/test/api/file-storage-controller.test.ts
+++ b/test/api/file-storage-controller.test.ts
@@ -37,29 +37,35 @@ describe("FileStorageController", () => {
     });
 
     vi.spyOn(fileStorageService, "calculateFileHash").mockResolvedValue("mock-hash-abc123");
-    vi.spyOn(fileStorageService, "getFilePath").mockImplementation((id: string) => `/mock/path/${id}`);
+    vi.spyOn(fileStorageService, "getFilePath").mockImplementation(
+      (id: string) => `/mock/path/${id}`,
+    );
     vi.spyOn(fileStorageService, "saveMetadata").mockResolvedValue(undefined);
     vi.spyOn(fileStorageService, "saveThumbnails").mockResolvedValue([]);
 
-    vi.spyOn(fileStorageService, "validateUniqueFilename").mockImplementation(async (filename: string) => {
-      if (uploadedFilenames.has(filename)) {
-        throw new ConflictException(
-          `A file named "${filename}" already exists in storage. Please rename the file, delete the existing file (ID: ${uploadedFilenames.get(filename)}), or choose a different name.`,
-          uploadedFilenames.get(filename),
-        );
-      }
-    });
+    vi.spyOn(fileStorageService, "validateUniqueFilename").mockImplementation(
+      async (filename: string) => {
+        if (uploadedFilenames.has(filename)) {
+          throw new ConflictException(
+            `A file named "${filename}" already exists in storage. Please rename the file, delete the existing file (ID: ${uploadedFilenames.get(filename)}), or choose a different name.`,
+            uploadedFilenames.get(filename),
+          );
+        }
+      },
+    );
 
-    vi.spyOn(fileStorageService, "findDuplicateByOriginalFileName").mockImplementation(async (filename: string) => {
-      const existingFileId = uploadedFilenames.get(filename);
-      if (existingFileId) {
-        return {
-          fileStorageId: existingFileId,
-          metadata: { _originalFileName: filename },
-        };
-      }
-      return null;
-    });
+    vi.spyOn(fileStorageService, "findDuplicateByOriginalFileName").mockImplementation(
+      async (filename: string) => {
+        const existingFileId = uploadedFilenames.get(filename);
+        if (existingFileId) {
+          return {
+            fileStorageId: existingFileId,
+            metadata: { _originalFileName: filename },
+          };
+        }
+        return null;
+      },
+    );
   });
 
   beforeEach(() => {
@@ -102,6 +108,29 @@ describe("FileStorageController", () => {
       expect(res.body.files.length).toBe(1);
       expect(res.body.files[0].fileName).toBe("test.gcode");
       expect(res.body.files[0].fileStorageId).toBe("file-123");
+    });
+
+    it("fileName should be the original name, not the internal storage UUID", async () => {
+      // Regression test: listAllFiles was using metadata._fileName (inexistent)
+      // instead of metadata._originalFileName, causing fileName to fall back to
+      // the raw UUID on disk. The search in the Files page never matched anything.
+      vi.spyOn(fileStorageService, "listAllFiles").mockResolvedValue([
+        {
+          fileStorageId: "5a83295c86b5593d05ea9b28f78435d1",
+          fileName: "02.Cara_0.4n_0.2mm_PLA_COREONEMMU3_59m.gcode",
+          fileFormat: "gcode",
+          fileSize: 10 * 1024 * 1024,
+          fileHash: "abc123",
+          createdAt: new Date(),
+          thumbnailCount: 0,
+          metadata: { _originalFileName: "02.Cara_0.4n_0.2mm_PLA_COREONEMMU3_59m.gcode" },
+        },
+      ]);
+
+      const res = await testRequest.get(baseRoute);
+      expectOkResponse(res);
+      expect(res.body.files[0].fileName).toBe("02.Cara_0.4n_0.2mm_PLA_COREONEMMU3_59m.gcode");
+      expect(res.body.files[0].fileName).not.toBe("5a83295c86b5593d05ea9b28f78435d1");
     });
   });
 
@@ -198,7 +227,11 @@ describe("FileStorageController", () => {
     });
 
     it("should handle files with special characters in name", async () => {
-      const specialNames = ["test with spaces.gcode", "test-with-dashes.gcode", "test_with_underscores.gcode"];
+      const specialNames = [
+        "test with spaces.gcode",
+        "test-with-dashes.gcode",
+        "test_with_underscores.gcode",
+      ];
 
       for (const name of specialNames) {
         const res = await uploadFile(name, SIMPLE_GCODE);

--- a/test/api/printer-files-controller.test.ts
+++ b/test/api/printer-files-controller.test.ts
@@ -72,6 +72,15 @@ describe(PrinterFilesController.name, () => {
     expectOkResponse(response, { dirs: [], files: [] });
   });
 
+  it("should fallback to non-recursive file listing when recursive mode is unsupported", async () => {
+    const bambuPrinter = await createTestBambuPrinter(request);
+
+    const response = await request.get(`${getFilesRoute(bambuPrinter.id)}?recursive=true`).send();
+
+    expectOkResponse(response);
+    expect(response.body.files.length).toBeGreaterThan(0);
+  });
+
   it("should retrieve file with hash character on GET for existing printer", async () => {
     const printer = await createTestPrinter(request);
     const filename = "test#.gcode";
@@ -88,7 +97,9 @@ describe(PrinterFilesController.name, () => {
           "content-disposition": "attachment; filename=test#.gcode",
         } as ReplyHeaders,
       );
-    const response = await request.get(downloadFileRoute(printer.id, encodeURIComponent(filename))).send();
+    const response = await request
+      .get(downloadFileRoute(printer.id, encodeURIComponent(filename)))
+      .send();
     expectOkResponse(response, reply0);
   });
 


### PR DESCRIPTION
# Description

Fixed two bugs affecting the Files page:

1. **File search always returned no results** — `listAllFiles()` was reading
   `metadata._fileName` which does not exist, causing `fileName` to fall back
   to the raw internal UUID on disk. The client-side filter compared against
   that UUID, so searching for any human-readable name never matched.

2. **Blank file list on Bambu/PrusaLink printers** — when the UI requested
   `recursive=true`, these printers throw "Recursive listing not supported",
   which propagated as an unhandled error and left the file list empty. A
   graceful fallback to `recursive=false` was added.

Fixes # (no open issue found)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added two regression tests:

- `file-storage-controller.test.ts`: asserts that `fileName` is the original
  human-readable name, not the internal storage UUID.
- `printer-files-controller.test.ts`: asserts that a recursive listing request
  against an unsupported printer still returns files via the non-recursive
  fallback.

- [x] Node test

**Test Configuration**:
* Node version: 22.22.2
* OctoPrint version: N/A
* Klipper version: N/A
* Nodemon/PM2/docker: Docker (dev profile)

# Checklist:

- [x] I checked my changes
- [x] I have commented my code concisely
- [x] I have covered my changes with tests