### PR TITLE
fix(bambu): drive error flag from gcode_state, not stale print_error

### DIFF
--- a/src/services/bambu/bambu-mqtt.adapter.ts
+++ b/src/services/bambu/bambu-mqtt.adapter.ts
@@ -422,27 +422,36 @@ export class BambuMqttAdapter implements IWebsocketAdapter {
   private transformStateToCurrentMessage(state: PrintData): any {
     const isPrinting = state.gcode_state === "PRINTING" || state.mc_print_stage === "printing";
     const isPaused = state.mc_print_stage === "paused";
+    const isFailed = state.gcode_state === "FAILED";
 
     // Check if connection is alive
     const isConnected = this.mqttClient?.connected || false;
-    const hasError = !isConnected || state.print_error !== 0;
+    // print_error is a side-channel hint that often carries non-zero stale codes when idle;
+    // gcode_state is the authoritative print-state machine. Use FAILED for the error flag,
+    // and surface print_error via debug logs so anomalies are still discoverable.
+    const hasError = !isConnected || isFailed;
+    if (state.print_error && state.print_error !== 0) {
+      this.logger.debug(
+        `Bambu print_error=${state.print_error} gcode_state=${state.gcode_state ?? "?"} (informational only)`,
+      );
+    }
 
     const isPausedText = isPaused ? "Paused" : "Printing";
 
     const onlineText = isPrinting ? isPausedText : "Operational";
     return {
       state: {
-        text: isConnected ? onlineText : "Offline",
+        text: isConnected ? (isFailed ? "Error" : onlineText) : "Offline",
         flags: {
-          operational: isConnected,
+          operational: isConnected && !isFailed,
           printing: isConnected && isPrinting && !isPaused,
           paused: isConnected && isPaused,
-          ready: isConnected && !isPrinting,
+          ready: isConnected && !isPrinting && !isFailed,
           error: hasError,
           cancelling: false,
           pausing: false,
           sdReady: isConnected,
-          closedOrError: !isConnected,
+          closedOrError: !isConnected || isFailed,
         },
       },
       temps: [


### PR DESCRIPTION
# Description

The state-flag derivation in `transformStateToCurrentMessage` triggered `error=true` whenever `state.print_error` was non-zero. That field can carry stale/historical codes while the printer is idle and operational, leading to:

- `ready=true` and `error=true` at the same time (mutually contradictory)
- the same printer counted in both **"Ready to Print"** and **"Offline / Issues"** tiles on the dashboard, and an OFFLINE badge in the Farm Status Overview while MQTT was actively connected and telemetry flowing

Drives the `error` flag from `gcode_state === "FAILED"` instead — Bambu's authoritative print-state machine — and propagates the same signal to `operational`, `ready`, and `closedOrError` so the flag set is internally consistent. `print_error` is still captured via debug log so a non-zero value remains discoverable for future investigation rather than silently shaping UI state.

Reproduced on a Bambu A1 running idle. Before/after on the same printer:

| Flag | Before | After |
|---|---|---|
| `text` | `"Operational"` | `"Operational"` |
| `operational` | `true` | `true` |
| `ready` | `true` | `true` |
| **`error`** | **`true`** | **`false`** |
| `closedOrError` | `false` | `false` |

<img width="2555" height="1132" alt="image" src="https://github.com/user-attachments/assets/3459a368-688c-4397-a0bc-b03f9ea7bfe5" />

<img width="2558" height="1279" alt="image" src="https://github.com/user-attachments/assets/dd2c5195-2fe7-4f0b-be3f-7a7454518797" />


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Node test — existing `test/application/bambu/` suite (32 tests) passes unchanged
- [ ] Vue test — N/A (server-side only)
- Manual verification against a live Bambu A1 over LAN: dashboard tile counts went from `Ready=1, Offline/Issues=1` to `Ready=1, Offline/Issues=0` after the fix, with no false OFFLINE badge

**Test Configuration**:
* Node version: v24.7.0
* OctoPrint version: N/A
* Klipper version: N/A
* Nodemon/PM2/docker: `yarn dev` (vite-plus watch mode) on Windows 10

# Checklist:

- [x] I checked my changes
- [x] I have commented my code concisely
- [ ] I have covered my changes with tests
