### PR TITLE
Fix Moonraker/Klipper API key never being sent to the printer

### DIFF
--- a/src/services/moonraker/moonraker-websocket.adapter.ts
+++ b/src/services/moonraker/moonraker-websocket.adapter.ts
@@ -164,11 +164,6 @@ export class MoonrakerWebsocketAdapter extends WebsocketRpcExtendedAdapter imple
   async setupSocketSession(): Promise<void> {
     this.resetSocketState();
 
-    // Can 404 or 503
-    // const oneshot = await this.client.getAccessOneshotToken(this.login);
-    // this.logger.log(`Oneshot ${oneshot.data.result}`);
-    // await this.client.getAccessOneshotToken(this.login);
-
     await this.moonrakerClient.getApiVersion(this.login).catch((e: AxiosError) => {
       this.setSocketState("aborted");
       this.logger.error(`Printer (${this.printerId}) network or transport error, marking it as unreachable; ${e}`);
@@ -220,6 +215,7 @@ export class MoonrakerWebsocketAdapter extends WebsocketRpcExtendedAdapter imple
         version: this.serverVersion,
         type: "other",
         url: AppConstants.githubUrl,
+        ...(this.login.apiKey?.length ? { api_key: this.login.apiKey } : {}),
       },
       id: 1,
     });

--- a/src/services/moonraker/moonraker.client.ts
+++ b/src/services/moonraker/moonraker.client.ts
@@ -77,6 +77,7 @@ import type { HistoryLastTotalsDto } from "@/services/moonraker/dto/server-histo
 import type { HistoryJobDto } from "@/services/moonraker/dto/server-history/history-job.dto";
 import type { PrinterObjectsQueryDto } from "@/services/moonraker/dto/objects/printer-objects-query.dto";
 import { DefaultHttpClientBuilder } from "@/shared/default-http-client.builder";
+import { apiKeyHeaderKey } from "@/services/octoprint/constants/octoprint-service.constants";
 import { HttpClientFactory } from "@/services/core/http-client.factory";
 import { LoggerService } from "@/handlers/logger";
 import type { ILoggerFactory } from "@/handlers/logger-factory";
@@ -912,6 +913,9 @@ export class MoonrakerClient {
     const baseAddress = login.printerURL;
 
     return this.createAnonymousClient(baseAddress, (o) => {
+      if (login.apiKey?.length) {
+        o.withHeaders({ [apiKeyHeaderKey]: login.apiKey });
+      }
       if (buildFluentOptions) {
         buildFluentOptions(o);
       }

--- a/src/services/validators/printer-service.validation.ts
+++ b/src/services/validators/printer-service.validation.ts
@@ -1,5 +1,11 @@
 import { apiKeyLengthMaxDefault, apiKeyLengthMinDefault } from "@/constants/service.constants";
-import { OctoprintType, PrinterTypesEnum, PrusaLinkType, BambuType } from "@/services/printer-api.interface";
+import {
+  OctoprintType,
+  PrinterTypesEnum,
+  PrusaLinkType,
+  BambuType,
+  MoonrakerType,
+} from "@/services/printer-api.interface";
 import { RefinementCtx, z } from "zod";
 
 const octoPrintApiKeySchema = z
@@ -57,6 +63,20 @@ export const refineApiKeyValidator = <T extends ApiKeyPrinterTypeSchema>(data: T
           path: ["apiKey", ...issue.path],
         });
       });
+    }
+  } else if (data.printerType === MoonrakerType) {
+    // Moonraker apiKey is optional (auth may be disabled/trusted-client), but if provided it must be well-formed
+    if (data.apiKey?.length) {
+      const result = octoPrintApiKeySchema.safeParse(data.apiKey);
+      if (!result.success) {
+        result.error.issues.forEach((issue) => {
+          ctx.addIssue({
+            ...issue,
+            // Nesting misses path under "apiKey"
+            path: ["apiKey", ...issue.path],
+          });
+        });
+      }
     }
   } else if (data.printerType === PrusaLinkType || data.printerType === BambuType) {
     const result = prusaLinkAuthSchema.safeParse({

--- a/test/application/moonraker/moonraker-client.test.ts
+++ b/test/application/moonraker/moonraker-client.test.ts
@@ -1,0 +1,50 @@
+import { DITokens } from "@/container.tokens";
+import { setupTestApp } from "../../test-server";
+import { AwilixContainer } from "awilix";
+import { MoonrakerClient } from "@/services/moonraker/moonraker.client";
+import { MoonrakerType } from "@/services/printer-api.interface";
+import nock from "nock";
+
+let moonrakerClient: MoonrakerClient;
+let container: AwilixContainer;
+
+beforeAll(async () => {
+  ({ container } = await setupTestApp(true));
+  moonrakerClient = container.resolve(DITokens.moonrakerClient);
+  await container.resolve(DITokens.settingsStore).loadSettings();
+});
+
+describe(MoonrakerClient.name, () => {
+  const printerURL = "http://someurl/";
+
+  it("should send X-Api-Key header when apiKey is configured", async () => {
+    const apiKey = "surewhynotsurewhynotsurewhynotsu";
+    const auth = { apiKey, printerURL, printerType: MoonrakerType };
+
+    const scope = nock(printerURL, {
+      reqheaders: {
+        "x-api-key": apiKey,
+      },
+    })
+      .get("/server/info")
+      .reply(200, {});
+
+    const result = await moonrakerClient.getServerInfo(auth);
+    expect(result.data).toStrictEqual({});
+    expect(scope.isDone()).toBe(true);
+  });
+
+  it("should not send X-Api-Key header when apiKey is not configured", async () => {
+    const auth = { printerURL, printerType: MoonrakerType };
+
+    const scope = nock(printerURL, {
+      badheaders: ["x-api-key"],
+    })
+      .get("/server/info")
+      .reply(200, {});
+
+    const result = await moonrakerClient.getServerInfo(auth);
+    expect(result.data).toStrictEqual({});
+    expect(scope.isDone()).toBe(true);
+  });
+});


### PR DESCRIPTION
# Description

FDM Monster advertises Klipper support via Moonraker, and printer creation lets you
set an API key for a Moonraker printer — but the key was never actually attached to
any outgoing request. `LoginDto.apiKey` reached `MoonrakerClient` and
`MoonrakerWebsocketAdapter` correctly, but neither ever read it:

- `MoonrakerClient.createClient()` built every request from `login.printerURL` only,
  never setting an `X-Api-Key` header (unlike `OctoprintClient`, which does this
  correctly via `withXApiKeyHeader`).
- `MoonrakerWebsocketAdapter.afterOpened()` sent `server.connection.identify` without
  `api_key`, even though the DTO already had an (unused) optional field for it.

As a result, Moonraker support only worked against instances with authorization
effectively disabled (e.g. via `trusted_clients`); any Moonraker requiring auth
rejected every request with 401, regardless of the key entered.

Fix:
- `MoonrakerClient` now sets the `X-Api-Key` header on every request when an `apiKey`
  is configured (per Moonraker's documented REST auth).
- `MoonrakerWebsocketAdapter` now passes `api_key` in the `server.connection.identify`
  RPC params, per Moonraker's documented websocket auth flow.
- `refineApiKeyValidator` now validates the Moonraker API key format when one is
  provided (stays optional, since Moonraker auth can be disabled).
- Added a unit test asserting the `X-Api-Key` header is set/omitted correctly based on
  whether `apiKey` is configured.

**Companion PR:** this only closes the loop together with the frontend fix in
[fdm-monster-client-next#1794](https://github.com/fdm-monster/fdm-monster-client-next/pull/1794) (the Add/Update Printer dialog was hiding the API Key
field for Moonraker and blanking it on submit). Please review/merge together.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Node test (`vp test`, incl. new `test/application/moonraker/moonraker-client.test.ts`)

**Test Configuration**:
* Node version: 24
* Klipper/Moonraker version: any recent version 
* Nodemon/PM2/docker: Docker (local build)

# Checklist:
- [x] I checked my changes
- [x] I have commented my code concisely
- [x] I have covered my changes with tests

---
This fix was drafted with AI assistance (Claude), cross-checked against Moonraker's
official authorization docs. I reviewed the code changes myself and verified this
end-to-end against my own Klipper/Moonraker printer with authorization enabled — it
connects and authenticates correctly now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Fixed Moonraker/Klipper authentication using configured API keys.
- Added API key support for REST and WebSocket connections.
- Added API key format validation and test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->