### PR TITLE
Fix Docker build failing on vp pack due to missing CA certificates in build stage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,9 @@
 FROM node:24-bookworm-slim AS build
 WORKDIR /build
 
+RUN apt update && apt install -y ca-certificates &&  \
+    apt clean && rm -rf /var/lib/apt/lists/*
+
 COPY .yarn/releases ./.yarn/releases
 COPY vite.config.ts tsconfig.json package.json yarn.lock .yarnrc.yml ./
 


### PR DESCRIPTION
# Description

The `build` stage of `docker/Dockerfile` (`node:24-bookworm-slim`) never installed
`ca-certificates`, unlike the `production` stage. This doesn't break `yarn install`
(Node/Yarn ship their own bundled CA set), but it breaks `yarn run build`, which runs
Vite+'s `vp pack`. Vite+'s Rust-based HTTP client reads the OS trust store directly,
and with an empty `/etc/ssl/certs` it panics:

```
Vite+ panicked. This is a bug in Vite+, not your code.
thread '<unnamed>' panicked at crates/vite_shared/src/http.rs:58:21:
failed to initialize HTTP client: builder error: unexpected error: No CA certificates were loaded from the system
```

Fix: install `ca-certificates` in the `build` stage too, mirroring what the
`production` stage already does.
Fixes # (no tracked issue)
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
## How Has This Been Tested?
- [x] Node test
**Test Configuration**:
* Node version: 24 (as pinned in Dockerfile)
* Nodemon/PM2/docker: `docker build -f docker/Dockerfile .`
# Checklist:
- [x] I checked my changes
- [x] I have commented my code concisely
- [x] I have covered my changes with tests (n/a — one-line Dockerfile fix; verified with a real `docker build` run)
---
This fix was drafted with AI assistance (Claude). I reviewed the change myself and
verified it by rebuilding the Docker image locally — the build now completes past the
previously failing `vp pack` step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release notes

- Fixed Docker builds failing during the application build process by ensuring required system certificates are installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->