### PR TITLE
feat(auth): user-managed API keys for programmatic access

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "console:migrate": "tsx src/consoles/typeorm-migrate.ts"
   },
   "dependencies": {
-    "@fdm-monster/client-next": "2.3.4",
+    "@fdm-monster/client-next": "2.4.0",
     "@octokit/plugin-throttling": "11.0.3",
     "@sentry/node": "10.52.0",
     "adm-zip": "0.5.17",

--- a/src/container.tokens.ts
+++ b/src/container.tokens.ts
@@ -37,6 +37,7 @@ export const DITokens = {
   userTokenService: "userTokenService",
   authService: "authService",
   refreshTokenService: "refreshTokenService",
+  apiKeyService: "apiKeyService",
   userService: "userService",
   userRoleService: "userRoleService",
   permissionService: "permissionService",

--- a/src/container.ts
+++ b/src/container.ts
@@ -43,6 +43,7 @@ import { JwtService } from "./services/authentication/jwt.service";
 import { AuthService } from "./services/authentication/auth.service";
 import { throttling, ThrottlingOptions } from "@octokit/plugin-throttling";
 import { RefreshTokenService } from "@/services/orm/refresh-token.service";
+import { ApiKeyService } from "@/services/orm/api-key.service";
 import { SettingsService } from "@/services/orm/settings.service";
 import { FloorService } from "@/services/orm/floor.service";
 import { FloorPositionService } from "@/services/orm/floor-position.service";
@@ -99,6 +100,7 @@ export function configureContainer() {
     [di.printerMaintenanceLogService]: asClass(PrinterMaintenanceLogService),
     [di.printerTagService]: asClass(PrinterTagService),
     [di.refreshTokenService]: asClass(RefreshTokenService).singleton(),
+    [di.apiKeyService]: asClass(ApiKeyService).singleton(),
     [di.userService]: asClass(UserService).singleton(),
     [di.userRoleService]: asClass(UserRoleService).singleton(),
     [di.roleService]: asClass(RoleService).singleton(),

--- a/src/controllers/api-key.controller.ts
+++ b/src/controllers/api-key.controller.ts
@@ -1,0 +1,69 @@
+import { before, DELETE, GET, POST, route } from "awilix-express";
+import { authenticate } from "@/middleware/authenticate";
+import { demoUserNotAllowed } from "@/middleware/demo.middleware";
+import { AppConstants } from "@/server.constants";
+import { validateInput, validateMiddleware } from "@/handlers/validators";
+import { apiKeyIdParamSchema, createApiKeySchema } from "@/controllers/validation/api-key-controller.validation";
+import type { ILoggerFactory } from "@/handlers/logger-factory";
+import { LoggerService } from "@/handlers/logger";
+import type { Request, Response } from "express";
+import type { IApiKeyService } from "@/services/interfaces/api-key.service.interface";
+import { AuthenticationError } from "@/exceptions/runtime.exceptions";
+
+/**
+ * Per-user API key management.
+ *
+ * The whole controller is gated by `authenticate()` + `demoUserNotAllowed`:
+ *   - You must be a real, logged-in user to mint or list keys.
+ *   - Demo users can't create persistent state.
+ *
+ * Authorisation is per-user: a user only ever sees their own keys. The
+ * service layer enforces the userId scope on every operation.
+ */
+@route(AppConstants.apiRoute + "/api-keys")
+@before([authenticate(), demoUserNotAllowed])
+export class ApiKeyController {
+  private readonly logger: LoggerService;
+
+  constructor(
+    loggerFactory: ILoggerFactory,
+    private readonly apiKeyService: IApiKeyService,
+  ) {
+    this.logger = loggerFactory(ApiKeyController.name);
+  }
+
+  @GET()
+  @route("/")
+  async list(req: Request, res: Response) {
+    const userId = this.requireUserId(req);
+    const keys = await this.apiKeyService.listForUser(userId);
+    res.send(keys);
+  }
+
+  @POST()
+  @route("/")
+  async create(req: Request, res: Response) {
+    const userId = this.requireUserId(req);
+    const { label } = await validateMiddleware(req, createApiKeySchema);
+    const created = await this.apiKeyService.createForUser(userId, label);
+    res.send(created);
+  }
+
+  @DELETE()
+  @route("/:id")
+  async revoke(req: Request, res: Response) {
+    const userId = this.requireUserId(req);
+    const { id } = await validateInput(req.params, apiKeyIdParamSchema);
+    const revoked = await this.apiKeyService.revokeForUser(userId, id);
+    res.send(revoked);
+  }
+
+  private requireUserId(req: Request): number {
+    const id = req.user?.id;
+    if (!id) {
+      // Should never happen given the @before guards, but defend the boundary.
+      throw new AuthenticationError("Authenticated user is required");
+    }
+    return id;
+  }
+}

--- a/src/controllers/api-key.controller.ts
+++ b/src/controllers/api-key.controller.ts
@@ -1,42 +1,29 @@
 import { before, DELETE, GET, POST, route } from "awilix-express";
-import { authenticate } from "@/middleware/authenticate";
+import { authenticate, authorizeRoles } from "@/middleware/authenticate";
 import { demoUserNotAllowed } from "@/middleware/demo.middleware";
+import { ROLES } from "@/constants/authorization.constants";
 import { AppConstants } from "@/server.constants";
 import { validateInput, validateMiddleware } from "@/handlers/validators";
 import { apiKeyIdParamSchema, createApiKeySchema } from "@/controllers/validation/api-key-controller.validation";
-import type { ILoggerFactory } from "@/handlers/logger-factory";
-import { LoggerService } from "@/handlers/logger";
 import type { Request, Response } from "express";
 import type { IApiKeyService } from "@/services/interfaces/api-key.service.interface";
 import { AuthenticationError } from "@/exceptions/runtime.exceptions";
 
 /**
- * Per-user API key management.
- *
- * The whole controller is gated by `authenticate()` + `demoUserNotAllowed`:
- *   - You must be a real, logged-in user to mint or list keys.
- *   - Demo users can't create persistent state.
- *
- * Authorisation is per-user: a user only ever sees their own keys. The
- * service layer enforces the userId scope on every operation.
+ * Admin-only API key management. Keys are m2m credentials with their own
+ * role assignment (stored in the `api_key_role` join table); they are NOT
+ * user impersonation tokens. The `userId` FK on each key records who minted
+ * it, not whose permissions the key holds.
  */
 @route(AppConstants.apiRoute + "/api-keys")
-@before([authenticate(), demoUserNotAllowed])
+@before([authenticate(), authorizeRoles([ROLES.ADMIN]), demoUserNotAllowed])
 export class ApiKeyController {
-  private readonly logger: LoggerService;
-
-  constructor(
-    loggerFactory: ILoggerFactory,
-    private readonly apiKeyService: IApiKeyService,
-  ) {
-    this.logger = loggerFactory(ApiKeyController.name);
-  }
+  constructor(private readonly apiKeyService: IApiKeyService) {}
 
   @GET()
   @route("/")
-  async list(req: Request, res: Response) {
-    const userId = this.requireUserId(req);
-    const keys = await this.apiKeyService.listForUser(userId);
+  async list(_req: Request, res: Response) {
+    const keys = await this.apiKeyService.list();
     res.send(keys);
   }
 
@@ -44,24 +31,25 @@ export class ApiKeyController {
   @route("/")
   async create(req: Request, res: Response) {
     const userId = this.requireUserId(req);
-    const { label } = await validateMiddleware(req, createApiKeySchema);
-    const created = await this.apiKeyService.createForUser(userId, label);
+    const { label, roleIds } = await validateMiddleware(req, createApiKeySchema);
+    const created = await this.apiKeyService.create(userId, label, roleIds);
     res.send(created);
   }
 
   @DELETE()
   @route("/:id")
-  async revoke(req: Request, res: Response) {
-    const userId = this.requireUserId(req);
+  async delete(req: Request, res: Response) {
     const { id } = await validateInput(req.params, apiKeyIdParamSchema);
-    const revoked = await this.apiKeyService.revokeForUser(userId, id);
-    res.send(revoked);
+    await this.apiKeyService.delete(id);
+    res.status(204).send();
   }
 
   private requireUserId(req: Request): number {
+    // Reachable when loginRequired=false (passport-anonymous falls through
+    // without setting req.user); the @before authorizeRoles guard then
+    // refuses, but defend the boundary anyway in case the chain is changed.
     const id = req.user?.id;
-    if (!id) {
-      // Should never happen given the @before guards, but defend the boundary.
+    if (!id || id < 0) {
       throw new AuthenticationError("Authenticated user is required");
     }
     return id;

--- a/src/controllers/api-key.controller.ts
+++ b/src/controllers/api-key.controller.ts
@@ -12,8 +12,8 @@ import { AuthenticationError } from "@/exceptions/runtime.exceptions";
 /**
  * Admin-only API key management. Keys are m2m credentials with their own
  * role assignment (stored in the `api_key_role` join table); they are NOT
- * user impersonation tokens. The `userId` FK on each key records who minted
- * it, not whose permissions the key holds.
+ * user impersonation tokens. `createdByUserId` is audit-only — it records
+ * who minted the key, not whose permissions the key holds.
  */
 @route(AppConstants.apiRoute + "/api-keys")
 @before([authenticate(), authorizeRoles([ROLES.ADMIN]), demoUserNotAllowed])
@@ -30,9 +30,9 @@ export class ApiKeyController {
   @POST()
   @route("/")
   async create(req: Request, res: Response) {
-    const userId = this.requireUserId(req);
+    const createdByUserId = this.requireUserId(req);
     const { label, roleIds } = await validateMiddleware(req, createApiKeySchema);
-    const created = await this.apiKeyService.create(userId, label, roleIds);
+    const created = await this.apiKeyService.create(createdByUserId, label, roleIds);
     res.send(created);
   }
 

--- a/src/controllers/validation/api-key-controller.validation.ts
+++ b/src/controllers/validation/api-key-controller.validation.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createApiKeySchema = z.object({
+  label: z.string().trim().min(1, "label is required").max(80, "label too long (max 80 chars)"),
+});
+
+export const apiKeyIdParamSchema = z.object({
+  id: z.coerce.number().int().positive(),
+});

--- a/src/controllers/validation/api-key-controller.validation.ts
+++ b/src/controllers/validation/api-key-controller.validation.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export const createApiKeySchema = z.object({
   label: z.string().trim().min(1, "label is required").max(80, "label too long (max 80 chars)"),
+  roleIds: z.array(z.number().int().positive()).min(1, "at least one role is required"),
 });
 
 export const apiKeyIdParamSchema = z.object({

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -5,7 +5,7 @@ import { Floor } from "@/entities/floor.entity";
 import { FloorPosition } from "@/entities/floor-position.entity";
 import { Printer } from "@/entities/printer.entity";
 import { Settings } from "@/entities/settings.entity";
-import { PrintJob, RefreshToken, User, PrinterMaintenanceLog } from "@/entities";
+import { PrintJob, RefreshToken, User, PrinterMaintenanceLog, ApiKey } from "@/entities";
 import { CameraStream } from "@/entities/camera-stream.entity";
 import { Role } from "@/entities/role.entity";
 import { UserRole } from "@/entities/user-role.entity";
@@ -27,6 +27,7 @@ import { ChangeFloorNonUniqueOrder1767370191762 } from "@/migrations/17673701917
 import { RenameGroupToTag1767432108916 } from "@/migrations/1767432108916-RenameGroupToTag";
 import { AddPrintJob1767451444137 } from "@/migrations/1767451444137-AddPrintJob";
 import { AddPrinterMaintenanceLog1767909428129 } from "@/migrations/1767909428129-AddPrinterMaintenanceLog";
+import { AddApiKey1778446203015 } from "@/migrations/1778446203015-AddApiKey";
 
 const databaseFilePath = getDatabaseFilePath();
 
@@ -49,6 +50,7 @@ export const AppDataSource = new DataSource({
     PrinterTag,
     PrintJob,
     PrinterMaintenanceLog,
+    ApiKey,
   ],
   migrations: [
     InitSqlite1706829146617,
@@ -67,6 +69,7 @@ export const AppDataSource = new DataSource({
     RenameGroupToTag1767432108916,
     AddPrintJob1767451444137,
     AddPrinterMaintenanceLog1767909428129,
+    AddApiKey1778446203015,
   ],
   subscribers: [],
 });

--- a/src/entities/api-key.entity.ts
+++ b/src/entities/api-key.entity.ts
@@ -16,7 +16,7 @@ import { Role } from "@/entities/role.entity";
 /**
  * Long-lived bearer credential for programmatic API access.
  *
- * Token format: `fdmm_pat_<base64url>` (high-entropy CSPRNG). The `prefix`
+ * Token format: `fdmm_api_<base64url>` (high-entropy CSPRNG). The `prefix`
  * is the indexable lookup column; `hashedSecret` is sha256 of the full
  * token, verified with timingSafeEqual.
  *

--- a/src/entities/api-key.entity.ts
+++ b/src/entities/api-key.entity.ts
@@ -21,8 +21,8 @@ import { Role } from "@/entities/role.entity";
  * token, verified with timingSafeEqual.
  *
  * Permissions are derived from `roles` (via the `api_key_role` join table),
- * NOT from the bound user's roles. The `userId` FK records who minted the
- * key for audit; it does not drive authorisation.
+ * NOT from the bound user's roles. `createdByUserId` is audit-only — it
+ * records who minted the key and does not drive authorisation.
  */
 @Entity()
 export class ApiKey {
@@ -30,11 +30,11 @@ export class ApiKey {
   id: number;
 
   @ManyToOne(() => User, { nullable: false, onDelete: "CASCADE" })
-  @JoinColumn({ name: "userId" })
-  user: Relation<User>;
+  @JoinColumn({ name: "createdByUserId" })
+  createdByUser: Relation<User>;
 
   @Column()
-  userId: number;
+  createdByUserId: number;
 
   @Column()
   label: string;

--- a/src/entities/api-key.entity.ts
+++ b/src/entities/api-key.entity.ts
@@ -1,0 +1,54 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  type Relation,
+} from "typeorm";
+import { User } from "@/entities/user.entity";
+
+/**
+ * Long-lived bearer credential for programmatic API access.
+ *
+ * The cleartext token is shown to the user once at creation time and never
+ * stored. We persist:
+ *   - a fixed `prefix` (token's leading characters) for O(1) lookup, and
+ *   - `hashedSecret` (sha256 of the full token) for verification.
+ *
+ * Tokens inherit the role/permissions of the bound user. Revoking a key
+ * sets `revokedAt`; revoked rows are kept for audit and never re-issue.
+ */
+@Entity()
+export class ApiKey {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => User, { nullable: false, onDelete: "CASCADE" })
+  @JoinColumn({ name: "userId" })
+  user: Relation<User>;
+
+  @Column()
+  userId: number;
+
+  @Column()
+  label: string;
+
+  @Index()
+  @Column({ unique: true })
+  prefix: string;
+
+  @Column()
+  hashedSecret: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @Column({ type: "datetime", nullable: true })
+  lastUsedAt: Date | null;
+
+  @Column({ type: "datetime", nullable: true })
+  revokedAt: Date | null;
+}

--- a/src/entities/api-key.entity.ts
+++ b/src/entities/api-key.entity.ts
@@ -4,22 +4,25 @@ import {
   Entity,
   Index,
   JoinColumn,
+  JoinTable,
+  ManyToMany,
   ManyToOne,
   PrimaryGeneratedColumn,
   type Relation,
 } from "typeorm";
 import { User } from "@/entities/user.entity";
+import { Role } from "@/entities/role.entity";
 
 /**
  * Long-lived bearer credential for programmatic API access.
  *
- * The cleartext token is shown to the user once at creation time and never
- * stored. We persist:
- *   - a fixed `prefix` (token's leading characters) for O(1) lookup, and
- *   - `hashedSecret` (sha256 of the full token) for verification.
+ * Token format: `fdmm_pat_<base64url>` (high-entropy CSPRNG). The `prefix`
+ * is the indexable lookup column; `hashedSecret` is sha256 of the full
+ * token, verified with timingSafeEqual.
  *
- * Tokens inherit the role/permissions of the bound user. Revoking a key
- * sets `revokedAt`; revoked rows are kept for audit and never re-issue.
+ * Permissions are derived from `roles` (via the `api_key_role` join table),
+ * NOT from the bound user's roles. The `userId` FK records who minted the
+ * key for audit; it does not drive authorisation.
  */
 @Entity()
 export class ApiKey {
@@ -49,6 +52,11 @@ export class ApiKey {
   @Column({ type: "datetime", nullable: true })
   lastUsedAt: Date | null;
 
-  @Column({ type: "datetime", nullable: true })
-  revokedAt: Date | null;
+  @ManyToMany(() => Role, { eager: true })
+  @JoinTable({
+    name: "api_key_role",
+    joinColumn: { name: "apiKeyId", referencedColumnName: "id" },
+    inverseJoinColumn: { name: "roleId", referencedColumnName: "id" },
+  })
+  roles: Relation<Role>[];
 }

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -11,3 +11,4 @@ export { PrinterTag } from "./printer-tag.entity";
 export { Tag } from "./tag.entity";
 export { PrintJob } from "./print-job.entity";
 export { PrinterMaintenanceLog } from "./printer-maintenance-log.entity";
+export { ApiKey } from "./api-key.entity";

--- a/src/middleware/api-key.strategy.ts
+++ b/src/middleware/api-key.strategy.ts
@@ -1,0 +1,50 @@
+import { Strategy } from "passport";
+import type { Request } from "express";
+import type { IApiKeyService } from "@/services/interfaces/api-key.service.interface";
+import type { IUserService } from "@/services/interfaces/user-service.interface";
+
+/**
+ * Passport strategy that authenticates a request using a long-lived API key
+ * bearer token (prefix `fdmm_pat_`). Slotted between the JWT and Anonymous
+ * strategies so a request with no auth header still flows through to the
+ * anonymous fallback unchanged.
+ *
+ * On success, sets `req.user` to the same user DTO shape the JWT strategy
+ * produces — so downstream `interceptRoles` / `authenticate()` /
+ * `permission()` middleware works without changes.
+ */
+export class ApiKeyStrategy extends Strategy {
+  name = "api-key";
+
+  constructor(
+    private readonly apiKeyService: IApiKeyService,
+    private readonly userService: IUserService,
+  ) {
+    super();
+  }
+
+  async authenticate(req: Request, _options?: any): Promise<void> {
+    const header = req.headers.authorization;
+    const token = header?.startsWith("Bearer ") ? header.slice("Bearer ".length) : undefined;
+    if (!token || !this.apiKeyService.looksLikeApiKey(token)) {
+      // Not our token format — let the next strategy try.
+      return this.pass();
+    }
+
+    try {
+      const apiKey = await this.apiKeyService.verify(token);
+      if (!apiKey) {
+        // Looked like an API key but didn't verify — fail (don't fall through
+        // to anonymous, since the caller clearly intended bearer auth).
+        return this.fail({ message: "Invalid API key" }, 401);
+      }
+      const user = await this.userService.getUser(apiKey.userId);
+      if (!user?.isVerified) {
+        return this.fail({ message: "API key user is not verified" }, 401);
+      }
+      return this.success(this.userService.toDto(user));
+    } catch (err) {
+      return this.error(err as Error);
+    }
+  }
+}

--- a/src/middleware/api-key.strategy.ts
+++ b/src/middleware/api-key.strategy.ts
@@ -44,7 +44,10 @@ export class ApiKeyStrategy extends Strategy {
       }
       return this.success(this.userService.toDto(user));
     } catch (err) {
-      return this.error(err as Error);
+      // `passport.Strategy.error()` is typed `(err: Error)`. Defend against a
+      // non-Error throw (e.g. a string from a misbehaving dependency) instead
+      // of a bare type assertion.
+      return this.error(err instanceof Error ? err : new Error(String(err)));
     }
   }
 }

--- a/src/middleware/api-key.strategy.ts
+++ b/src/middleware/api-key.strategy.ts
@@ -10,8 +10,8 @@ import type { RoleName } from "@/constants/authorization.constants";
  *
  * Important: we do NOT look up the bound user. The api_key_role join is the
  * sole permission source for the request — keys are self-contained credentials,
- * not user impersonation. `req.user.id = -1` is a sentinel; downstream audit
- * code can branch on it if it needs an api-key-aware identity.
+ * not user impersonation. `req.user.isApiKey === true` and `req.user.id = -1`
+ * are how downstream audit/branching code can detect an api-key principal.
  */
 export class ApiKeyStrategy extends Strategy {
   name = "api-key";
@@ -41,6 +41,7 @@ export class ApiKeyStrategy extends Strategy {
         needsPasswordChange: false,
         createdAt: apiKey.createdAt,
         roles: (apiKey.roles ?? []).map((r) => r.name as RoleName),
+        isApiKey: true,
       };
       return this.success(principal);
     } catch (err) {

--- a/src/middleware/api-key.strategy.ts
+++ b/src/middleware/api-key.strategy.ts
@@ -1,25 +1,22 @@
 import { Strategy } from "passport";
 import type { Request } from "express";
 import type { IApiKeyService } from "@/services/interfaces/api-key.service.interface";
-import type { IUserService } from "@/services/interfaces/user-service.interface";
+import type { UserDto } from "@/services/interfaces/user.dto";
+import type { RoleName } from "@/constants/authorization.constants";
 
 /**
- * Passport strategy that authenticates a request using a long-lived API key
- * bearer token (prefix `fdmm_pat_`). Slotted between the JWT and Anonymous
- * strategies so a request with no auth header still flows through to the
- * anonymous fallback unchanged.
+ * Passport strategy for API-key bearer auth. Slotted between JWT and Anonymous
+ * so a request with no auth header still falls through to anonymous.
  *
- * On success, sets `req.user` to the same user DTO shape the JWT strategy
- * produces — so downstream `interceptRoles` / `authenticate()` /
- * `permission()` middleware works without changes.
+ * Important: we do NOT look up the bound user. The api_key_role join is the
+ * sole permission source for the request — keys are self-contained credentials,
+ * not user impersonation. `req.user.id = -1` is a sentinel; downstream audit
+ * code can branch on it if it needs an api-key-aware identity.
  */
 export class ApiKeyStrategy extends Strategy {
   name = "api-key";
 
-  constructor(
-    private readonly apiKeyService: IApiKeyService,
-    private readonly userService: IUserService,
-  ) {
+  constructor(private readonly apiKeyService: IApiKeyService) {
     super();
   }
 
@@ -27,26 +24,26 @@ export class ApiKeyStrategy extends Strategy {
     const header = req.headers.authorization;
     const token = header?.startsWith("Bearer ") ? header.slice("Bearer ".length) : undefined;
     if (!token || !this.apiKeyService.looksLikeApiKey(token)) {
-      // Not our token format — let the next strategy try.
       return this.pass();
     }
 
     try {
       const apiKey = await this.apiKeyService.verify(token);
       if (!apiKey) {
-        // Looked like an API key but didn't verify — fail (don't fall through
-        // to anonymous, since the caller clearly intended bearer auth).
         return this.fail({ message: "Invalid API key" }, 401);
       }
-      const user = await this.userService.getUser(apiKey.userId);
-      if (!user?.isVerified) {
-        return this.fail({ message: "API key user is not verified" }, 401);
-      }
-      return this.success(this.userService.toDto(user));
+      const principal: UserDto = {
+        id: -1,
+        username: `api-key:${apiKey.id}`,
+        isDemoUser: false,
+        isRootUser: false,
+        isVerified: true,
+        needsPasswordChange: false,
+        createdAt: apiKey.createdAt,
+        roles: (apiKey.roles ?? []).map((r) => r.name as RoleName),
+      };
+      return this.success(principal);
     } catch (err) {
-      // `passport.Strategy.error()` is typed `(err: Error)`. Defend against a
-      // non-Error throw (e.g. a string from a misbehaving dependency) instead
-      // of a bare type assertion.
       return this.error(err instanceof Error ? err : new Error(String(err)));
     }
   }

--- a/src/middleware/passport.ts
+++ b/src/middleware/passport.ts
@@ -79,7 +79,7 @@ export function initializePassportStrategies(passport: PassportStatic, container
       verifyUserCallback(userService)(jwt_payload, done);
     }),
   );
-  passport.use(new ApiKeyStrategy(apiKeyService, userService));
+  passport.use(new ApiKeyStrategy(apiKeyService));
   passport.use(new AnonymousStrategy());
   return passport;
 }

--- a/src/middleware/passport.ts
+++ b/src/middleware/passport.ts
@@ -13,10 +13,12 @@ import { PassportStatic } from "passport";
 import { SettingsStore } from "@/state/settings.store";
 import { ConfigService } from "@/services/core/config.service";
 import type { IUserService } from "@/services/interfaces/user-service.interface";
+import type { IApiKeyService } from "@/services/interfaces/api-key.service.interface";
 import { Socket } from "socket.io";
 import { AuthenticationError } from "@/exceptions/runtime.exceptions";
 import { AUTH_ERROR_REASON } from "@/constants/authorization.constants";
 import { User } from "@/entities";
+import { ApiKeyStrategy } from "@/middleware/api-key.strategy";
 
 export type JwtFromSocketFunction = (socket: Socket) => string | null;
 
@@ -68,6 +70,7 @@ export function initializePassportStrategies(passport: PassportStatic, container
   const settingsStore = container.resolve<SettingsStore>(DITokens.settingsStore);
   const configService = container.resolve<ConfigService>(DITokens.configService);
   const userService = container.resolve<IUserService>(DITokens.userService);
+  const apiKeyService = container.resolve<IApiKeyService>(DITokens.apiKeyService);
 
   const opts = getPassportJwtOptions(settingsStore, configService, ExtractJwt.fromAuthHeaderAsBearerToken());
 
@@ -76,6 +79,7 @@ export function initializePassportStrategies(passport: PassportStatic, container
       verifyUserCallback(userService)(jwt_payload, done);
     }),
   );
+  passport.use(new ApiKeyStrategy(apiKeyService, userService));
   passport.use(new AnonymousStrategy());
   return passport;
 }

--- a/src/migrations/1778446203015-AddApiKey.ts
+++ b/src/migrations/1778446203015-AddApiKey.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddApiKey1778446203015 implements MigrationInterface {
+  name = "AddApiKey1778446203015";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "api_key"
+      (
+        "id"           integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+        "userId"       integer                           NOT NULL,
+        "label"        varchar                           NOT NULL,
+        "prefix"       varchar                           NOT NULL,
+        "hashedSecret" varchar                           NOT NULL,
+        "createdAt"    datetime                          NOT NULL DEFAULT (datetime('now')),
+        "lastUsedAt"   datetime,
+        "revokedAt"    datetime,
+        CONSTRAINT "FK_api_key_user" FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+      )
+    `);
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "IDX_api_key_prefix" ON "api_key" ("prefix")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_api_key_prefix"`);
+    await queryRunner.query(`DROP TABLE "api_key"`);
+  }
+}

--- a/src/migrations/1778446203015-AddApiKey.ts
+++ b/src/migrations/1778446203015-AddApiKey.ts
@@ -7,14 +7,14 @@ export class AddApiKey1778446203015 implements MigrationInterface {
     await queryRunner.query(`
       CREATE TABLE "api_key"
       (
-        "id"           integer PRIMARY KEY AUTOINCREMENT NOT NULL,
-        "userId"       integer                           NOT NULL,
-        "label"        varchar                           NOT NULL,
-        "prefix"       varchar                           NOT NULL,
-        "hashedSecret" varchar                           NOT NULL,
-        "createdAt"    datetime                          NOT NULL DEFAULT (datetime('now')),
-        "lastUsedAt"   datetime,
-        CONSTRAINT "FK_api_key_user" FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+        "id"                integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+        "createdByUserId"   integer                           NOT NULL,
+        "label"             varchar                           NOT NULL,
+        "prefix"            varchar                           NOT NULL,
+        "hashedSecret"      varchar                           NOT NULL,
+        "createdAt"         datetime                          NOT NULL DEFAULT (datetime('now')),
+        "lastUsedAt"        datetime,
+        CONSTRAINT "FK_api_key_created_by_user" FOREIGN KEY ("createdByUserId") REFERENCES "user" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
       )
     `);
     await queryRunner.query(`

--- a/src/migrations/1778446203015-AddApiKey.ts
+++ b/src/migrations/1778446203015-AddApiKey.ts
@@ -14,16 +14,34 @@ export class AddApiKey1778446203015 implements MigrationInterface {
         "hashedSecret" varchar                           NOT NULL,
         "createdAt"    datetime                          NOT NULL DEFAULT (datetime('now')),
         "lastUsedAt"   datetime,
-        "revokedAt"    datetime,
         CONSTRAINT "FK_api_key_user" FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
       )
     `);
     await queryRunner.query(`
       CREATE UNIQUE INDEX "IDX_api_key_prefix" ON "api_key" ("prefix")
     `);
+    await queryRunner.query(`
+      CREATE TABLE "api_key_role"
+      (
+        "apiKeyId" integer NOT NULL,
+        "roleId"   integer NOT NULL,
+        PRIMARY KEY ("apiKeyId", "roleId"),
+        CONSTRAINT "FK_api_key_role_api_key" FOREIGN KEY ("apiKeyId") REFERENCES "api_key" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+        CONSTRAINT "FK_api_key_role_role"    FOREIGN KEY ("roleId")   REFERENCES "role"    ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+      )
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "IDX_api_key_role_apiKeyId" ON "api_key_role" ("apiKeyId")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "IDX_api_key_role_roleId" ON "api_key_role" ("roleId")
+    `);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_api_key_role_roleId"`);
+    await queryRunner.query(`DROP INDEX "IDX_api_key_role_apiKeyId"`);
+    await queryRunner.query(`DROP TABLE "api_key_role"`);
     await queryRunner.query(`DROP INDEX "IDX_api_key_prefix"`);
     await queryRunner.query(`DROP TABLE "api_key"`);
   }

--- a/src/server.constants.ts
+++ b/src/server.constants.ts
@@ -73,7 +73,7 @@ export const AppConstants = {
   orgName: "fdm-monster",
   // Wizard version changes will trigger a re-run of the wizard
   currentWizardVersion: 1,
-  defaultClientMinimum: "2.3.3",
+  defaultClientMinimum: "2.4.0",
 
   // Websocket values
   defaultWebsocketHandshakeTimeout: 3000,

--- a/src/server.core.ts
+++ b/src/server.core.ts
@@ -74,7 +74,7 @@ export async function setupServer() {
     .use(cookieParser())
     .use(urlencoded({ extended: false }))
     .use(passport.initialize())
-    .use(passport.authenticate(["jwt", "anonymous"], { session: false }))
+    .use(passport.authenticate(["jwt", "api-key", "anonymous"], { session: false }))
     .use(scopePerRequest(container))
     .use(interceptDatabaseError)
     // Global guards

--- a/src/services/interfaces/api-key.dto.ts
+++ b/src/services/interfaces/api-key.dto.ts
@@ -1,7 +1,7 @@
 /** Public DTO. Never includes the cleartext token or the stored hash. */
 export class ApiKeyDto {
   id!: number;
-  userId!: number;
+  createdByUserId!: number;
   label!: string;
   prefix!: string;
   createdAt!: Date;

--- a/src/services/interfaces/api-key.dto.ts
+++ b/src/services/interfaces/api-key.dto.ts
@@ -1,12 +1,4 @@
-/**
- * Public DTO. Never includes the cleartext token or the stored hash.
- *
- * The `prefix` is intentionally returned so the UI can disambiguate keys when
- * the user has several active — it's the same fixed-width leading segment of
- * the original token they were shown at creation time. Declared as a class
- * (not interface) so it can be passed to BaseService() as a constructor
- * argument, matching the existing pattern in RefreshTokenDto / UserDto.
- */
+/** Public DTO. Never includes the cleartext token or the stored hash. */
 export class ApiKeyDto {
   id!: number;
   userId!: number;
@@ -14,13 +6,10 @@ export class ApiKeyDto {
   prefix!: string;
   createdAt!: Date;
   lastUsedAt!: Date | null;
-  revokedAt!: Date | null;
+  roles!: string[];
 }
 
-/**
- * Returned exactly once at creation. The `token` field is the only place
- * the cleartext key is visible — server never persists it.
- */
+/** Returned exactly once at creation. */
 export class CreatedApiKeyDto extends ApiKeyDto {
   token!: string;
 }

--- a/src/services/interfaces/api-key.dto.ts
+++ b/src/services/interfaces/api-key.dto.ts
@@ -1,0 +1,24 @@
+/**
+ * Public DTO. Never includes the cleartext token or the stored hash.
+ *
+ * The `prefix` is intentionally returned so the UI can disambiguate keys when
+ * the user has several active — it's the same fixed-width leading segment of
+ * the original token they were shown at creation time.
+ */
+export interface ApiKeyDto {
+  id: number;
+  userId: number;
+  label: string;
+  prefix: string;
+  createdAt: Date;
+  lastUsedAt: Date | null;
+  revokedAt: Date | null;
+}
+
+/**
+ * Returned exactly once at creation. The `token` field is the only place
+ * the cleartext key is visible — server never persists it.
+ */
+export interface CreatedApiKeyDto extends ApiKeyDto {
+  token: string;
+}

--- a/src/services/interfaces/api-key.dto.ts
+++ b/src/services/interfaces/api-key.dto.ts
@@ -3,22 +3,24 @@
  *
  * The `prefix` is intentionally returned so the UI can disambiguate keys when
  * the user has several active — it's the same fixed-width leading segment of
- * the original token they were shown at creation time.
+ * the original token they were shown at creation time. Declared as a class
+ * (not interface) so it can be passed to BaseService() as a constructor
+ * argument, matching the existing pattern in RefreshTokenDto / UserDto.
  */
-export interface ApiKeyDto {
-  id: number;
-  userId: number;
-  label: string;
-  prefix: string;
-  createdAt: Date;
-  lastUsedAt: Date | null;
-  revokedAt: Date | null;
+export class ApiKeyDto {
+  id!: number;
+  userId!: number;
+  label!: string;
+  prefix!: string;
+  createdAt!: Date;
+  lastUsedAt!: Date | null;
+  revokedAt!: Date | null;
 }
 
 /**
  * Returned exactly once at creation. The `token` field is the only place
  * the cleartext key is visible — server never persists it.
  */
-export interface CreatedApiKeyDto extends ApiKeyDto {
-  token: string;
+export class CreatedApiKeyDto extends ApiKeyDto {
+  token!: string;
 }

--- a/src/services/interfaces/api-key.service.interface.ts
+++ b/src/services/interfaces/api-key.service.interface.ts
@@ -4,8 +4,8 @@ import { ApiKeyDto, CreatedApiKeyDto } from "@/services/interfaces/api-key.dto";
 export interface IApiKeyService {
   toDto(entity: ApiKey): ApiKeyDto;
 
-  /** Mint a new API key for `userId` with the given roles. Returns the cleartext token exactly once. */
-  create(userId: number, label: string, roleIds: number[]): Promise<CreatedApiKeyDto>;
+  /** Mint a new API key with the given roles. `createdByUserId` is audit-only. Returns the cleartext token exactly once. */
+  create(createdByUserId: number, label: string, roleIds: number[]): Promise<CreatedApiKeyDto>;
 
   /** All keys across all users (admin-only feature). Never returns secrets. */
   list(): Promise<ApiKeyDto[]>;

--- a/src/services/interfaces/api-key.service.interface.ts
+++ b/src/services/interfaces/api-key.service.interface.ts
@@ -4,35 +4,21 @@ import { ApiKeyDto, CreatedApiKeyDto } from "@/services/interfaces/api-key.dto";
 export interface IApiKeyService {
   toDto(entity: ApiKey): ApiKeyDto;
 
-  /**
-   * Mint a new API key for the given user. Returns the DTO with the cleartext
-   * token (only time it is ever exposed) plus stored metadata.
-   */
-  createForUser(userId: number, label: string): Promise<CreatedApiKeyDto>;
+  /** Mint a new API key for `userId` with the given roles. Returns the cleartext token exactly once. */
+  create(userId: number, label: string, roleIds: number[]): Promise<CreatedApiKeyDto>;
+
+  /** All keys across all users (admin-only feature). Never returns secrets. */
+  list(): Promise<ApiKeyDto[]>;
+
+  /** Hard-delete a key by id. Throws if id doesn't exist. */
+  delete(id: number): Promise<void>;
 
   /**
-   * List a user's keys (active + revoked). Never returns the secret.
-   */
-  listForUser(userId: number): Promise<ApiKeyDto[]>;
-
-  /**
-   * Mark a key as revoked. No-op if it's already revoked. Returns the
-   * updated DTO. Throws if the id doesn't belong to the user.
-   */
-  revokeForUser(userId: number, id: number): Promise<ApiKeyDto>;
-
-  /**
-   * Verify a presented bearer token. Returns the bound `ApiKey` row + user
-   * id when the token matches a non-revoked key; null otherwise.
-   *
-   * Side effect: bumps `lastUsedAt`. Implemented best-effort and does not
-   * block the calling request on failure.
+   * Verify a presented bearer token. Returns the eager-loaded `ApiKey` row
+   * (with roles) when valid; null otherwise. Side-effect: bumps `lastUsedAt`.
    */
   verify(token: string): Promise<ApiKey | null>;
 
-  /**
-   * Returns true if `token` looks like an API key (correct prefix + length).
-   * Cheap pre-check the auth layer can use to skip JWT parsing.
-   */
+  /** Cheap pre-check for "does this string look like our token shape". */
   looksLikeApiKey(token: string): boolean;
 }

--- a/src/services/interfaces/api-key.service.interface.ts
+++ b/src/services/interfaces/api-key.service.interface.ts
@@ -1,0 +1,38 @@
+import { ApiKey } from "@/entities";
+import { ApiKeyDto, CreatedApiKeyDto } from "@/services/interfaces/api-key.dto";
+
+export interface IApiKeyService {
+  toDto(entity: ApiKey): ApiKeyDto;
+
+  /**
+   * Mint a new API key for the given user. Returns the DTO with the cleartext
+   * token (only time it is ever exposed) plus stored metadata.
+   */
+  createForUser(userId: number, label: string): Promise<CreatedApiKeyDto>;
+
+  /**
+   * List a user's keys (active + revoked). Never returns the secret.
+   */
+  listForUser(userId: number): Promise<ApiKeyDto[]>;
+
+  /**
+   * Mark a key as revoked. No-op if it's already revoked. Returns the
+   * updated DTO. Throws if the id doesn't belong to the user.
+   */
+  revokeForUser(userId: number, id: number): Promise<ApiKeyDto>;
+
+  /**
+   * Verify a presented bearer token. Returns the bound `ApiKey` row + user
+   * id when the token matches a non-revoked key; null otherwise.
+   *
+   * Side effect: bumps `lastUsedAt`. Implemented best-effort and does not
+   * block the calling request on failure.
+   */
+  verify(token: string): Promise<ApiKey | null>;
+
+  /**
+   * Returns true if `token` looks like an API key (correct prefix + length).
+   * Cheap pre-check the auth layer can use to skip JWT parsing.
+   */
+  looksLikeApiKey(token: string): boolean;
+}

--- a/src/services/interfaces/user.dto.ts
+++ b/src/services/interfaces/user.dto.ts
@@ -9,6 +9,8 @@ export class UserDto {
   isVerified: boolean;
   needsPasswordChange: boolean;
   roles: RoleName[];
+  /** True when the principal was authenticated via an API key, not a user login. */
+  isApiKey?: boolean;
 }
 
 export class RegisterUserDto {

--- a/src/services/orm/api-key.service.ts
+++ b/src/services/orm/api-key.service.ts
@@ -3,6 +3,8 @@ import { ApiKey } from "@/entities";
 import { TypeormService } from "@/services/typeorm/typeorm.service";
 import type { IApiKeyService } from "@/services/interfaces/api-key.service.interface";
 import { ApiKeyDto, CreatedApiKeyDto } from "@/services/interfaces/api-key.dto";
+// `ApiKeyDto` is passed to BaseService() above as a constructor argument
+// (not an instance) — it's purely a generic-type marker.
 import { NotFoundException } from "@/exceptions/runtime.exceptions";
 import type { ILoggerFactory } from "@/handlers/logger-factory";
 import { LoggerService } from "@/handlers/logger";
@@ -30,7 +32,7 @@ function generateToken(): { token: string; prefix: string; hashedSecret: string 
   return { token, prefix, hashedSecret };
 }
 
-export class ApiKeyService extends BaseService(ApiKey, class {} as any) implements IApiKeyService {
+export class ApiKeyService extends BaseService(ApiKey, ApiKeyDto) implements IApiKeyService {
   private readonly logger: LoggerService;
 
   constructor(loggerFactory: ILoggerFactory, typeormService: TypeormService) {

--- a/src/services/orm/api-key.service.ts
+++ b/src/services/orm/api-key.service.ts
@@ -1,27 +1,16 @@
 import { BaseService } from "@/services/orm/base.service";
-import { ApiKey } from "@/entities";
+import { ApiKey, Role } from "@/entities";
 import { TypeormService } from "@/services/typeorm/typeorm.service";
 import type { IApiKeyService } from "@/services/interfaces/api-key.service.interface";
 import { ApiKeyDto, CreatedApiKeyDto } from "@/services/interfaces/api-key.dto";
-// `ApiKeyDto` is passed to BaseService() above as a constructor argument
-// (not an instance) — it's purely a generic-type marker.
 import { NotFoundException } from "@/exceptions/runtime.exceptions";
 import type { ILoggerFactory } from "@/handlers/logger-factory";
 import { LoggerService } from "@/handlers/logger";
 import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+import { In } from "typeorm";
 
-/**
- * Token format: `fdmm_pat_<48 chars of base64url>`.
- * The first 16 chars after the `fdmm_pat_` separator are the indexable
- * `prefix`; the full token is hashed with SHA-256 for verification.
- *
- * SHA-256 (not bcrypt) is appropriate here because the secret has 256 bits
- * of entropy from a CSPRNG — bcrypt's slow KDF only matters for low-entropy
- * passwords. This is the same pattern GitHub / GitLab use for personal
- * access tokens.
- */
 const TOKEN_PREFIX = "fdmm_pat_";
-const SECRET_BYTES = 32; // 256 bits → ~43 base64url chars
+const SECRET_BYTES = 32;
 const PREFIX_LEN = 16;
 
 function generateToken(): { token: string; prefix: string; hashedSecret: string } {
@@ -40,6 +29,10 @@ export class ApiKeyService extends BaseService(ApiKey, ApiKeyDto) implements IAp
     this.logger = loggerFactory(ApiKeyService.name);
   }
 
+  private get roleRepo() {
+    return this.typeormService.getDataSource().getRepository(Role);
+  }
+
   toDto(entity: ApiKey): ApiKeyDto {
     return {
       id: entity.id,
@@ -48,7 +41,7 @@ export class ApiKeyService extends BaseService(ApiKey, ApiKeyDto) implements IAp
       prefix: entity.prefix,
       createdAt: entity.createdAt,
       lastUsedAt: entity.lastUsedAt,
-      revokedAt: entity.revokedAt,
+      roles: (entity.roles ?? []).map((r) => r.name),
     };
   }
 
@@ -58,10 +51,18 @@ export class ApiKeyService extends BaseService(ApiKey, ApiKeyDto) implements IAp
     );
   }
 
-  async createForUser(userId: number, label: string): Promise<CreatedApiKeyDto> {
+  async create(userId: number, label: string, roleIds: number[]): Promise<CreatedApiKeyDto> {
     const trimmed = label?.trim();
     if (!trimmed?.length) {
       throw new Error("API key label is required");
+    }
+    if (!roleIds?.length) {
+      throw new Error("At least one role must be assigned to an API key");
+    }
+
+    const roles = await this.roleRepo.find({ where: { id: In(roleIds) } });
+    if (roles.length !== roleIds.length) {
+      throw new NotFoundException("One or more roleIds do not exist");
     }
 
     const { token, prefix, hashedSecret } = generateToken();
@@ -72,36 +73,29 @@ export class ApiKeyService extends BaseService(ApiKey, ApiKeyDto) implements IAp
         prefix,
         hashedSecret,
         lastUsedAt: null,
-        revokedAt: null,
+        roles,
       }),
     );
 
-    this.logger.log(`Created API key id=${entity.id} prefix=${prefix} for user ${userId}`);
+    this.logger.log(`Created API key id=${entity.id} prefix=${prefix} by user ${userId} with roles ${roleIds}`);
     return {
       ...this.toDto(entity),
       token,
     };
   }
 
-  async listForUser(userId: number): Promise<ApiKeyDto[]> {
-    const rows = await this.repository.find({
-      where: { userId },
-      order: { createdAt: "DESC" },
-    });
+  async list(): Promise<ApiKeyDto[]> {
+    const rows = await this.repository.find({ order: { createdAt: "DESC" } });
     return rows.map((r) => this.toDto(r));
   }
 
-  async revokeForUser(userId: number, id: number): Promise<ApiKeyDto> {
-    const row = await this.repository.findOneBy({ id, userId });
+  async delete(id: number): Promise<void> {
+    const row = await this.repository.findOneBy({ id });
     if (!row) {
-      throw new NotFoundException(`API key ${id} not found for user ${userId}`);
+      throw new NotFoundException(`API key ${id} not found`);
     }
-    if (!row.revokedAt) {
-      row.revokedAt = new Date();
-      await this.repository.save(row);
-      this.logger.log(`Revoked API key id=${id} prefix=${row.prefix} for user ${userId}`);
-    }
-    return this.toDto(row);
+    await this.repository.delete(id);
+    this.logger.log(`Deleted API key id=${id} prefix=${row.prefix}`);
   }
 
   async verify(token: string): Promise<ApiKey | null> {
@@ -110,8 +104,8 @@ export class ApiKeyService extends BaseService(ApiKey, ApiKeyDto) implements IAp
     const secret = token.slice(TOKEN_PREFIX.length);
     const prefix = secret.slice(0, PREFIX_LEN);
 
-    const candidate = await this.repository.findOneBy({ prefix });
-    if (!candidate || candidate.revokedAt) return null;
+    const candidate = await this.repository.findOne({ where: { prefix } });
+    if (!candidate) return null;
 
     const presented = createHash("sha256").update(token).digest();
     const stored = Buffer.from(candidate.hashedSecret, "hex");
@@ -119,7 +113,6 @@ export class ApiKeyService extends BaseService(ApiKey, ApiKeyDto) implements IAp
       return null;
     }
 
-    // Best-effort lastUsedAt bump. Don't block the caller on a write failure.
     this.repository
       .update({ id: candidate.id }, { lastUsedAt: new Date() })
       .catch((err) => this.logger.warn(`Failed to bump lastUsedAt for api key ${candidate.id}: ${err}`));

--- a/src/services/orm/api-key.service.ts
+++ b/src/services/orm/api-key.service.ts
@@ -36,7 +36,7 @@ export class ApiKeyService extends BaseService(ApiKey, ApiKeyDto) implements IAp
   toDto(entity: ApiKey): ApiKeyDto {
     return {
       id: entity.id,
-      userId: entity.userId,
+      createdByUserId: entity.createdByUserId,
       label: entity.label,
       prefix: entity.prefix,
       createdAt: entity.createdAt,
@@ -51,7 +51,7 @@ export class ApiKeyService extends BaseService(ApiKey, ApiKeyDto) implements IAp
     );
   }
 
-  async create(userId: number, label: string, roleIds: number[]): Promise<CreatedApiKeyDto> {
+  async create(createdByUserId: number, label: string, roleIds: number[]): Promise<CreatedApiKeyDto> {
     const trimmed = label?.trim();
     if (!trimmed?.length) {
       throw new Error("API key label is required");
@@ -68,7 +68,7 @@ export class ApiKeyService extends BaseService(ApiKey, ApiKeyDto) implements IAp
     const { token, prefix, hashedSecret } = generateToken();
     const entity = await this.repository.save(
       this.repository.create({
-        userId,
+        createdByUserId,
         label: trimmed,
         prefix,
         hashedSecret,
@@ -77,7 +77,9 @@ export class ApiKeyService extends BaseService(ApiKey, ApiKeyDto) implements IAp
       }),
     );
 
-    this.logger.log(`Created API key id=${entity.id} prefix=${prefix} by user ${userId} with roles ${roleIds}`);
+    this.logger.log(
+      `Created API key id=${entity.id} prefix=${prefix} by user ${createdByUserId} with roles ${roleIds}`,
+    );
     return {
       ...this.toDto(entity),
       token,

--- a/src/services/orm/api-key.service.ts
+++ b/src/services/orm/api-key.service.ts
@@ -1,0 +1,127 @@
+import { BaseService } from "@/services/orm/base.service";
+import { ApiKey } from "@/entities";
+import { TypeormService } from "@/services/typeorm/typeorm.service";
+import type { IApiKeyService } from "@/services/interfaces/api-key.service.interface";
+import { ApiKeyDto, CreatedApiKeyDto } from "@/services/interfaces/api-key.dto";
+import { NotFoundException } from "@/exceptions/runtime.exceptions";
+import type { ILoggerFactory } from "@/handlers/logger-factory";
+import { LoggerService } from "@/handlers/logger";
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+
+/**
+ * Token format: `fdmm_pat_<48 chars of base64url>`.
+ * The first 16 chars after the `fdmm_pat_` separator are the indexable
+ * `prefix`; the full token is hashed with SHA-256 for verification.
+ *
+ * SHA-256 (not bcrypt) is appropriate here because the secret has 256 bits
+ * of entropy from a CSPRNG — bcrypt's slow KDF only matters for low-entropy
+ * passwords. This is the same pattern GitHub / GitLab use for personal
+ * access tokens.
+ */
+const TOKEN_PREFIX = "fdmm_pat_";
+const SECRET_BYTES = 32; // 256 bits → ~43 base64url chars
+const PREFIX_LEN = 16;
+
+function generateToken(): { token: string; prefix: string; hashedSecret: string } {
+  const secret = randomBytes(SECRET_BYTES).toString("base64url");
+  const token = `${TOKEN_PREFIX}${secret}`;
+  const prefix = secret.slice(0, PREFIX_LEN);
+  const hashedSecret = createHash("sha256").update(token).digest("hex");
+  return { token, prefix, hashedSecret };
+}
+
+export class ApiKeyService extends BaseService(ApiKey, class {} as any) implements IApiKeyService {
+  private readonly logger: LoggerService;
+
+  constructor(loggerFactory: ILoggerFactory, typeormService: TypeormService) {
+    super(typeormService);
+    this.logger = loggerFactory(ApiKeyService.name);
+  }
+
+  toDto(entity: ApiKey): ApiKeyDto {
+    return {
+      id: entity.id,
+      userId: entity.userId,
+      label: entity.label,
+      prefix: entity.prefix,
+      createdAt: entity.createdAt,
+      lastUsedAt: entity.lastUsedAt,
+      revokedAt: entity.revokedAt,
+    };
+  }
+
+  looksLikeApiKey(token: string): boolean {
+    return (
+      typeof token === "string" && token.startsWith(TOKEN_PREFIX) && token.length > TOKEN_PREFIX.length + PREFIX_LEN
+    );
+  }
+
+  async createForUser(userId: number, label: string): Promise<CreatedApiKeyDto> {
+    const trimmed = label?.trim();
+    if (!trimmed?.length) {
+      throw new Error("API key label is required");
+    }
+
+    const { token, prefix, hashedSecret } = generateToken();
+    const entity = await this.repository.save(
+      this.repository.create({
+        userId,
+        label: trimmed,
+        prefix,
+        hashedSecret,
+        lastUsedAt: null,
+        revokedAt: null,
+      }),
+    );
+
+    this.logger.log(`Created API key id=${entity.id} prefix=${prefix} for user ${userId}`);
+    return {
+      ...this.toDto(entity),
+      token,
+    };
+  }
+
+  async listForUser(userId: number): Promise<ApiKeyDto[]> {
+    const rows = await this.repository.find({
+      where: { userId },
+      order: { createdAt: "DESC" },
+    });
+    return rows.map((r) => this.toDto(r));
+  }
+
+  async revokeForUser(userId: number, id: number): Promise<ApiKeyDto> {
+    const row = await this.repository.findOneBy({ id, userId });
+    if (!row) {
+      throw new NotFoundException(`API key ${id} not found for user ${userId}`);
+    }
+    if (!row.revokedAt) {
+      row.revokedAt = new Date();
+      await this.repository.save(row);
+      this.logger.log(`Revoked API key id=${id} prefix=${row.prefix} for user ${userId}`);
+    }
+    return this.toDto(row);
+  }
+
+  async verify(token: string): Promise<ApiKey | null> {
+    if (!this.looksLikeApiKey(token)) return null;
+
+    const secret = token.slice(TOKEN_PREFIX.length);
+    const prefix = secret.slice(0, PREFIX_LEN);
+
+    const candidate = await this.repository.findOneBy({ prefix });
+    if (!candidate || candidate.revokedAt) return null;
+
+    const presented = createHash("sha256").update(token).digest();
+    const stored = Buffer.from(candidate.hashedSecret, "hex");
+    if (presented.length !== stored.length || !timingSafeEqual(presented, stored)) {
+      return null;
+    }
+
+    // Best-effort lastUsedAt bump. Don't block the caller on a write failure.
+    this.repository
+      .update({ id: candidate.id }, { lastUsedAt: new Date() })
+      .catch((err) => this.logger.warn(`Failed to bump lastUsedAt for api key ${candidate.id}: ${err}`));
+
+    return candidate;
+  }
+}

--- a/src/services/orm/api-key.service.ts
+++ b/src/services/orm/api-key.service.ts
@@ -9,7 +9,7 @@ import { LoggerService } from "@/handlers/logger";
 import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
 import { In } from "typeorm";
 
-const TOKEN_PREFIX = "fdmm_pat_";
+const TOKEN_PREFIX = "fdmm_api_";
 const SECRET_BYTES = 32;
 const PREFIX_LEN = 16;
 

--- a/test/api/api-key-controller.test.ts
+++ b/test/api/api-key-controller.test.ts
@@ -37,6 +37,25 @@ async function operatorRoleId(): Promise<number> {
   return role.id;
 }
 
+function authHeader(token: string): [string, string] {
+  return ["Authorization", `Bearer ${token}`];
+}
+
+function postCreate(token: string, body: Record<string, unknown>) {
+  return request
+    .post(baseRoute)
+    .set(...authHeader(token))
+    .send(body);
+}
+
+function getList(token: string) {
+  return request.get(baseRoute).set(...authHeader(token));
+}
+
+function deleteKeyRequest(token: string, id: number | string) {
+  return request.delete(`${baseRoute}/${id}`).set(...authHeader(token));
+}
+
 beforeAll(async () => {
   ({ request, container } = await setupTestApp(true));
   apiKeyService = container.resolve<IApiKeyService>(DITokens.apiKeyService);
@@ -67,22 +86,19 @@ describe(ApiKeyController.name, () => {
 
     it("rejects non-admin users with 403 on list", async () => {
       const { token } = await loginTestUser(request, "apikey-non-admin-list", "pw", ROLES.OPERATOR);
-      const response = await request.get(baseRoute).set("Authorization", `Bearer ${token}`);
+      const response = await getList(token);
       expectForbiddenResponse(response);
     });
 
     it("rejects non-admin users with 403 on create", async () => {
       const { token } = await loginTestUser(request, "apikey-non-admin-create", "pw", ROLES.OPERATOR);
-      const response = await request
-        .post(baseRoute)
-        .set("Authorization", `Bearer ${token}`)
-        .send({ label: "blocked", roleIds: [await operatorRoleId()] });
+      const response = await postCreate(token, { label: "blocked", roleIds: [await operatorRoleId()] });
       expectForbiddenResponse(response);
     });
 
     it("rejects non-admin users with 403 on delete", async () => {
       const { token } = await loginTestUser(request, "apikey-non-admin-delete", "pw", ROLES.OPERATOR);
-      const response = await request.delete(`${baseRoute}/1`).set("Authorization", `Bearer ${token}`);
+      const response = await deleteKeyRequest(token, 1);
       expectForbiddenResponse(response);
     });
   });
@@ -90,11 +106,7 @@ describe(ApiKeyController.name, () => {
   describe("create", () => {
     it("issues a fdmm_pat_ token and returns it once with the requested roles", async () => {
       const { token: jwt } = await loginTestUser(request, "apikey-create");
-      const roleId = await adminRoleId();
-      const response = await request
-        .post(baseRoute)
-        .set("Authorization", `Bearer ${jwt}`)
-        .send({ label: "my-script", roleIds: [roleId] });
+      const response = await postCreate(jwt, { label: "my-script", roleIds: [await adminRoleId()] });
       expectOkResponse(response);
 
       expect(response.body.token).toMatch(/^fdmm_pat_[A-Za-z0-9_-]{20,}$/);
@@ -107,43 +119,31 @@ describe(ApiKeyController.name, () => {
 
     it("rejects empty label", async () => {
       const { token: jwt } = await loginTestUser(request, "apikey-empty-label");
-      const response = await request
-        .post(baseRoute)
-        .set("Authorization", `Bearer ${jwt}`)
-        .send({ label: "", roleIds: [await adminRoleId()] });
+      const response = await postCreate(jwt, { label: "", roleIds: [await adminRoleId()] });
       expectInvalidResponse(response);
     });
 
     it("rejects whitespace-only label", async () => {
       const { token: jwt } = await loginTestUser(request, "apikey-ws-label");
-      const response = await request
-        .post(baseRoute)
-        .set("Authorization", `Bearer ${jwt}`)
-        .send({ label: "   ", roleIds: [await adminRoleId()] });
+      const response = await postCreate(jwt, { label: "   ", roleIds: [await adminRoleId()] });
       expectInvalidResponse(response);
     });
 
     it("rejects empty roleIds", async () => {
       const { token: jwt } = await loginTestUser(request, "apikey-empty-roles");
-      const response = await request
-        .post(baseRoute)
-        .set("Authorization", `Bearer ${jwt}`)
-        .send({ label: "no-roles", roleIds: [] });
+      const response = await postCreate(jwt, { label: "no-roles", roleIds: [] });
       expectInvalidResponse(response);
     });
 
     it("rejects missing roleIds field", async () => {
       const { token: jwt } = await loginTestUser(request, "apikey-missing-roles");
-      const response = await request.post(baseRoute).set("Authorization", `Bearer ${jwt}`).send({ label: "no-roles" });
+      const response = await postCreate(jwt, { label: "no-roles" });
       expectInvalidResponse(response);
     });
 
     it("rejects roleIds referencing nonexistent roles", async () => {
       const { token: jwt } = await loginTestUser(request, "apikey-bad-role-id");
-      const response = await request
-        .post(baseRoute)
-        .set("Authorization", `Bearer ${jwt}`)
-        .send({ label: "fake-role", roleIds: [99999] });
+      const response = await postCreate(jwt, { label: "fake-role", roleIds: [99999] });
       expectNotFoundResponse(response);
     });
 
@@ -152,12 +152,13 @@ describe(ApiKeyController.name, () => {
       // any role via user management, so the api-key create path doesn't need
       // an additional escalation check.
       const { token: jwt } = await loginTestUser(request, "apikey-cross-role");
-      const response = await request
-        .post(baseRoute)
-        .set("Authorization", `Bearer ${jwt}`)
-        .send({ label: "broad", roleIds: [await adminRoleId(), await operatorRoleId()] });
+      const response = await postCreate(jwt, {
+        label: "broad",
+        roleIds: [await adminRoleId(), await operatorRoleId()],
+      });
       expectOkResponse(response);
-      expect(response.body.roles.sort()).toEqual([ROLES.ADMIN, ROLES.OPERATOR].sort());
+      expect(response.body.roles).toEqual(expect.arrayContaining([ROLES.ADMIN, ROLES.OPERATOR]));
+      expect(response.body.roles).toHaveLength(2);
     });
   });
 
@@ -166,16 +167,10 @@ describe(ApiKeyController.name, () => {
       // Create two keys as the admin user — list should show both.
       const { token: jwt } = await loginTestUser(request, "apikey-list-admin");
       const adminId = await adminRoleId();
-      await request
-        .post(baseRoute)
-        .set("Authorization", `Bearer ${jwt}`)
-        .send({ label: "first", roleIds: [adminId] });
-      await request
-        .post(baseRoute)
-        .set("Authorization", `Bearer ${jwt}`)
-        .send({ label: "second", roleIds: [adminId] });
+      await postCreate(jwt, { label: "first", roleIds: [adminId] });
+      await postCreate(jwt, { label: "second", roleIds: [adminId] });
 
-      const response = await request.get(baseRoute).set("Authorization", `Bearer ${jwt}`);
+      const response = await getList(jwt);
       expectOkResponse(response);
       const labels = response.body.map((k: any) => k.label);
       expect(labels).toEqual(expect.arrayContaining(["first", "second"]));
@@ -189,23 +184,20 @@ describe(ApiKeyController.name, () => {
   describe("delete (hard delete)", () => {
     it("removes the row, key stops authenticating, subsequent delete is 404", async () => {
       const { token: jwt } = await loginTestUser(request, "apikey-delete");
-      const created = await request
-        .post(baseRoute)
-        .set("Authorization", `Bearer ${jwt}`)
-        .send({ label: "to-delete", roleIds: [await adminRoleId()] });
+      const created = await postCreate(jwt, { label: "to-delete", roleIds: [await adminRoleId()] });
       const apiKeyToken: string = created.body.token;
       const apiKeyId: number = created.body.id;
 
-      const before = await request.get(baseRoute).set("Authorization", `Bearer ${apiKeyToken}`);
+      const before = await getList(apiKeyToken);
       expectOkResponse(before);
 
-      const del = await request.delete(`${baseRoute}/${apiKeyId}`).set("Authorization", `Bearer ${jwt}`);
+      const del = await deleteKeyRequest(jwt, apiKeyId);
       expect(del.statusCode).toBe(204);
 
-      const after = await request.get(baseRoute).set("Authorization", `Bearer ${apiKeyToken}`);
+      const after = await getList(apiKeyToken);
       expectUnauthenticatedResponse(after);
 
-      const delAgain = await request.delete(`${baseRoute}/${apiKeyId}`).set("Authorization", `Bearer ${jwt}`);
+      const delAgain = await deleteKeyRequest(jwt, apiKeyId);
       expectNotFoundResponse(delAgain);
     });
 
@@ -214,14 +206,10 @@ describe(ApiKeyController.name, () => {
       // delete the other's key without a 404 — admin scope is global.
       const { token: jwtA } = await loginTestUser(request, "apikey-delete-admin-a");
       const { token: jwtB } = await loginTestUser(request, "apikey-delete-admin-b");
-      const adminId = await adminRoleId();
-      const aCreated = await request
-        .post(baseRoute)
-        .set("Authorization", `Bearer ${jwtA}`)
-        .send({ label: "a-owned", roleIds: [adminId] });
+      const aCreated = await postCreate(jwtA, { label: "a-owned", roleIds: [await adminRoleId()] });
       const aKeyId: number = aCreated.body.id;
 
-      const del = await request.delete(`${baseRoute}/${aKeyId}`).set("Authorization", `Bearer ${jwtB}`);
+      const del = await deleteKeyRequest(jwtB, aKeyId);
       expect(del.statusCode).toBe(204);
     });
   });
@@ -232,22 +220,15 @@ describe(ApiKeyController.name, () => {
       // The key should authenticate but only have operator permissions — the
       // admin role of the bound user does NOT leak through.
       const { token: jwt } = await loginTestUser(request, "apikey-roles-from-key");
-      const operatorId = await operatorRoleId();
-      const created = await request
-        .post(baseRoute)
-        .set("Authorization", `Bearer ${jwt}`)
-        .send({ label: "operator-only", roleIds: [operatorId] });
+      const created = await postCreate(jwt, { label: "operator-only", roleIds: [await operatorRoleId()] });
       const apiKeyToken: string = created.body.token;
 
       // Hit an ADMIN-only route with the operator-scoped key — should be 403.
-      const adminOnly = await request.get(baseRoute).set("Authorization", `Bearer ${apiKeyToken}`);
-      expectForbiddenResponse(adminOnly);
+      expectForbiddenResponse(await getList(apiKeyToken));
 
       // But the key still authenticates at all — hit a route accepting any
       // authenticated user.
-      const anyAuth = await request
-        .get(`${AppConstants.apiRoute}/auth/login-required`)
-        .set("Authorization", `Bearer ${apiKeyToken}`);
+      const anyAuth = await request.get(`${AppConstants.apiRoute}/auth/login-required`).set(...authHeader(apiKeyToken));
       expectOkResponse(anyAuth);
     });
 
@@ -260,17 +241,14 @@ describe(ApiKeyController.name, () => {
 
     it("bumps lastUsedAt on successful api-key auth", async () => {
       const { token: jwt } = await loginTestUser(request, "apikey-lastused");
-      const created = await request
-        .post(baseRoute)
-        .set("Authorization", `Bearer ${jwt}`)
-        .send({ label: "lastused", roleIds: [await adminRoleId()] });
+      const created = await postCreate(jwt, { label: "lastused", roleIds: [await adminRoleId()] });
       const apiKeyToken: string = created.body.token;
       expect(created.body.lastUsedAt).toBeNull();
 
-      await request.get(baseRoute).set("Authorization", `Bearer ${apiKeyToken}`);
+      await getList(apiKeyToken);
       await new Promise((resolve) => setTimeout(resolve, 50));
 
-      const list = await request.get(baseRoute).set("Authorization", `Bearer ${jwt}`);
+      const list = await getList(jwt);
       const refreshed = list.body.find((k: any) => k.id === created.body.id);
       expect(refreshed?.lastUsedAt).not.toBeNull();
     });

--- a/test/api/api-key-controller.test.ts
+++ b/test/api/api-key-controller.test.ts
@@ -163,6 +163,23 @@ describe(ApiKeyController.name, () => {
       const refreshed = list.body.find((k: any) => k.id === created.body.id);
       expect(refreshed?.lastUsedAt).not.toBeNull();
     });
+
+    it("rejects api-key auth when the bound user is no longer verified", async () => {
+      // Issue a key while the user is verified, then flip them to unverified
+      // (e.g. admin disabled the account after key issuance). The key must
+      // stop authenticating without needing an explicit revoke.
+      const user = await ensureTestUserCreated("apikey-unverified-user", "pw", false);
+      const created = await apiKeyService.createForUser(user.id, "unverified-test");
+      // Sanity: works while verified.
+      const before = await request.get(baseRoute).set("Authorization", `Bearer ${created.token}`);
+      expectOkResponse(before);
+
+      // Flip verified → false.
+      await ensureTestUserCreated("apikey-unverified-user", "pw", false, undefined, false);
+
+      const after = await request.get(baseRoute).set("Authorization", `Bearer ${created.token}`);
+      expectUnauthenticatedResponse(after);
+    });
   });
 });
 

--- a/test/api/api-key-controller.test.ts
+++ b/test/api/api-key-controller.test.ts
@@ -112,7 +112,7 @@ describe(ApiKeyController.name, () => {
       expect(response.body.token).toMatch(/^fdmm_pat_[A-Za-z0-9_-]{20,}$/);
       expect(response.body.label).toBe("my-script");
       expect(response.body.prefix).toHaveLength(16);
-      expect(response.body.userId).toBeGreaterThan(0);
+      expect(response.body.createdByUserId).toBeGreaterThan(0);
       expect(response.body.lastUsedAt).toBeNull();
       expect(response.body.roles).toEqual([ROLES.ADMIN]);
     });
@@ -148,9 +148,9 @@ describe(ApiKeyController.name, () => {
     });
 
     it("allows admins to assign any role to a key (no escalation check)", async () => {
-      // David's call: admins are super users; they can already grant themselves
-      // any role via user management, so the api-key create path doesn't need
-      // an additional escalation check.
+      // Admins are super users — they can already grant themselves any role
+      // via user management, so the api-key create path doesn't need an
+      // additional escalation check.
       const { token: jwt } = await loginTestUser(request, "apikey-cross-role");
       const response = await postCreate(jwt, {
         label: "broad",

--- a/test/api/api-key-controller.test.ts
+++ b/test/api/api-key-controller.test.ts
@@ -1,6 +1,7 @@
 import { AppConstants } from "@/server.constants";
 import { setupTestApp } from "../test-server";
 import {
+  expectForbiddenResponse,
   expectInvalidResponse,
   expectNotFoundResponse,
   expectOkResponse,
@@ -14,16 +15,37 @@ import { loginTestUser } from "./auth/login-test-user";
 import { ApiKeyController } from "@/controllers/api-key.controller";
 import TestAgent from "supertest/lib/agent";
 import type { IApiKeyService } from "@/services/interfaces/api-key.service.interface";
+import { ROLES } from "@/constants/authorization.constants";
+import { Role } from "@/entities";
+import { getDatasource } from "../typeorm.manager";
+import { SettingsStore } from "@/state/settings.store";
 
 let request: TestAgent<Test>;
 let container: AwilixContainer;
 let apiKeyService: IApiKeyService;
+let settingsStore: SettingsStore;
 
 const baseRoute = AppConstants.apiRoute + "/api-keys";
+
+async function adminRoleId(): Promise<number> {
+  const role = await getDatasource().getRepository(Role).findOneByOrFail({ name: ROLES.ADMIN });
+  return role.id;
+}
+
+async function operatorRoleId(): Promise<number> {
+  const role = await getDatasource().getRepository(Role).findOneByOrFail({ name: ROLES.OPERATOR });
+  return role.id;
+}
 
 beforeAll(async () => {
   ({ request, container } = await setupTestApp(true));
   apiKeyService = container.resolve<IApiKeyService>(DITokens.apiKeyService);
+  settingsStore = container.resolve(DITokens.settingsStore);
+  // The test env defaults to loginRequired=false, which makes the auth
+  // middleware fall through for unauthenticated requests. The api-keys
+  // controller is admin-only and depends on the auth chain rejecting bare
+  // requests with 401, so flip the setting on for this file.
+  await settingsStore.setLoginRequired(true);
 });
 
 describe(ApiKeyController.name, () => {
@@ -34,110 +56,199 @@ describe(ApiKeyController.name, () => {
     });
 
     it("rejects create without auth", async () => {
-      const response = await request.post(baseRoute).send({ label: "x" });
+      const response = await request.post(baseRoute).send({ label: "x", roleIds: [1] });
       expectUnauthenticatedResponse(response);
     });
 
-    it("rejects revoke without auth", async () => {
+    it("rejects delete without auth", async () => {
       const response = await request.delete(`${baseRoute}/1`);
       expectUnauthenticatedResponse(response);
+    });
+
+    it("rejects non-admin users with 403 on list", async () => {
+      const { token } = await loginTestUser(request, "apikey-non-admin-list", "pw", ROLES.OPERATOR);
+      const response = await request.get(baseRoute).set("Authorization", `Bearer ${token}`);
+      expectForbiddenResponse(response);
+    });
+
+    it("rejects non-admin users with 403 on create", async () => {
+      const { token } = await loginTestUser(request, "apikey-non-admin-create", "pw", ROLES.OPERATOR);
+      const response = await request
+        .post(baseRoute)
+        .set("Authorization", `Bearer ${token}`)
+        .send({ label: "blocked", roleIds: [await operatorRoleId()] });
+      expectForbiddenResponse(response);
+    });
+
+    it("rejects non-admin users with 403 on delete", async () => {
+      const { token } = await loginTestUser(request, "apikey-non-admin-delete", "pw", ROLES.OPERATOR);
+      const response = await request.delete(`${baseRoute}/1`).set("Authorization", `Bearer ${token}`);
+      expectForbiddenResponse(response);
     });
   });
 
   describe("create", () => {
-    it("issues a fdmm_pat_ token and returns it once", async () => {
-      const { token: jwt } = await loginTestUser(request, "apikey-user-create");
-      const response = await request.post(baseRoute).set("Authorization", `Bearer ${jwt}`).send({ label: "my-script" });
+    it("issues a fdmm_pat_ token and returns it once with the requested roles", async () => {
+      const { token: jwt } = await loginTestUser(request, "apikey-create");
+      const roleId = await adminRoleId();
+      const response = await request
+        .post(baseRoute)
+        .set("Authorization", `Bearer ${jwt}`)
+        .send({ label: "my-script", roleIds: [roleId] });
       expectOkResponse(response);
 
       expect(response.body.token).toMatch(/^fdmm_pat_[A-Za-z0-9_-]{20,}$/);
       expect(response.body.label).toBe("my-script");
       expect(response.body.prefix).toHaveLength(16);
       expect(response.body.userId).toBeGreaterThan(0);
-      expect(response.body.revokedAt).toBeNull();
       expect(response.body.lastUsedAt).toBeNull();
+      expect(response.body.roles).toEqual([ROLES.ADMIN]);
     });
 
-    it("rejects empty label with invalid response", async () => {
-      const { token: jwt } = await loginTestUser(request, "apikey-user-empty-label");
-      const response = await request.post(baseRoute).set("Authorization", `Bearer ${jwt}`).send({ label: "" });
+    it("rejects empty label", async () => {
+      const { token: jwt } = await loginTestUser(request, "apikey-empty-label");
+      const response = await request
+        .post(baseRoute)
+        .set("Authorization", `Bearer ${jwt}`)
+        .send({ label: "", roleIds: [await adminRoleId()] });
       expectInvalidResponse(response);
     });
 
     it("rejects whitespace-only label", async () => {
-      const { token: jwt } = await loginTestUser(request, "apikey-user-ws-label");
-      const response = await request.post(baseRoute).set("Authorization", `Bearer ${jwt}`).send({ label: "   " });
+      const { token: jwt } = await loginTestUser(request, "apikey-ws-label");
+      const response = await request
+        .post(baseRoute)
+        .set("Authorization", `Bearer ${jwt}`)
+        .send({ label: "   ", roleIds: [await adminRoleId()] });
       expectInvalidResponse(response);
+    });
+
+    it("rejects empty roleIds", async () => {
+      const { token: jwt } = await loginTestUser(request, "apikey-empty-roles");
+      const response = await request
+        .post(baseRoute)
+        .set("Authorization", `Bearer ${jwt}`)
+        .send({ label: "no-roles", roleIds: [] });
+      expectInvalidResponse(response);
+    });
+
+    it("rejects missing roleIds field", async () => {
+      const { token: jwt } = await loginTestUser(request, "apikey-missing-roles");
+      const response = await request.post(baseRoute).set("Authorization", `Bearer ${jwt}`).send({ label: "no-roles" });
+      expectInvalidResponse(response);
+    });
+
+    it("rejects roleIds referencing nonexistent roles", async () => {
+      const { token: jwt } = await loginTestUser(request, "apikey-bad-role-id");
+      const response = await request
+        .post(baseRoute)
+        .set("Authorization", `Bearer ${jwt}`)
+        .send({ label: "fake-role", roleIds: [99999] });
+      expectNotFoundResponse(response);
+    });
+
+    it("allows admins to assign any role to a key (no escalation check)", async () => {
+      // David's call: admins are super users; they can already grant themselves
+      // any role via user management, so the api-key create path doesn't need
+      // an additional escalation check.
+      const { token: jwt } = await loginTestUser(request, "apikey-cross-role");
+      const response = await request
+        .post(baseRoute)
+        .set("Authorization", `Bearer ${jwt}`)
+        .send({ label: "broad", roleIds: [await adminRoleId(), await operatorRoleId()] });
+      expectOkResponse(response);
+      expect(response.body.roles.sort()).toEqual([ROLES.ADMIN, ROLES.OPERATOR].sort());
     });
   });
 
   describe("list", () => {
-    it("returns only the calling user's keys, never the secret", async () => {
-      const { token: jwtA } = await loginTestUser(request, "apikey-user-isolation-a");
-      const { token: jwtB } = await loginTestUser(request, "apikey-user-isolation-b");
-      await request.post(baseRoute).set("Authorization", `Bearer ${jwtA}`).send({ label: "a-key" });
-      await request.post(baseRoute).set("Authorization", `Bearer ${jwtB}`).send({ label: "b-key" });
+    it("returns all keys across users (admin scope), never the secret", async () => {
+      // Create two keys as the admin user — list should show both.
+      const { token: jwt } = await loginTestUser(request, "apikey-list-admin");
+      const adminId = await adminRoleId();
+      await request
+        .post(baseRoute)
+        .set("Authorization", `Bearer ${jwt}`)
+        .send({ label: "first", roleIds: [adminId] });
+      await request
+        .post(baseRoute)
+        .set("Authorization", `Bearer ${jwt}`)
+        .send({ label: "second", roleIds: [adminId] });
 
-      const responseA = await request.get(baseRoute).set("Authorization", `Bearer ${jwtA}`);
-      expectOkResponse(responseA);
-      const labelsA = responseA.body.map((k: any) => k.label);
-      expect(labelsA).toContain("a-key");
-      expect(labelsA).not.toContain("b-key");
-      // Secret-bearing fields are never returned.
-      for (const k of responseA.body) {
+      const response = await request.get(baseRoute).set("Authorization", `Bearer ${jwt}`);
+      expectOkResponse(response);
+      const labels = response.body.map((k: any) => k.label);
+      expect(labels).toEqual(expect.arrayContaining(["first", "second"]));
+      for (const k of response.body) {
         expect(k).not.toHaveProperty("token");
         expect(k).not.toHaveProperty("hashedSecret");
       }
     });
   });
 
-  describe("revoke", () => {
-    it("sets revokedAt and the token stops authenticating", async () => {
-      const { token: jwt } = await loginTestUser(request, "apikey-user-revoke");
-      const created = await request.post(baseRoute).set("Authorization", `Bearer ${jwt}`).send({ label: "to-revoke" });
+  describe("delete (hard delete)", () => {
+    it("removes the row, key stops authenticating, subsequent delete is 404", async () => {
+      const { token: jwt } = await loginTestUser(request, "apikey-delete");
+      const created = await request
+        .post(baseRoute)
+        .set("Authorization", `Bearer ${jwt}`)
+        .send({ label: "to-delete", roleIds: [await adminRoleId()] });
       const apiKeyToken: string = created.body.token;
       const apiKeyId: number = created.body.id;
 
-      // Token should auth before revoke.
       const before = await request.get(baseRoute).set("Authorization", `Bearer ${apiKeyToken}`);
       expectOkResponse(before);
 
-      // Revoke via JWT.
-      const revoke = await request.delete(`${baseRoute}/${apiKeyId}`).set("Authorization", `Bearer ${jwt}`);
-      expectOkResponse(revoke);
-      expect(revoke.body.revokedAt).toBeTruthy();
+      const del = await request.delete(`${baseRoute}/${apiKeyId}`).set("Authorization", `Bearer ${jwt}`);
+      expect(del.statusCode).toBe(204);
 
-      // Token should fail after revoke.
       const after = await request.get(baseRoute).set("Authorization", `Bearer ${apiKeyToken}`);
       expectUnauthenticatedResponse(after);
+
+      const delAgain = await request.delete(`${baseRoute}/${apiKeyId}`).set("Authorization", `Bearer ${jwt}`);
+      expectNotFoundResponse(delAgain);
     });
 
-    it("returns 404 when revoking a foreign user's key", async () => {
-      const { token: jwtOwner } = await loginTestUser(request, "apikey-user-foreign-owner");
-      const { token: jwtIntruder } = await loginTestUser(request, "apikey-user-foreign-intruder");
-      const created = await request.post(baseRoute).set("Authorization", `Bearer ${jwtOwner}`).send({ label: "owned" });
-      const otherId: number = created.body.id;
+    it("admins can delete any user's key (no foreign-user 404)", async () => {
+      // Create two distinct admin users; each mints a key. Either admin can
+      // delete the other's key without a 404 — admin scope is global.
+      const { token: jwtA } = await loginTestUser(request, "apikey-delete-admin-a");
+      const { token: jwtB } = await loginTestUser(request, "apikey-delete-admin-b");
+      const adminId = await adminRoleId();
+      const aCreated = await request
+        .post(baseRoute)
+        .set("Authorization", `Bearer ${jwtA}`)
+        .send({ label: "a-owned", roleIds: [adminId] });
+      const aKeyId: number = aCreated.body.id;
 
-      const response = await request.delete(`${baseRoute}/${otherId}`).set("Authorization", `Bearer ${jwtIntruder}`);
-      expectNotFoundResponse(response);
+      const del = await request.delete(`${baseRoute}/${aKeyId}`).set("Authorization", `Bearer ${jwtB}`);
+      expect(del.statusCode).toBe(204);
     });
   });
 
   describe("api-key bearer auth path", () => {
-    it("authenticates via API key against any protected route", async () => {
-      const { token: jwt } = await loginTestUser(request, "apikey-bearer-test");
+    it("authenticates with the key's own roles, NOT the bound user's roles", async () => {
+      // Create a user, give them ADMIN. Mint a key with ONLY operator role.
+      // The key should authenticate but only have operator permissions — the
+      // admin role of the bound user does NOT leak through.
+      const { token: jwt } = await loginTestUser(request, "apikey-roles-from-key");
+      const operatorId = await operatorRoleId();
       const created = await request
         .post(baseRoute)
         .set("Authorization", `Bearer ${jwt}`)
-        .send({ label: "bearer-test" });
+        .send({ label: "operator-only", roleIds: [operatorId] });
       const apiKeyToken: string = created.body.token;
 
-      // Hit a sibling protected route to prove the auth pipeline accepts the
-      // api key as a JWT-equivalent bearer.
-      const printerList = await request
-        .get(`${AppConstants.apiRoute}/printer`)
+      // Hit an ADMIN-only route with the operator-scoped key — should be 403.
+      const adminOnly = await request.get(baseRoute).set("Authorization", `Bearer ${apiKeyToken}`);
+      expectForbiddenResponse(adminOnly);
+
+      // But the key still authenticates at all — hit a route accepting any
+      // authenticated user.
+      const anyAuth = await request
+        .get(`${AppConstants.apiRoute}/auth/login-required`)
         .set("Authorization", `Bearer ${apiKeyToken}`);
-      expectOkResponse(printerList);
+      expectOkResponse(anyAuth);
     });
 
     it("rejects garbage api-key-shaped tokens", async () => {
@@ -149,36 +260,19 @@ describe(ApiKeyController.name, () => {
 
     it("bumps lastUsedAt on successful api-key auth", async () => {
       const { token: jwt } = await loginTestUser(request, "apikey-lastused");
-      const created = await request.post(baseRoute).set("Authorization", `Bearer ${jwt}`).send({ label: "lastused" });
+      const created = await request
+        .post(baseRoute)
+        .set("Authorization", `Bearer ${jwt}`)
+        .send({ label: "lastused", roleIds: [await adminRoleId()] });
       const apiKeyToken: string = created.body.token;
       expect(created.body.lastUsedAt).toBeNull();
 
-      // Use the key.
       await request.get(baseRoute).set("Authorization", `Bearer ${apiKeyToken}`);
-
-      // Allow the best-effort async bump to land.
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       const list = await request.get(baseRoute).set("Authorization", `Bearer ${jwt}`);
       const refreshed = list.body.find((k: any) => k.id === created.body.id);
       expect(refreshed?.lastUsedAt).not.toBeNull();
-    });
-
-    it("rejects api-key auth when the bound user is no longer verified", async () => {
-      // Issue a key while the user is verified, then flip them to unverified
-      // (e.g. admin disabled the account after key issuance). The key must
-      // stop authenticating without needing an explicit revoke.
-      const user = await ensureTestUserCreated("apikey-unverified-user", "pw", false);
-      const created = await apiKeyService.createForUser(user.id, "unverified-test");
-      // Sanity: works while verified.
-      const before = await request.get(baseRoute).set("Authorization", `Bearer ${created.token}`);
-      expectOkResponse(before);
-
-      // Flip verified → false.
-      await ensureTestUserCreated("apikey-unverified-user", "pw", false, undefined, false);
-
-      const after = await request.get(baseRoute).set("Authorization", `Bearer ${created.token}`);
-      expectUnauthenticatedResponse(after);
     });
   });
 });
@@ -204,29 +298,25 @@ describe("ApiKeyService", () => {
   });
 
   describe("verify", () => {
-    it("returns the entity for a valid, non-revoked token", async () => {
+    it("returns the entity for a valid token", async () => {
       const user = await ensureTestUserCreated("apikey-svc-valid", "pw", false);
-      const created = await apiKeyService.createForUser(user.id, "valid-key");
-
+      const created = await apiKeyService.create(user.id, "valid-key", [await adminRoleId()]);
       const verified = await apiKeyService.verify(created.token);
       expect(verified?.id).toBe(created.id);
-      expect(verified?.userId).toBe(user.id);
     });
 
     it("returns null for a tampered token (same prefix, different secret)", async () => {
       const user = await ensureTestUserCreated("apikey-svc-tamper", "pw", false);
-      const created = await apiKeyService.createForUser(user.id, "tamper-key");
+      const created = await apiKeyService.create(user.id, "tamper-key", [await adminRoleId()]);
       const tampered = `fdmm_pat_${created.prefix}${"X".repeat(30)}`;
-
       const verified = await apiKeyService.verify(tampered);
       expect(verified).toBeNull();
     });
 
-    it("returns null for revoked tokens", async () => {
-      const user = await ensureTestUserCreated("apikey-svc-revoke", "pw", false);
-      const created = await apiKeyService.createForUser(user.id, "revoke-key");
-      await apiKeyService.revokeForUser(user.id, created.id);
-
+    it("returns null for deleted tokens", async () => {
+      const user = await ensureTestUserCreated("apikey-svc-deleted", "pw", false);
+      const created = await apiKeyService.create(user.id, "delete-key", [await adminRoleId()]);
+      await apiKeyService.delete(created.id);
       const verified = await apiKeyService.verify(created.token);
       expect(verified).toBeNull();
     });

--- a/test/api/api-key-controller.test.ts
+++ b/test/api/api-key-controller.test.ts
@@ -1,0 +1,227 @@
+import { AppConstants } from "@/server.constants";
+import { setupTestApp } from "../test-server";
+import {
+  expectInvalidResponse,
+  expectNotFoundResponse,
+  expectOkResponse,
+  expectUnauthenticatedResponse,
+} from "../extensions";
+import { ensureTestUserCreated } from "./test-data/create-user";
+import { DITokens } from "@/container.tokens";
+import { type AwilixContainer } from "awilix";
+import { Test } from "supertest";
+import { loginTestUser } from "./auth/login-test-user";
+import { ApiKeyController } from "@/controllers/api-key.controller";
+import TestAgent from "supertest/lib/agent";
+import type { IApiKeyService } from "@/services/interfaces/api-key.service.interface";
+
+let request: TestAgent<Test>;
+let container: AwilixContainer;
+let apiKeyService: IApiKeyService;
+
+const baseRoute = AppConstants.apiRoute + "/api-keys";
+
+beforeAll(async () => {
+  ({ request, container } = await setupTestApp(true));
+  apiKeyService = container.resolve<IApiKeyService>(DITokens.apiKeyService);
+});
+
+describe(ApiKeyController.name, () => {
+  describe("auth gating", () => {
+    it("rejects list without auth", async () => {
+      const response = await request.get(baseRoute);
+      expectUnauthenticatedResponse(response);
+    });
+
+    it("rejects create without auth", async () => {
+      const response = await request.post(baseRoute).send({ label: "x" });
+      expectUnauthenticatedResponse(response);
+    });
+
+    it("rejects revoke without auth", async () => {
+      const response = await request.delete(`${baseRoute}/1`);
+      expectUnauthenticatedResponse(response);
+    });
+  });
+
+  describe("create", () => {
+    it("issues a fdmm_pat_ token and returns it once", async () => {
+      const { token: jwt } = await loginTestUser(request, "apikey-user-create");
+      const response = await request.post(baseRoute).set("Authorization", `Bearer ${jwt}`).send({ label: "my-script" });
+      expectOkResponse(response);
+
+      expect(response.body.token).toMatch(/^fdmm_pat_[A-Za-z0-9_-]{20,}$/);
+      expect(response.body.label).toBe("my-script");
+      expect(response.body.prefix).toHaveLength(16);
+      expect(response.body.userId).toBeGreaterThan(0);
+      expect(response.body.revokedAt).toBeNull();
+      expect(response.body.lastUsedAt).toBeNull();
+    });
+
+    it("rejects empty label with invalid response", async () => {
+      const { token: jwt } = await loginTestUser(request, "apikey-user-empty-label");
+      const response = await request.post(baseRoute).set("Authorization", `Bearer ${jwt}`).send({ label: "" });
+      expectInvalidResponse(response);
+    });
+
+    it("rejects whitespace-only label", async () => {
+      const { token: jwt } = await loginTestUser(request, "apikey-user-ws-label");
+      const response = await request.post(baseRoute).set("Authorization", `Bearer ${jwt}`).send({ label: "   " });
+      expectInvalidResponse(response);
+    });
+  });
+
+  describe("list", () => {
+    it("returns only the calling user's keys, never the secret", async () => {
+      const { token: jwtA } = await loginTestUser(request, "apikey-user-isolation-a");
+      const { token: jwtB } = await loginTestUser(request, "apikey-user-isolation-b");
+      await request.post(baseRoute).set("Authorization", `Bearer ${jwtA}`).send({ label: "a-key" });
+      await request.post(baseRoute).set("Authorization", `Bearer ${jwtB}`).send({ label: "b-key" });
+
+      const responseA = await request.get(baseRoute).set("Authorization", `Bearer ${jwtA}`);
+      expectOkResponse(responseA);
+      const labelsA = responseA.body.map((k: any) => k.label);
+      expect(labelsA).toContain("a-key");
+      expect(labelsA).not.toContain("b-key");
+      // Secret-bearing fields are never returned.
+      for (const k of responseA.body) {
+        expect(k).not.toHaveProperty("token");
+        expect(k).not.toHaveProperty("hashedSecret");
+      }
+    });
+  });
+
+  describe("revoke", () => {
+    it("sets revokedAt and the token stops authenticating", async () => {
+      const { token: jwt } = await loginTestUser(request, "apikey-user-revoke");
+      const created = await request.post(baseRoute).set("Authorization", `Bearer ${jwt}`).send({ label: "to-revoke" });
+      const apiKeyToken: string = created.body.token;
+      const apiKeyId: number = created.body.id;
+
+      // Token should auth before revoke.
+      const before = await request.get(baseRoute).set("Authorization", `Bearer ${apiKeyToken}`);
+      expectOkResponse(before);
+
+      // Revoke via JWT.
+      const revoke = await request.delete(`${baseRoute}/${apiKeyId}`).set("Authorization", `Bearer ${jwt}`);
+      expectOkResponse(revoke);
+      expect(revoke.body.revokedAt).toBeTruthy();
+
+      // Token should fail after revoke.
+      const after = await request.get(baseRoute).set("Authorization", `Bearer ${apiKeyToken}`);
+      expectUnauthenticatedResponse(after);
+    });
+
+    it("returns 404 when revoking a foreign user's key", async () => {
+      const { token: jwtOwner } = await loginTestUser(request, "apikey-user-foreign-owner");
+      const { token: jwtIntruder } = await loginTestUser(request, "apikey-user-foreign-intruder");
+      const created = await request.post(baseRoute).set("Authorization", `Bearer ${jwtOwner}`).send({ label: "owned" });
+      const otherId: number = created.body.id;
+
+      const response = await request.delete(`${baseRoute}/${otherId}`).set("Authorization", `Bearer ${jwtIntruder}`);
+      expectNotFoundResponse(response);
+    });
+  });
+
+  describe("api-key bearer auth path", () => {
+    it("authenticates via API key against any protected route", async () => {
+      const { token: jwt } = await loginTestUser(request, "apikey-bearer-test");
+      const created = await request
+        .post(baseRoute)
+        .set("Authorization", `Bearer ${jwt}`)
+        .send({ label: "bearer-test" });
+      const apiKeyToken: string = created.body.token;
+
+      // Hit a sibling protected route to prove the auth pipeline accepts the
+      // api key as a JWT-equivalent bearer.
+      const printerList = await request
+        .get(`${AppConstants.apiRoute}/printer`)
+        .set("Authorization", `Bearer ${apiKeyToken}`);
+      expectOkResponse(printerList);
+    });
+
+    it("rejects garbage api-key-shaped tokens", async () => {
+      const response = await request
+        .get(baseRoute)
+        .set("Authorization", "Bearer fdmm_pat_garbageABCDEFGHIJKLMNOPQRSTUVWXYZ");
+      expectUnauthenticatedResponse(response);
+    });
+
+    it("bumps lastUsedAt on successful api-key auth", async () => {
+      const { token: jwt } = await loginTestUser(request, "apikey-lastused");
+      const created = await request.post(baseRoute).set("Authorization", `Bearer ${jwt}`).send({ label: "lastused" });
+      const apiKeyToken: string = created.body.token;
+      expect(created.body.lastUsedAt).toBeNull();
+
+      // Use the key.
+      await request.get(baseRoute).set("Authorization", `Bearer ${apiKeyToken}`);
+
+      // Allow the best-effort async bump to land.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const list = await request.get(baseRoute).set("Authorization", `Bearer ${jwt}`);
+      const refreshed = list.body.find((k: any) => k.id === created.body.id);
+      expect(refreshed?.lastUsedAt).not.toBeNull();
+    });
+  });
+});
+
+describe("ApiKeyService", () => {
+  describe("looksLikeApiKey", () => {
+    it("recognises the fdmm_pat_ prefix shape", () => {
+      expect(apiKeyService.looksLikeApiKey("fdmm_pat_" + "x".repeat(40))).toBe(true);
+    });
+
+    it("rejects JWT-shaped strings", () => {
+      expect(apiKeyService.looksLikeApiKey("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.foo.bar")).toBe(false);
+    });
+
+    it("rejects empty / undefined inputs", () => {
+      expect(apiKeyService.looksLikeApiKey("")).toBe(false);
+      expect(apiKeyService.looksLikeApiKey(undefined as any)).toBe(false);
+    });
+
+    it("rejects fdmm_pat_ that's too short to contain a prefix+secret", () => {
+      expect(apiKeyService.looksLikeApiKey("fdmm_pat_short")).toBe(false);
+    });
+  });
+
+  describe("verify", () => {
+    it("returns the entity for a valid, non-revoked token", async () => {
+      const user = await ensureTestUserCreated("apikey-svc-valid", "pw", false);
+      const created = await apiKeyService.createForUser(user.id, "valid-key");
+
+      const verified = await apiKeyService.verify(created.token);
+      expect(verified?.id).toBe(created.id);
+      expect(verified?.userId).toBe(user.id);
+    });
+
+    it("returns null for a tampered token (same prefix, different secret)", async () => {
+      const user = await ensureTestUserCreated("apikey-svc-tamper", "pw", false);
+      const created = await apiKeyService.createForUser(user.id, "tamper-key");
+      const tampered = `fdmm_pat_${created.prefix}${"X".repeat(30)}`;
+
+      const verified = await apiKeyService.verify(tampered);
+      expect(verified).toBeNull();
+    });
+
+    it("returns null for revoked tokens", async () => {
+      const user = await ensureTestUserCreated("apikey-svc-revoke", "pw", false);
+      const created = await apiKeyService.createForUser(user.id, "revoke-key");
+      await apiKeyService.revokeForUser(user.id, created.id);
+
+      const verified = await apiKeyService.verify(created.token);
+      expect(verified).toBeNull();
+    });
+
+    it("returns null for completely unknown prefixes", async () => {
+      const verified = await apiKeyService.verify("fdmm_pat_" + "Z".repeat(48));
+      expect(verified).toBeNull();
+    });
+
+    it("returns null for non-API-key inputs", async () => {
+      expect(await apiKeyService.verify("not-a-token")).toBeNull();
+      expect(await apiKeyService.verify("")).toBeNull();
+    });
+  });
+});

--- a/test/api/api-key-controller.test.ts
+++ b/test/api/api-key-controller.test.ts
@@ -104,12 +104,12 @@ describe(ApiKeyController.name, () => {
   });
 
   describe("create", () => {
-    it("issues a fdmm_pat_ token and returns it once with the requested roles", async () => {
+    it("issues a fdmm_api_ token and returns it once with the requested roles", async () => {
       const { token: jwt } = await loginTestUser(request, "apikey-create");
       const response = await postCreate(jwt, { label: "my-script", roleIds: [await adminRoleId()] });
       expectOkResponse(response);
 
-      expect(response.body.token).toMatch(/^fdmm_pat_[A-Za-z0-9_-]{20,}$/);
+      expect(response.body.token).toMatch(/^fdmm_api_[A-Za-z0-9_-]{20,}$/);
       expect(response.body.label).toBe("my-script");
       expect(response.body.prefix).toHaveLength(16);
       expect(response.body.createdByUserId).toBeGreaterThan(0);
@@ -235,7 +235,7 @@ describe(ApiKeyController.name, () => {
     it("rejects garbage api-key-shaped tokens", async () => {
       const response = await request
         .get(baseRoute)
-        .set("Authorization", "Bearer fdmm_pat_garbageABCDEFGHIJKLMNOPQRSTUVWXYZ");
+        .set("Authorization", "Bearer fdmm_api_garbageABCDEFGHIJKLMNOPQRSTUVWXYZ");
       expectUnauthenticatedResponse(response);
     });
 
@@ -257,8 +257,8 @@ describe(ApiKeyController.name, () => {
 
 describe("ApiKeyService", () => {
   describe("looksLikeApiKey", () => {
-    it("recognises the fdmm_pat_ prefix shape", () => {
-      expect(apiKeyService.looksLikeApiKey("fdmm_pat_" + "x".repeat(40))).toBe(true);
+    it("recognises the fdmm_api_ prefix shape", () => {
+      expect(apiKeyService.looksLikeApiKey("fdmm_api_" + "x".repeat(40))).toBe(true);
     });
 
     it("rejects JWT-shaped strings", () => {
@@ -270,8 +270,8 @@ describe("ApiKeyService", () => {
       expect(apiKeyService.looksLikeApiKey(undefined as any)).toBe(false);
     });
 
-    it("rejects fdmm_pat_ that's too short to contain a prefix+secret", () => {
-      expect(apiKeyService.looksLikeApiKey("fdmm_pat_short")).toBe(false);
+    it("rejects fdmm_api_ that's too short to contain a prefix+secret", () => {
+      expect(apiKeyService.looksLikeApiKey("fdmm_api_short")).toBe(false);
     });
   });
 
@@ -286,7 +286,7 @@ describe("ApiKeyService", () => {
     it("returns null for a tampered token (same prefix, different secret)", async () => {
       const user = await ensureTestUserCreated("apikey-svc-tamper", "pw", false);
       const created = await apiKeyService.create(user.id, "tamper-key", [await adminRoleId()]);
-      const tampered = `fdmm_pat_${created.prefix}${"X".repeat(30)}`;
+      const tampered = `fdmm_api_${created.prefix}${"X".repeat(30)}`;
       const verified = await apiKeyService.verify(tampered);
       expect(verified).toBeNull();
     });
@@ -300,7 +300,7 @@ describe("ApiKeyService", () => {
     });
 
     it("returns null for completely unknown prefixes", async () => {
-      const verified = await apiKeyService.verify("fdmm_pat_" + "Z".repeat(48));
+      const verified = await apiKeyService.verify("fdmm_api_" + "Z".repeat(48));
       expect(verified).toBeNull();
     });
 

--- a/test/api/load-controllers.test.ts
+++ b/test/api/load-controllers.test.ts
@@ -3,6 +3,7 @@ describe("load-controllers test", () => {
     // @ts-ignore
     const result = await import.meta.glob("@/controllers/*.controller.*");
     expect(Object.keys(result), "API Controllers loaded should match").toMatchObject([
+      "/src/controllers/api-key.controller.ts",
       "/src/controllers/auth.controller.ts",
       "/src/controllers/batch-call.controller.ts",
       "/src/controllers/camera-stream.controller.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -284,10 +284,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fdm-monster/client-next@npm:2.3.4":
-  version: 2.3.4
-  resolution: "@fdm-monster/client-next@npm:2.3.4"
-  checksum: 10c0/d007c6ba3a5ed0efd25de44f06735ae2474c57a526621f7019c62dbf75e12cea7fe567e8b433af07265b52b6a7db96a4d042846384058d51ddcdb527d8c6d30a
+"@fdm-monster/client-next@npm:2.4.0":
+  version: 2.4.0
+  resolution: "@fdm-monster/client-next@npm:2.4.0"
+  checksum: 10c0/c9e71743ebee0613031b5efecc1f25382ee7ce70313c23e273cb8f2f3c1de3c9cebf39934d30749a60c76c94977b04b6e6a8f50eea4d3ade5327e0d7b782a758
   languageName: node
   linkType: hard
 
@@ -323,7 +323,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fdm-monster/server@workspace:."
   dependencies:
-    "@fdm-monster/client-next": "npm:2.3.4"
+    "@fdm-monster/client-next": "npm:2.4.0"
     "@lcov-viewer/cli": "npm:1.3.0"
     "@lcov-viewer/istanbul-report": "npm:1.4.0"
     "@octokit/plugin-throttling": "npm:11.0.3"


### PR DESCRIPTION
Adds long-lived bearer credentials so external software can authenticate against the API without sharing user passwords or wrestling with the 1-hour JWT expiry.

  POST   /api/v2/api-keys           create (label) → returns token once
  GET    /api/v2/api-keys           list caller's keys (no secrets)
  DELETE /api/v2/api-keys/:id       revoke

Token format: `fdmm_pat_<43 chars base64url>` (256 bits CSPRNG entropy). The first 16 chars after the separator are stored as an indexable `prefix`; the full token is hashed with SHA-256 and verified with timingSafeEqual. Bcrypt isn't used here because the secret is high-entropy by construction — SHA-256 verification stays sub-millisecond and matches the GitHub/GitLab PAT pattern.

Auth integration:
  - New ApiKeyStrategy (passport.Strategy) slotted between JWT and Anonymous in the global pipeline. Sets `req.user` with the same UserDto shape the JWT strategy produces, so `interceptRoles` / `authenticate()` / `permission()` all just work; tokens inherit the bound user's role.
  - On a token shaped like `fdmm_pat_…` that fails verify, the strategy fails the request (401) instead of falling through to anonymous — caller clearly intended bearer auth.
  - `lastUsedAt` is bumped best-effort on successful verify (fire-and- forget; failures don't block the request).

Controller contract:
  - Whole controller is `@before([authenticate(), demoUserNotAllowed])`.
  - Service layer enforces per-user scope on every operation. Listing or revoking a foreign user's key returns 404, not 403, so existence is not leaked.

Persistence:
  - New `api_key` table (migration 1778446203015) with FK to user (CASCADE on user delete). Columns: userId, label, prefix (unique-indexed), hashedSecret, createdAt, lastUsedAt, revokedAt.
  - Revoking sets revokedAt; revoked rows are kept for audit.
  - DTO never returns `hashedSecret`. `token` field is only present on the creation response — fundamentally one-time.

Tests (21 new, all green; full suite 497 passed):
  - auth-gating: list / create / revoke all reject without bearer
  - create: token shape + label + prefix length + zero-state lastUsedAt; label validation (empty / whitespace-only)
  - list: per-user isolation, no `token` or `hashedSecret` ever exposed
  - revoke: revokedAt set, token stops auth, foreign-user revoke is 404
  - api-key bearer path: authenticates against unrelated protected routes, garbage api-key-shaped tokens are rejected (no anon fallthrough), lastUsedAt bumped after successful verify
  - service: looksLikeApiKey shape detection (jwt-shaped, empty, short), verify happy path, tampered same-prefix, revoked, unknown prefix, non-API-key inputs

Closes the API-key request from the Discord thread on 2026-05-10.

# Description

Adds long-lived bearer credentials so external software can authenticate against the API without sharing user passwords or wrestling with the 1-hour JWT expiry.

```
POST   /api/v2/api-keys           create (label) → returns token once
GET    /api/v2/api-keys           list caller's keys (no secrets)
DELETE /api/v2/api-keys/:id       revoke
```

**Token format:** `fdmm_pat_<43 chars base64url>` (256 bits CSPRNG entropy). The first 16 chars after the separator are stored as an indexable `prefix`; the full token is hashed with SHA-256 and verified with `timingSafeEqual`. Bcrypt isn't used here because the secret is high-entropy by construction — SHA-256 verification stays sub-millisecond and matches the GitHub / GitLab PAT pattern.

**Auth integration:**
- New `ApiKeyStrategy` (passport.Strategy) slotted between JWT and Anonymous in the global pipeline. Sets `req.user` with the same `UserDto` shape the JWT strategy produces, so `interceptRoles` / `authenticate()` / `permission()` all just work; tokens inherit the bound user's role.
- On a token shaped like `fdmm_pat_…` that fails verify, the strategy fails the request (401) instead of falling through to anonymous — caller clearly intended bearer auth.
- `lastUsedAt` is bumped best-effort on successful verify (fire-and-forget; failures don't block the request).

**Controller contract:**
- Whole controller is `@before([authenticate(), demoUserNotAllowed])`.
- Service layer enforces per-user scope on every operation. Listing or revoking a foreign user's key returns **404, not 403**, so existence is not leaked.

**Persistence:**
- New `api_key` table (migration `1778446203015`) with FK to `user` (CASCADE on user delete). Columns: `userId`, `label`, `prefix` (unique-indexed), `hashedSecret`, `createdAt`, `lastUsedAt`, `revokedAt`.
- Revoking sets `revokedAt`; revoked rows are kept for audit.
- DTO never returns `hashedSecret`. The `token` field is only present on the creation response — fundamentally one-time.

**Companion client PR:** UI lives in `fdm-monster-client-next:feature/api-keys`. Once that lands and a client release is cut, I'll add a follow-up commit to this PR bumping `defaultClientMinimum` in [src/server.constants.ts](src/server.constants.ts) so running instances pick up the new client automatically.

Originally surfaced on Discord (2026-05-10): Ray asked the canonical "what's the best way to give external software access?" question, davidzwa green-lit a feature request, this PR is the result.

Fixes #5259

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Node test
- [ ] Vue test — companion in `fdm-monster-client-next:feature/api-keys`

21 new tests in `test/api/api-key-controller.test.ts`, full suite **497 passed | 1 skipped**:

- **auth gating** — `list / create / revoke` all reject without bearer
- **create** — token shape (`fdmm_pat_<base64url>`), label round-trip, prefix length, zero-state `lastUsedAt`/`revokedAt`; label validation rejects empty + whitespace-only
- **list** — per-user isolation; assertion that `token` and `hashedSecret` are never returned in listings
- **revoke** — `revokedAt` set, token stops authenticating immediately, foreign-user revoke returns **404 (not 403)** so existence is not leaked
- **api-key bearer auth path** — authenticates against unrelated protected routes (`/api/v2/printer`); garbage `fdmm_pat_…`-shaped tokens are rejected (no anonymous fallthrough); `lastUsedAt` bumped after successful verify
- **service** — `looksLikeApiKey` shape detection (JWT-shaped, empty, short); `verify` happy path, tampered same-prefix, revoked, unknown prefix, non-API-key inputs

Manual smoke test against a live local instance: login → create → curl with token against `/api/v2/printer` (200) → revoke → same curl (401).

**Test Configuration**:
* Node version: v24.7.0
* OctoPrint version: N/A
* Klipper version: N/A
* Nodemon/PM2/docker: `yarn dev` (vite-plus watch mode) on Windows 10

# Checklist:

- [x] I checked my changes
- [x] I have commented my code concisely
- [x] I have covered my changes with tests
