### PR TITLE
release: 2.1.1

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,3 +1,17 @@
+# FDM Monster 15/05/2026 2.1.1
+
+## Features
+
+- feat(auth): expose INSTANCE_LABEL env var on /auth/login-required response for better client-side handling of multi-instance setups
+
+## Fixes
+
+- Extends Digest auth for broader PrusaLink support (especially for MK2/MK3 printers with PrusaLink extension on Raspberry Pi)
+
+## Chores
+
+- Remove unused package Luxon, moved chalk to devDependencies
+
 # FDM Monster 13/05/2026 2.1.0
 
 ## Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fdm-monster/server",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "FDM Monster is a bulk OctoPrint, Klipper, PrusaLink and BambuLab manager to set up, configure and monitor 3D printers. Our aim is to provide neat overview over your farm.",
   "keywords": [
     "3d printing",


### PR DESCRIPTION
# FDM Monster 15/05/2026 2.1.1

## Features

- feat(auth): expose INSTANCE_LABEL env var on /auth/login-required response for better client-side handling of multi-instance setups

## Fixes

- Extends Digest auth for broader PrusaLink support (especially for MK2/MK3 printers with PrusaLink extension on Raspberry Pi)

## Chores

- Remove unused package Luxon, moved chalk to devDependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## FDM Monster 2.1.1 Release Notes

**Release Date:** May 15, 2026

### New Features
- **Improved Multi-Instance Setup**: The authentication response now includes instance labeling information to better support configurations running multiple FDM Monster instances.

### Improvements
- **Expanded Printer Support**: Enhanced authentication compatibility for PrusaLink, extending support to Prusa MK2/MK3 printers running PrusaLink on Raspberry Pi setups.

### Maintenance
- Improved package dependencies for a leaner installation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fdm-monster/fdm-monster/pull/5282)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->